### PR TITLE
Add support for CBOR encoded events

### DIFF
--- a/appcontext/context.go
+++ b/appcontext/context.go
@@ -24,6 +24,8 @@ import (
 
 // Context ...
 type Context struct {
+	EventId       string
+	EventChecksum string
 	CorrelationID string
 	OutputData    []byte
 	Trigger       trigger.Trigger

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,14 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/BurntSushi/toml v0.3.1
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190429073535-f8b9cd669563
-	github.com/edgexfoundry/go-mod-messaging v0.0.0-20190327144236-4222ae1edb0b
+	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190515170337-eeea036f04bd
+	github.com/edgexfoundry/go-mod-messaging v0.0.0-20190507192740-04f9582c7a08
 	github.com/edgexfoundry/go-mod-registry v0.0.0-20190401195203-552208258719
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 // indirect
 	github.com/gorilla/mux v1.7.0
 	github.com/hashicorp/consul v1.4.2
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.3.0
+	github.com/ugorji/go/codec v0.0.0-20190316192920-e2bddce071ad
 	golang.org/x/net v0.0.0-20190301231341-16b79f2e4e95 // indirect
 )


### PR DESCRIPTION
This PR addresses #59 and also saves the EventId or EventChecksum in context for later use when marking event as handled.