### PR TITLE
Mark as pushed

### DIFF
--- a/appsdk/sdk_test.go
+++ b/appsdk/sdk_test.go
@@ -28,14 +28,20 @@ import (
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/runtime"
 	triggerHttp "github.com/edgexfoundry/app-functions-sdk-go/internal/trigger/http"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/trigger/messagebus"
+	"github.com/edgexfoundry/app-functions-sdk-go/pkg/startup"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	"github.com/stretchr/testify/assert"
 )
 
 var lc logger.LoggingClient
+var context *appcontext.Context
 
 func init() {
 	lc = logger.NewClient("app_functions_sdk_go", false, "./test.log", "DEBUG")
+
 }
 func TestSetFunctionsPipelineNoTransforms(t *testing.T) {
 	sdk := AppFunctionsSDK{
@@ -115,18 +121,35 @@ func TestHTTPPostJSON(t *testing.T) {
 		assert.Equal(t, "application/json", r.Header.Get("Content-type"), "Unexpected content-type received %s, expected %s", r.Header.Get("Content-type"), "application/xml")
 		assert.Equal(t, path, r.URL.EscapedPath(), "Invalid path received %s, expected %s", r.URL.EscapedPath(), path)
 	}
-
+	pushedHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		assert.Contains(t, r.URL.EscapedPath(), "234")
+	}
 	// create test server with handler
 	ts := httptest.NewServer(http.HandlerFunc(handler))
+	ts2 := httptest.NewServer(http.HandlerFunc(pushedHandler))
 	defer ts.Close()
+	defer ts2.Close()
+	//Setup eventClient
+	params := types.EndpointParams{
+		ServiceKey:  clients.CoreDataServiceKey,
+		Path:        clients.ApiEventRoute,
+		UseRegistry: false,
+		Url:         ts2.URL,
+		Interval:    1000,
+	}
+	eventClient := coredata.NewEventClient(params, startup.Endpoint{RegistryClient: nil})
 
+	context = &appcontext.Context{
+		EventID:       "234",
+		LoggingClient: lc,
+		EventClient:   eventClient,
+	}
+	// used to ensure MarkAsPushed is called
 	trx := sdk.HTTPPostJSON(ts.URL)
 	assert.NotNil(t, trx, "return result from HTTPPostJSON should not be nil")
 
-	ctx := &appcontext.Context{
-		LoggingClient: lc,
-	}
-	result, data := trx(ctx, msgStr)
+	result, data := trx(context, msgStr)
 	assert.True(t, result, "continuePipeline should be true")
 	assert.Equal(t, "RESPONSE", (string)((data).([]byte)), "response should be \"RESPONSE\"")
 }
@@ -145,18 +168,36 @@ func TestHTTPPostXML(t *testing.T) {
 		assert.Equal(t, "application/xml", r.Header.Get("Content-type"), "Unexpected content-type received %s, expected %s", r.Header.Get("Content-type"), "application/xml")
 		assert.Equal(t, path, r.URL.EscapedPath(), "Invalid path received %s, expected %s", r.URL.EscapedPath(), path)
 	}
-
+	// used to ensure MarkAsPushed is called
+	pushedHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		assert.Contains(t, r.URL.EscapedPath(), "123")
+	}
 	// create test server with handler
 	ts := httptest.NewServer(http.HandlerFunc(handler))
+	ts2 := httptest.NewServer(http.HandlerFunc(pushedHandler))
 	defer ts.Close()
+	defer ts2.Close()
+	//Setup eventClient
+	params := types.EndpointParams{
+		ServiceKey:  clients.CoreDataServiceKey,
+		Path:        clients.ApiEventRoute,
+		UseRegistry: false,
+		Url:         ts2.URL,
+		Interval:    1000,
+	}
+	eventClient := coredata.NewEventClient(params, startup.Endpoint{RegistryClient: nil})
+
+	context = &appcontext.Context{
+		EventID:       "123",
+		LoggingClient: lc,
+		EventClient:   eventClient,
+	}
 
 	trx := sdk.HTTPPostXML(ts.URL)
 	assert.NotNil(t, trx, "return result from HTTPPostXML should not be nil")
 
