### PR TITLE
first implementation with an mqtt configuration for Qos, Retain and Autoreconnect.

### DIFF
--- a/appsdk/sdk.go
+++ b/appsdk/sdk.go
@@ -149,8 +149,12 @@ func (sdk *AppFunctionsSDK) HTTPPostXML(url string) func(*appcontext.Context, ..
 // MQTTSend sends data from the previous function to the specified MQTT broker.
 // If no previous function exists, then the event that triggered the pipeline will be used.
 // This function is a configuration function and returns a function pointer.
-func (sdk *AppFunctionsSDK) MQTTSend(addr models.Addressable, cert string, key string) func(*appcontext.Context, ...interface{}) (bool, interface{}) {
-	sender := transforms.NewMQTTSender(sdk.LoggingClient, addr, cert, key)
+func (sdk *AppFunctionsSDK) MQTTSend(addr models.Addressable, cert string, key string, qos byte, retain bool, autoreconnect bool) func(*appcontext.Context, ...interface{}) (bool, interface{}) {
+	mqttconfig := transforms.NewMqttConfig()
+	mqttconfig.SetQos(qos)
+	mqttconfig.SetRetain(retain)
+	mqttconfig.SetAutoreconnect(autoreconnect)
+	sender := transforms.NewMQTTSender(sdk.LoggingClient, addr, cert, key, mqttconfig)
 	return sender.MQTTSend
 }
 

--- a/examples/simple-filter-xml-mqtt/main.go
+++ b/examples/simple-filter-xml-mqtt/main.go
@@ -52,13 +52,14 @@ func main() {
 		Password:  "",
 		Topic:     "sampleTopic",
 	}
+
 	// 3) This is our pipeline configuration, the collection of functions to
 	// execute every time an event is triggered.
 	edgexSdk.SetFunctionsPipeline(
 		edgexSdk.DeviceNameFilter(deviceNames),
 		edgexSdk.XMLTransform(),
 		printXMLToConsole,
-		edgexSdk.MQTTSend(addressable, "", ""),
+		edgexSdk.MQTTSend(addressable, "", "", 0, false, false),
 	)
 
 	// 4) shows how to access the application's specific configuration settings.

--- a/pkg/transforms/mqtt_test.go
+++ b/pkg/transforms/mqtt_test.go
@@ -92,7 +92,7 @@ func TestNewMQTTSender(t *testing.T) {
 		Password:  "password",
 		Topic:     "testMQTTTopic",
 	}
-	sender := NewMQTTSender(lc, addr1, "", "")
+	sender := NewMQTTSender(lc, addr1, "", "", NewMqttConfig())
 	assert.NotNil(t, sender.client, "Client should not be nil")
 	opts := sender.client.OptionsReader()
 	assert.Equal(t, "testMQTTTopic", sender.topic, "Topic should be set to testMQTTTopic")


### PR DESCRIPTION
This is a first Idea how to use additional parameter in mqtt export.Qos , retain and autoconnect are imho something you can customize from an sdk point of view.
Actually  I don't like very much the implementation that uses parameters in MQTTSend() func : maybe is a good idea to use a struct but we must export the type somewhere.

thanks for comments

Marco

 


