### PR TITLE
build(makefile): Create empty prepare command for CI fix

### DIFF
--- a/makefile
+++ b/makefile
@@ -44,5 +44,8 @@ test:
 	gofmt -l .
 	[ "`gofmt -l .`" = "" ]
 
+prepare:
+	echo "You've prepared nothing"
+	
 clean:
 	rm -f $(MICROSERVICES)


### PR DESCRIPTION
Testing CI Pipeline to unblock pull requests due to pipeline trying to run `make prepare`. This is a temp fix until CI Pipeline is addressed.

Signed-off-by: Mike Johanson <michael.johanson@intel.com>