-	ctx := &appcontext.Context{
-		LoggingClient: lc,
-	}
-	result, data := trx(ctx, msgStr)
+	result, data := trx(context, msgStr)
 	assert.True(t, result, "continuePipeline should be true")
 	assert.Equal(t, "RESPONSE", (string)((data).([]byte)), "response should be \"RESPONSE\"")
 }

--- a/examples/advanced-filter-convert-publish/res/configuration.toml
+++ b/examples/advanced-filter-convert-publish/res/configuration.toml
@@ -17,6 +17,12 @@ Host = 'localhost'
 Port = 8500
 Type = 'consul'
 
+[Clients]
+  [Clients.CoreData]
+  Protocol = 'http'
+  Host = 'localhost'
+  Port = 48080
+
 [MessageBus]
 Type = 'zero'
     [MessageBus.SubscribeHost]

--- a/examples/advanced-filter-convert-publish/res/docker/configuration.toml
+++ b/examples/advanced-filter-convert-publish/res/docker/configuration.toml
@@ -17,6 +17,12 @@ Host = 'edgex-core-consul'
 Port = 8500
 Type = 'consul'
 
+[Clients]
+  [Clients.CoreData]
+  Protocol = 'http'
+  Host = 'edgex-core-data'
+  Port = 48080
+
 [MessageBus]
 Type = 'zero'
     [MessageBus.SubscribeHost]

--- a/examples/simple-filter-xml-mqtt/res/configuration.toml
+++ b/examples/simple-filter-xml-mqtt/res/configuration.toml
@@ -17,6 +17,12 @@ Host = 'localhost'
 Port = 8500
 Type = 'consul'
 
+[Clients]
+  [Clients.CoreData]
+  Protocol = 'http'
+  Host = 'localhost'
+  Port = 48080
+
 [MessageBus]
 Type = 'zero'
     [MessageBus.PublishHost]

--- a/examples/simple-filter-xml-mqtt/res/docker/configuration.toml
+++ b/examples/simple-filter-xml-mqtt/res/docker/configuration.toml
@@ -17,6 +17,12 @@ Host = 'edgex-core-consul'
 Port = 8500
 Type = 'consul'
 
+[Clients]
+  [Clients.CoreData]
+  Protocol = 'http'
+  Host = 'edgex-core-data'
+  Port = 48080
+
 [MessageBus]
 Type = 'zero'
     [MessageBus.PublishHost]

--- a/examples/simple-filter-xml-post/res/configuration.toml
+++ b/examples/simple-filter-xml-post/res/configuration.toml
@@ -17,6 +17,12 @@ Host = 'localhost'
 Port = 8500
 Type = 'consul'
 
+[Clients]
+  [Clients.CoreData]
+  Protocol = 'http'
+  Host = 'localhost'
+  Port = 48080
+
 [MessageBus]
 Type = 'zero'
     [MessageBus.PublishHost]

--- a/examples/simple-filter-xml-post/res/docker/configuration.toml
+++ b/examples/simple-filter-xml-post/res/docker/configuration.toml
@@ -16,6 +16,12 @@ Timeout = 5000
 Port = 8500
 Type = 'consul'
 
+[Clients]
+  [Clients.CoreData]
+  Protocol = 'http'
+  Host = 'edgex-core-data'
+  Port = 48080
+
 [MessageBus]
 Type = 'zero'
     [MessageBus.PublishHost]

--- a/examples/simple-filter-xml/res/configuration.toml
+++ b/examples/simple-filter-xml/res/configuration.toml
@@ -17,6 +17,12 @@ Host = 'localhost'
 Port = 8500
 Type = 'consul'
 
+[Clients]
+  [Clients.CoreData]
+  Protocol = 'http'
+  Host = 'localhost'
+  Port = 48080
+  
 [MessageBus]
 Type = 'zero'
     [MessageBus.PublishHost]
@@ -33,13 +39,15 @@ EnableRemote = false
 File = './logs/simple-filter-xml.log'
 
 # Choose either an HTTP trigger or MessageBus trigger (aka Binding)
-# [Binding]
-#  Type="messagebus"
-#  SubscribeTopic="events"
-#  PublishTopic="somewhere"
-
 [Binding]
-Type="http"
+ Type="messagebus"
+ SubscribeTopic=""
+ PublishTopic="somewhere"
+
+# [Binding]
+# Type="http"
 
 [ApplicationSettings]
 ApplicationName = "simple-filter-xml"
