### PR TITLE
feat(Filter): Pass all events/reading through if no filter values are set

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ E.G. NewFilter([] {"Device1", "Device2"}).FilterByDeviceName
 
 ### Filtering
 
-There are two basic types of filtering included in the SDK to add to your pipeline. Theses provided Filter functions return a type of `events.Model`. If filtering results in no remain data, the pipeline execution for that pass is terminated.
+There are two basic types of filtering included in the SDK to add to your pipeline. Theses provided Filter functions return a type of events.Model. If filtering results in no remaining data, the pipeline execution for that pass is terminated. If no values are provided for filtering, then data flows through unfiltered.
  - `NewFilter([]string filterValues)` - This function returns a `Filter` instance initialized with the passed in filter values. This `Filter` instance is used to access the following filter functions that will operate using the specified filter values.
     - `FilterByDeviceName` - This function will filter the event data down to the specified device names and return the filtered data to the pipeline.
     - `FilterByValueDescriptor` - This function will filter the event data down to the specified device value descriptor and return the filtered data to the pipeline. 

--- a/pkg/transforms/filter.go
+++ b/pkg/transforms/filter.go
@@ -48,6 +48,11 @@ func (f Filter) FilterByDeviceName(edgexcontext *appcontext.Context, params ...i
 	deviceIDs := f.FilterValues
 	event := params[0].(models.Event)
 
+	// No deviceIDs to filter for, so pass events thru rather than filtering them all out.
+	if len(deviceIDs) == 0 {
+		return true, event
+	}
+
 	for _, devID := range deviceIDs {
 		if event.Device == devID {
 			// LoggingClient.Debug(fmt.Sprintf("Event accepted: %s", event.Device))
@@ -72,6 +77,12 @@ func (f Filter) FilterByValueDescriptor(edgexcontext *appcontext.Context, params
 	}
 
 	existingEvent := params[0].(models.Event)
+
+	// No filter values, so pass all event and all readings thru, rather than filtering them all out.
+	if len(f.FilterValues) == 0 {
+		return true, existingEvent
+	}
+
 	auxEvent := models.Event{
 		Pushed:   existingEvent.Pushed,
 		Device:   existingEvent.Device,

--- a/pkg/transforms/filter_test.go
+++ b/pkg/transforms/filter_test.go
@@ -17,6 +17,7 @@
 package transforms
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
@@ -79,7 +80,7 @@ func TestFilterByDeviceNameNoParameters(t *testing.T) {
 	// }
 }
 
-func TestFilterValue(t *testing.T) {
+func TestFilterByValueDescriptor(t *testing.T) {
 
 	f1 := NewFilter([]string{descriptor1})
 	f12 := NewFilter([]string{descriptor1, descriptor2})
@@ -150,5 +151,59 @@ func TestFilterValue(t *testing.T) {
 	}
 	if len(res.(models.Event).Readings) != 1 {
 		t.Fatal("Event should be one reading, there are ", len(res.(models.Event).Readings))
+	}
+}
+
+func TestFilterByValueDescriptorNoFilterValues(t *testing.T) {
+	expected := models.Event{
+		Device: devID1,
+	}
+
+	expected.Readings = append(expected.Readings, models.Reading{Name: descriptor1})
+
+	filter := NewFilter(nil)
+
+	continuePipeline, result := filter.FilterByValueDescriptor(context, expected)
+	if !assert.NotNil(t, result, "Expected event to be passed thru") {
+		t.Fatal()
+	}
+
+	actual, ok := result.(models.Event)
+	if !assert.True(t, ok, "Expected result to be an Event") {
+		t.Fatal()
+	}
+
+	if !assert.NotNil(t, actual.Readings, "Expected Reading passed thru") {
+		t.Fatal()
+	}
+
+	assert.Equal(t, expected.Device, actual.Device, "Expected Event to be same as passed in")
+	assert.Equal(t, expected.Readings[0].Name, actual.Readings[0].Name, "Expected Reading to be same as passed in")
+
+	if !assert.True(t, continuePipeline, "Pipeline should'nt stop processing") {
+		t.Fatal()
+	}
+}
+
+func TestFilterByDeviceNameNoFilterValues(t *testing.T) {
+	expected := models.Event{
+		Device: devID1,
+	}
+
+	filter := NewFilter(nil)
+
+	continuePipeline, result := filter.FilterByDeviceName(context, expected)
+	if !assert.NotNil(t, result, "Expected event to be passed thru") {
+		t.Fatal()
+	}
+
+	actual, ok := result.(models.Event)
+	if !assert.True(t, ok, "Expected result to be an Event") {
+		t.Fatal()
+	}
+
+	assert.Equal(t, expected.Device, actual.Device, "Expected Event to be same as passed in")
+	if !assert.True(t, continuePipeline, "Pipeline should'nt stop processing") {
+		t.Fatal()
 	}
 }


### PR DESCRIPTION
Filter functions allow all events/reading to pass through (unfiltered) when the list of filter values is empty, rather then filter out all events/readings. This allows filter functions to be in the pipeline via configuration, but not filter if no filter values set until the values are dynamically updated via Consul.

Closes #137 

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>