### PR TITLE
bugfix(empty TOML Node): Allow for empty TOML nodes used in Pipeline configuration

### DIFF
--- a/appsdk/sdk_test.go
+++ b/appsdk/sdk_test.go
@@ -115,7 +115,7 @@ func TestLoadConfigurablePipelineFunctionNotFound(t *testing.T) {
 		LoggingClient: lc,
 		config: common.ConfigurationStruct{
 			Writable: common.WritableInfo{
-				Pipeline: common.PipeLineInfo{
+				Pipeline: common.PipelineInfo{
 					ExecutionOrder: "Bogus",
 					Functions:      make(map[string]common.PipelineFunction),
 				},
@@ -137,7 +137,7 @@ func TestLoadConfigurablePipelineNotABuiltInSdkFunction(t *testing.T) {
 		LoggingClient: lc,
 		config: common.ConfigurationStruct{
 			Writable: common.WritableInfo{
-				Pipeline: common.PipeLineInfo{
+				Pipeline: common.PipelineInfo{
 					ExecutionOrder: "Bogus",
 					Functions:      functions,
 				},
@@ -169,7 +169,7 @@ func TestLoadConfigurablePipelineAddressableConfig(t *testing.T) {
 		LoggingClient: lc,
 		config: common.ConfigurationStruct{
 			Writable: common.WritableInfo{
-				Pipeline: common.PipeLineInfo{
+				Pipeline: common.PipelineInfo{
 					ExecutionOrder: functionName,
 					Functions:      functions,
 				},
@@ -194,7 +194,7 @@ func TestLoadConfigurablePipelineNumFunctions(t *testing.T) {
 		LoggingClient: lc,
 		config: common.ConfigurationStruct{
 			Writable: common.WritableInfo{
-				Pipeline: common.PipeLineInfo{
+				Pipeline: common.PipelineInfo{
 					ExecutionOrder: "DeviceNameFilter, XMLTransform, SetOutputData",
 					Functions:      functions,
 				},

--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -26,7 +26,7 @@ import (
 // WritableInfo ...
 type WritableInfo struct {
 	LogLevel string
-	Pipeline PipeLineInfo
+	Pipeline PipelineInfo
 }
 
 // ClientInfo provides the host and port of another service in the eco-system.
@@ -90,7 +90,7 @@ type BindingInfo struct {
 	PublishTopic   string
 }
 
-type PipeLineInfo struct {
+type PipelineInfo struct {
 	ExecutionOrder string
 	Functions      map[string]PipelineFunction
 }

--- a/internal/common/loader.go
+++ b/internal/common/loader.go
@@ -18,10 +18,11 @@ package common
 
 import (
 	"fmt"
-	"github.com/edgexfoundry/app-functions-sdk-go/internal"
-	"github.com/pelletier/go-toml"
 	"io/ioutil"
 	"os"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/internal"
+	"github.com/pelletier/go-toml"
 )
 
 const (
@@ -30,7 +31,7 @@ const (
 )
 
 // LoadFromFile loads .toml file for configuration
-func LoadFromFile(profile string, configDir string) (configuration *ConfigurationStruct, tree *toml.Tree, err error) {
+func LoadFromFile(profile string, configDir string) (configuration *ConfigurationStruct, err error) {
 	path := determinePath(configDir)
 	fileName := path + "/" + internal.ConfigFileName //default profile
 	if len(profile) > 0 {
@@ -38,22 +39,17 @@ func LoadFromFile(profile string, configDir string) (configuration *Configuratio
 	}
 	contents, err := ioutil.ReadFile(fileName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Could not load configuration file (%s): %v", fileName, err.Error())
+		return nil, fmt.Errorf("Could not load configuration file (%s): %v", fileName, err.Error())
 	}
 
 	// Decode the configuration from TOML
 	configuration = &ConfigurationStruct{}
 	err = toml.Unmarshal(contents, configuration)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Unable to parse configuration file (%s): %v", fileName, err.Error())
+		return nil, fmt.Errorf("Unable to parse configuration file (%s): %v", fileName, err.Error())
 	}
 
-	tree, err = toml.LoadBytes(contents)
-	if err != nil {
-		return nil, nil, fmt.Errorf("Unable to unmarshal configuration tree (%s): %v", path, err.Error())
-	}
-
-	return configuration, tree, nil
+	return configuration, nil
 }
 
 func determinePath(configDir string) string {


### PR DESCRIPTION
This addresses #147 by Marshaling the configuration object to TOML tree just before needing to push into Consul. Empty Pipeline.Functions nodes in the TOML file end up with an empty Addressable in Consul allowing them to exist in Consul.