+
+

--- a/examples/simple-filter-xml/res/docker/configuration.toml
+++ b/examples/simple-filter-xml/res/docker/configuration.toml
@@ -17,6 +17,12 @@ Host = 'edgex-core-consul'
 Port = 8500
 Type = 'consul'
 
+[Clients]
+  [Clients.CoreData]
+  Protocol = 'http'
+  Host = 'edgex-core-data'
+  Port = 48080
+
 [MessageBus]
 Type = 'zero'
     [MessageBus.PublishHost]

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,12 @@
 module github.com/edgexfoundry/app-functions-sdk-go
 
 require (
-	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/BurntSushi/toml v0.3.1
-	github.com/eclipse/paho.mqtt.golang v1.1.1
+	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190515170337-eeea036f04bd
 	github.com/edgexfoundry/go-mod-messaging v0.0.0
-	github.com/edgexfoundry/go-mod-registry v0.0.0-20190401195203-552208258719
-	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 // indirect
-	github.com/gorilla/mux v1.7.0
-	github.com/hashicorp/consul v1.4.2
-	github.com/stretchr/objx v0.1.1 // indirect
+	github.com/edgexfoundry/go-mod-registry v0.0.0-20190509181716-bf686e98fa06
+	github.com/gorilla/mux v1.7.2
 	github.com/stretchr/testify v1.3.0
 	github.com/ugorji/go/codec v0.0.0-20190316192920-e2bddce071ad
-	golang.org/x/net v0.0.0-20190301231341-16b79f2e4e95 // indirect
 )

--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -16,11 +16,30 @@
 
 package common
 
-import "github.com/edgexfoundry/go-mod-messaging/pkg/types"
+import (
+	"fmt"
+
+	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
+)
 
 // WritableInfo ...
 type WritableInfo struct {
 	LogLevel string
+}
+
+// ClientInfo provides the host and port of another service in the eco-system.
+type ClientInfo struct {
+	// Host is the hostname or IP address of a service.
+	Host string
+	// Port defines the port on which to access a given service
+	Port int
+	// Protocol indicates the protocol to use when accessing a given service
+	Protocol string
+}
+
+func (c ClientInfo) Url() string {
+	url := fmt.Sprintf("%s://%s:%v", c.Protocol, c.Host, c.Port)
+	return url
 }
 
 // ConfigurationStruct ...
