### PR TITLE
Changed SDK to never exit so caller can do clean-up

### DIFF
--- a/examples/advanced-filter-convert-publish/main.go
+++ b/examples/advanced-filter-convert-publish/main.go
@@ -80,5 +80,13 @@ func main() {
 
 	// 5) Lastly, we'll go ahead and tell the SDK to "start" and begin listening for events
 	// to trigger the pipeline.
-	edgexSdk.MakeItRun()
+	err = edgexSdk.MakeItRun()
+	if err != nil {
+		edgexSdk.LoggingClient.Error("MakeItRun returned error: ", err.Error())
+		os.Exit(-1)
+	}
+
+	// Do any required cleanup here
+
+	os.Exit(0)
 }

--- a/examples/simple-filter-xml-mqtt/main.go
+++ b/examples/simple-filter-xml-mqtt/main.go
@@ -79,7 +79,15 @@ func main() {
 
 	// 5) Lastly, we'll go ahead and tell the SDK to "start" and begin listening for events
 	// to trigger the pipeline.
-	edgexSdk.MakeItRun()
+	err := edgexSdk.MakeItRun()
+	if err != nil {
+		edgexSdk.LoggingClient.Error("MakeItRun returned error: ", err.Error())
+		os.Exit(-1)
+	}
+
+	// Do any required cleanup here
+
+	os.Exit(0)
 }
 
 func printXMLToConsole(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {

--- a/examples/simple-filter-xml-post/main.go
+++ b/examples/simple-filter-xml-post/main.go
@@ -58,4 +58,5 @@ func main() {
 
 	// Do any required cleanup here
 
-	os.Exit(0)}
+	os.Exit(0)
+}

--- a/examples/simple-filter-xml-post/main.go
+++ b/examples/simple-filter-xml-post/main.go
@@ -50,5 +50,12 @@ func main() {
 
 	// 5) Lastly, we'll go ahead and tell the SDK to "start" and begin listening for events
 	// to trigger the pipeline.
-	edgexSdk.MakeItRun()
-}
+	err := edgexSdk.MakeItRun()
+	if err != nil {
+		edgexSdk.LoggingClient.Error("MakeItRun returned error: ", err.Error())
+		os.Exit(-1)
+	}
+
+	// Do any required cleanup here
+
+	os.Exit(0)}

--- a/examples/simple-filter-xml/main.go
+++ b/examples/simple-filter-xml/main.go
@@ -67,7 +67,15 @@ func main() {
 
 	// 5) Lastly, we'll go ahead and tell the SDK to "start" and begin listening for events
 	// to trigger the pipeline.
-	edgexSdk.MakeItRun()
+	err := edgexSdk.MakeItRun()
+	if err != nil {
+		edgexSdk.LoggingClient.Error("MakeItRun returned error: ", err.Error())
+		os.Exit(-1)
+	}
+
+	// Do any required cleanup here
+
+	os.Exit(0)
 }
 
 func printXMLToConsole(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {


### PR DESCRIPTION
This PR addresses issue #83 

SDK no longer calls os.exit and leaves it to the caller to exit properly after doing any potential clean-up.