### PR TITLE
feat(env-variables): Override Configuration Using Environment Variables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.12
 
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
-	github.com/BurntSushi/toml v0.3.1
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.0
 	github.com/edgexfoundry/go-mod-messaging v0.1.0
 	github.com/edgexfoundry/go-mod-registry v0.1.0
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gorilla/mux v1.7.2
+	github.com/pelletier/go-toml v1.2.0
 	github.com/stretchr/testify v1.3.0
 	github.com/ugorji/go v1.1.4
 )

--- a/internal/config/environment.go
+++ b/internal/config/environment.go
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package config
+
+import (
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/common"
+	"github.com/pelletier/go-toml"
+)
+
+const (
+	envKeyUrl = "edgex_registry"
+)
+
+// environment is receiver that holds environment variables and encapsulates toml.Tree-based configuration field
+// overrides.  Assumes "_" embedded in environment variable key separates substructs; e.g. foo_bar_baz might refer to
+//
+// 		type foo struct {
+// 			bar struct {
+//          	baz string
+//  		}
+//		}
+type environment struct {
+	env map[string]interface{}
+}
+
+// NewEnvironment constructor reads/stores os.Environ() for use by environment receiver methods.
+func NewEnvironment() *environment {
+	osEnv := os.Environ()
+	e := &environment{
+		env: make(map[string]interface{}, len(osEnv)),
+	}
+	for _, env := range osEnv {
+		kv := strings.Split(env, "=")
+		if len(kv) == 2 && len(kv[0]) > 0 && len(kv[1]) > 0 {
+			e.env[kv[0]] = kv[1]
+		}
+	}
+	return e
+}
+
+// OverrideRegistryInfoFromEnvironment method overrides registry location with environment variables.
+func (e *environment) OverrideRegistryInfoFromEnvironment(registry common.RegistryInfo) common.RegistryInfo {
+	if env := os.Getenv(envKeyUrl); env != "" {
+		if u, err := url.Parse(env); err == nil {
+			if p, err := strconv.ParseInt(u.Port(), 10, 0); err == nil {
+				registry.Port = int(p)
+				registry.Host = u.Hostname()
+				registry.Type = u.Scheme
+			}
+		}
+	}
+	return registry
+}
+
+// OverrideRegistryConfigFromEnvironment method replaces values in the toml.Tree for matching environment variable keys.
+func (e *environment) OverrideFromEnvironment(tree *toml.Tree) *toml.Tree {
+	for k, v := range e.env {
+		k = strings.Replace(k, "_", ".", -1)
+		switch {
+		case tree.Has(k):
+			// global key
+			tree.Set(k, v)
+		}
+	}
+	return tree
+}

--- a/internal/config/environment_test.go
+++ b/internal/config/environment_test.go
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package config
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/common"
+	"github.com/pelletier/go-toml"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	envValue  = "envValue"
+	rootKey   = "rootKey"
+	rootValue = "rootValue"
+	sub       = "sub"
+	subKey    = "subKey"
+	subValue  = "subValue"
+
+	testToml = `
+` + rootKey + `="` + rootValue + `"
+[` + sub + `]
+` + subKey + `="` + subValue + `"`
+)
+
+func newSUT(t *testing.T, env map[string]string) *environment {
+	os.Clearenv()
+	for k, v := range env {
+		if err := os.Setenv(k, v); err != nil {
+			t.Fail()
+		}
+	}
+	return NewEnvironment()
+}
+
+func newOverrideFromEnvironmentSUT(t *testing.T, envKey string, envValue string) (*toml.Tree, *environment) {
+	tree, err := toml.Load(testToml)
+	if err != nil {
+		t.Fail()
+	}
+	return tree, newSUT(t, map[string]string{envKey: envValue})
+}
+
+func TestKeyMatchOverwritesValue(t *testing.T) {
+	var tests = []struct {
+		name          string
+		key           string
+		envKey        string
+		envValue      string
+		expectedValue string
+	}{
+		{"generic root", rootKey, rootKey, envValue, envValue},
+		{"generic sub", sub + "." + subKey, sub + "." + subKey, envValue, envValue},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tree, sut := newOverrideFromEnvironmentSUT(t, test.key, test.envValue)
+
+			result := sut.OverrideFromEnvironment(tree)
+
+			assert.Equal(t, result.Get(test.key), test.envValue)
+		})
+	}
+}
+
+func TestNonMatchingKeyDoesNotOverwritesValue(t *testing.T) {
+	var tests = []struct {
+		name          string
+		key           string
+		envKey        string
+		envValue      string
+		expectedValue string
+	}{
+		{"root", rootKey, rootKey, envValue, rootValue},
+		{"sub", sub + "." + subKey, sub + "." + subKey, envValue, rootValue},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tree, sut := newOverrideFromEnvironmentSUT(t, test.key, test.envValue)
+
+			result := sut.OverrideFromEnvironment(tree)
+
+			assert.Equal(t, result.Get(test.key), test.envValue)
+		})
+	}
+}
+
+const (
+	expectedTypeValue = "consul"
+	expectedHostValue = "localhost"
+	expectedPortValue = 8500
+
+	defaultHostValue = "defaultHost"
+	defaultPortValue = 987654321
+	defaultTypeValue = "defaultType"
+)
+
+func initializeTest(t *testing.T) common.RegistryInfo {
+	os.Clearenv()
+	return common.RegistryInfo{
+		Host: defaultHostValue,
+		Port: defaultPortValue,
+		Type: defaultTypeValue,
+	}
+}
+
+func TestEnvVariableUpdatesRegistryInfo(t *testing.T) {
+	registryInfo := initializeTest(t)
+	sut := newSUT(t, map[string]string{envKeyUrl: expectedTypeValue + "://" + expectedHostValue + ":" + strconv.Itoa(expectedPortValue)})
+
+	registryInfo = sut.OverrideRegistryInfoFromEnvironment(registryInfo)
+
+	assert.Equal(t, registryInfo.Host, expectedHostValue)
+	assert.Equal(t, registryInfo.Port, expectedPortValue)
+	assert.Equal(t, registryInfo.Type, expectedTypeValue)
+}
+
+func TestNoEnvVariableDoesNotUpdateRegistryInfo(t *testing.T) {
+	registryInfo := initializeTest(t)
+	sut := newSUT(t, map[string]string{})
+
+	registryInfo = sut.OverrideRegistryInfoFromEnvironment(registryInfo)
+
+	assert.Equal(t, registryInfo.Host, defaultHostValue)
+	assert.Equal(t, registryInfo.Port, defaultPortValue)
+	assert.Equal(t, registryInfo.Type, defaultTypeValue)
+}


### PR DESCRIPTION
Added ability to override configuration.toml-provided registry address
with environment variables -- edgex_registry_host, edgex_registry_port,
and edgex_registry_type to be consistent with edgex-go core implementation
(see https://github.com/edgexfoundry/edgex-go/issues/1450).

Added ability to override any configuration value with environment
variables for the use case where a command line registry flag is
provided, the referenced registry does not have configuration for this
service, and this service pushes a copy of its local configuration into
the registry. The key in an environment variable specifies the
configuration value to override; e.g. Clients_Logging_Host=<someNewValue>

https://github.com/edgexfoundry/app-functions-sdk-go/issues/134
Signed-off-by: Michael W. Estrin <me@michaelestrin.com>