@@ -32,6 +51,7 @@ type ConfigurationStruct struct {
 	MessageBus          types.MessageBusConfig
 	Binding             BindingInfo
 	ApplicationSettings map[string]string
+	Clients             map[string]ClientInfo
 }
 
 // RegistryInfo ...

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -261,7 +261,7 @@ func TestProcessEventJSON(t *testing.T) {
 	transform1 := func(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
 		transform1WasCalled = true
 
-		if !assert.Equal(t, expectedEventId, edgexcontext.EventId, "Context doesn't contain expected EventId") {
+		if !assert.Equal(t, expectedEventId, edgexcontext.EventID, "Context doesn't contain expected EventID") {
 			t.Fatal()
 		}
 

--- a/internal/trigger/messagebus/messaging.go
+++ b/internal/trigger/messagebus/messaging.go
@@ -18,15 +18,15 @@ package messagebus
 
 import (
 	"fmt"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-messaging/messaging"
-	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/common"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/runtime"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-messaging/messaging"
+	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
 )
 
 // Trigger implements Trigger to support MessageBusData
@@ -36,6 +36,7 @@ type Trigger struct {
 	logging       logger.LoggingClient
 	client        messaging.MessageClient
 	topics        []types.TopicChannel
+	EventClient   coredata.EventClient
 }
 
 // Initialize ...
@@ -66,6 +67,7 @@ func (trigger *Trigger) Initialize(logger logger.LoggingClient) error {
 					Trigger:       trigger,
 					LoggingClient: trigger.logging,
 					CorrelationID: msgs.CorrelationID,
+					EventClient:   trigger.EventClient,
 				}
 				trigger.Runtime.ProcessEvent(edgexContext, msgs)
 				if edgexContext.OutputData != nil {

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -67,7 +67,7 @@ func TestConfigureAndConfigRoute(t *testing.T) {
 	rr := httptest.NewRecorder()
 	webserver.router.ServeHTTP(rr, req)
 
-	expected := `{"Writable":{"LogLevel":""},"Logging":{"EnableRemote":false,"File":""},"Registry":{"Host":"","Port":0,"Type":""},"Service":{"BootTimeout":0,"CheckInterval":"","ClientMonitor":0,"Host":"","Port":0,"Protocol":"","StartupMsg":"","ReadMaxLimit":0,"Timeout":0},"MessageBus":{"PublishHost":{"Host":"","Port":0,"Protocol":""},"SubscribeHost":{"Host":"","Port":0,"Protocol":""},"Type":"","Optional":null},"Binding":{"Type":"","Name":"","SubscribeTopic":"","PublishTopic":""},"ApplicationSettings":null}` + "\n"
+	expected := `{"Writable":{"LogLevel":""},"Logging":{"EnableRemote":false,"File":""},"Registry":{"Host":"","Port":0,"Type":""},"Service":{"BootTimeout":0,"CheckInterval":"","ClientMonitor":0,"Host":"","Port":0,"Protocol":"","StartupMsg":"","ReadMaxLimit":0,"Timeout":0},"MessageBus":{"PublishHost":{"Host":"","Port":0,"Protocol":""},"SubscribeHost":{"Host":"","Port":0,"Protocol":""},"Type":"","Optional":null},"Binding":{"Type":"","Name":"","SubscribeTopic":"","PublishTopic":""},"ApplicationSettings":null,"Clients":null}` + "\n"
 	body := rr.Body.String()
 	assert.Equal(t, expected, body)
 }

--- a/pkg/startup/endpoint.go
+++ b/pkg/startup/endpoint.go
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package startup
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
+	"github.com/edgexfoundry/go-mod-registry/registry"
+)
+
+type Endpoint struct {
+	RegistryClient *registry.Client
+}
+
+func (e Endpoint) Monitor(params types.EndpointParams, ch chan string) {
+	var endpoint registryTypes.ServiceEndpoint
+	var err error
+	for {
+
+		if e.RegistryClient != nil {
+			endpoint, err = (*e.RegistryClient).GetServiceEndpoint(params.ServiceKey)
+			if err != nil {
+				err = fmt.Errorf("unable to get Service endpoint for %s: %s", params.ServiceKey, err.Error())
+			}
+		} else {
+			err = fmt.Errorf("unable to get Service endpoint for %s: Registry client is nil", params.ServiceKey)
+		}
+
+		if err != nil {
+			fmt.Fprintln(os.Stdout, err.Error())
+		}
+		url := fmt.Sprintf("http://%s:%v%s", endpoint.Host, endpoint.Port, params.Path)
+		ch <- url
+		time.Sleep(time.Millisecond * time.Duration(params.Interval))
+	}
+}

--- a/pkg/transforms/conversion_test.go
+++ b/pkg/transforms/conversion_test.go
@@ -19,14 +19,19 @@ package transforms
 import (
 	"testing"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
+	"github.com/edgexfoundry/app-functions-sdk-go/pkg/startup"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 var context *appcontext.Context
+var lc logger.LoggingClient
 
 const (
 	devID1        = "id1"
@@ -37,8 +42,19 @@ const (
 
 func init() {
 	lc := logger.NewClient("app_functions_sdk_go", false, "./test.log", "DEBUG")
+	//Setup eventClient
+	params := types.EndpointParams{
+		ServiceKey:  clients.CoreDataServiceKey,
+		Path:        clients.ApiEventRoute,
+		UseRegistry: false,
+		Url:         "http://test" + clients.ApiEventRoute,
+		Interval:    1000,
+	}
+	eventClient := coredata.NewEventClient(params, startup.Endpoint{RegistryClient: nil})
+
 	context = &appcontext.Context{
 		LoggingClient: lc,
+		EventClient:   eventClient,
 	}
 }
 func TestTransformToXML(t *testing.T) {

--- a/pkg/transforms/filter_test.go
+++ b/pkg/transforms/filter_test.go
@@ -19,9 +19,6 @@ package transforms
 import (
 	"testing"
 
-	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
@@ -30,12 +27,6 @@ const (
 	descriptor2 = "Descriptor2"
 )
 
-func init() {
-	lc := logger.NewClient("app_functions_sdk_go", false, "./test.log", "DEBUG")
-	context = &appcontext.Context{
-		LoggingClient: lc,
-	}
-}
 func TestFilterByDeviceNameFound(t *testing.T) {
 	// Event from device 1
 	eventIn := models.Event{

--- a/pkg/transforms/http.go
+++ b/pkg/transforms/http.go
@@ -20,11 +20,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"io/ioutil"
 	"net/http"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 )
 
 // HTTPSender ...
@@ -60,7 +60,14 @@ func (sender HTTPSender) HTTPPost(edgexcontext *appcontext.Context, params ...in
 		edgexcontext.LoggingClient.Trace("Data exported", "Transport", "HTTP", clients.CorrelationHeader, edgexcontext.CorrelationID)
 
 		// continues the pipeline if we get a 2xx response, stops pipeline if non-2xx response
-		return response.StatusCode >= 200 && response.StatusCode < 300, bodyBytes
+		isSuccessfulPost := response.StatusCode >= 200 && response.StatusCode < 300
+		if isSuccessfulPost == true {
+			err = edgexcontext.MarkAsPushed()
+			if err != nil {
+				edgexcontext.LoggingClient.Error(err.Error())
+			}
+		}
+		return isSuccessfulPost, bodyBytes
 	}
 
 	return false, errors.New("Unexpected type received")

--- a/pkg/transforms/http_test.go
+++ b/pkg/transforms/http_test.go
@@ -22,20 +22,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-
-	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
 )
 
-var lc logger.LoggingClient
-
-func init() {
-	lc = logger.NewClient("app_functions_sdk_go", false, "./test.log", "TRACE")
-	context = &appcontext.Context{
-		LoggingClient: lc,
-	}
-}
 func TestHTTPPost(t *testing.T) {
 	const (
 		msgStr = "test message"
@@ -51,7 +39,6 @@ func TestHTTPPost(t *testing.T) {
 		r.Body.Close()
 		if strings.Compare((string)(readMsg), msgStr) != 0 {
 			t.Errorf("Invalid msg received %v, expected %v", readMsg, msgStr)
-
 		}
 
 		if r.Header.Get("Content-type") != "application/json" {
@@ -61,7 +48,6 @@ func TestHTTPPost(t *testing.T) {
 			t.Errorf("Invalid path received %s, expected %s",
 				r.URL.EscapedPath(), path)
 		}
-
 	}
 
 	// create test server with handler

--- a/pkg/transforms/mqtt.go
+++ b/pkg/transforms/mqtt.go
@@ -20,14 +20,13 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"strconv"
 	"strings"
 
-	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-
 	MQTT "github.com/eclipse/paho.mqtt.golang"
+	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
@@ -91,7 +90,10 @@ func (sender MQTTSender) MQTTSend(edgexcontext *appcontext.Context, params ...in
 		}
 		edgexcontext.LoggingClient.Info("Sent data to MQTT Broker")
 		edgexcontext.LoggingClient.Trace("Data exported", "Transport", "MQTT", clients.CorrelationHeader, edgexcontext.CorrelationID)
-
+		err := edgexcontext.MarkAsPushed()
+		if err != nil {
+			edgexcontext.LoggingClient.Error(err.Error())
+		}
 		return true, nil
 
 	}

--- a/pkg/transforms/mqtt_test.go
+++ b/pkg/transforms/mqtt_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	MQTT "github.com/eclipse/paho.mqtt.golang"
-	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,7 +13,6 @@ import (
 var addr models.Addressable
 
 func init() {
-	lc = logger.NewClient("app_functions_sdk_go", false, "./test.log", "TRACE")
 	addr = models.Addressable{
 		Address:   "localhost",
 		Port:      1883,
@@ -23,9 +20,6 @@ func init() {
 		Publisher: "",
 		Password:  "",
 		Topic:     "testMQTTTopic",
-	}
-	context = &appcontext.Context{
-		LoggingClient: lc,
 	}
 }
 


### PR DESCRIPTION
This pull request provides a function on the context that allows developers to optionally mark an event as pushed in core data once it has been sent to the desired destination. It will also mark events as pushed if using the SDK provided HTTP/MQTT export functions. An error will be logged if the mark fails; However, it will not stop the pipeline in the event of failure.

Signed-off-by: Mike Johanson <michael.johanson@intel.com>