### PR TITLE
Fix bug where ContentType isn't set when publishing back to bus

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -60,7 +60,7 @@ func (gr GolangRuntime) ProcessEvent(edgexcontext *appcontext.Context, envelope 
 		edgexcontext.EventChecksum = envelope.Checksum
 
 	default:
-		edgexcontext.LoggingClient.Error("'"+envelope.ContentType+"' content type for EdgeX Event not unsupported: ", clients.CorrelationHeader, envelope.CorrelationID)
+		edgexcontext.LoggingClient.Error("'"+envelope.ContentType+"' content type for EdgeX Event not supported: ", clients.CorrelationHeader, envelope.CorrelationID)
 		return nil
 	}
 

--- a/internal/trigger/messagebus/messaging.go
+++ b/internal/trigger/messagebus/messaging.go
@@ -73,6 +73,7 @@ func (trigger *Trigger) Initialize(logger logger.LoggingClient) error {
 					outputEnvelope := types.MessageEnvelope{
 						CorrelationID: edgexContext.CorrelationID,
 						Payload:       edgexContext.OutputData,
+						ContentType:   clients.ContentTypeJSON,
 					}
 					err := trigger.client.Publish(outputEnvelope, trigger.Configuration.Binding.PublishTopic)
 					if err != nil {


### PR DESCRIPTION
This PR addresses #99 

Simply set the Evnvelope.ContentType before publishing.
Also fixed typo in error message when content type wasn't set.