### PR TITLE
feature(version): Add /api/version endpoint to SDK

### DIFF
--- a/examples/simple-filter-xml/main.go
+++ b/examples/simple-filter-xml/main.go
@@ -33,6 +33,7 @@ const (
 var counter int
 
 func main() {
+
 	// 1) First thing to do is to create an instance of the EdgeX SDK and initialize it.
 	edgexSdk := &appsdk.AppFunctionsSDK{ServiceKey: serviceKey}
 	if err := edgexSdk.Initialize(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/eclipse/paho.mqtt.golang v1.2.0
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.0
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.14
 	github.com/edgexfoundry/go-mod-messaging v0.1.11
 	github.com/edgexfoundry/go-mod-registry v0.1.0
 	github.com/go-stack/stack v1.8.0 // indirect

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -25,3 +25,9 @@ const (
 	ApiPingRoute         = "/api/v1/ping"
 	LogDurationKey       = "duration"
 )
+
+// SDKVersion indicates the version of the SDK - will be overwritten by build
+var SDKVersion string = "0.0.0"
+
+// ApplicationVersion indicates the version of the application itself, not the SDK - will be overwritten by build
+var ApplicationVersion string = "0.0.0"

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/edgexfoundry/app-functions-sdk-go/internal/telemetry"
-
+	"github.com/edgexfoundry/app-functions-sdk-go/internal"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/common"
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/telemetry"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 
@@ -68,6 +68,19 @@ func (webserver *WebServer) metricsHandler(writer http.ResponseWriter, _ *http.R
 
 	return
 }
+func (webserver *WebServer) versionHandler(writer http.ResponseWriter, _ *http.Request) {
+	type Version struct {
+		Version    string `json:"version"`
+		SDKVersion string `json:"sdk_version"`
+	}
+	version := Version{
+		Version:    internal.ApplicationVersion,
+		SDKVersion: internal.SDKVersion,
+	}
+	webserver.encode(version, writer)
+
+	return
+}
 
 // ConfigureStandardRoutes loads up some default routes
 func (webserver *WebServer) ConfigureStandardRoutes() {
@@ -83,6 +96,8 @@ func (webserver *WebServer) ConfigureStandardRoutes() {
 	// Metrics
 	webserver.router.HandleFunc(clients.ApiMetricsRoute, webserver.metricsHandler).Methods(http.MethodGet)
 
+	// Version
+	webserver.router.HandleFunc(clients.ApiVersionRoute, webserver.versionHandler).Methods(http.MethodGet)
 }
 
 // SetupTriggerRoute adds a route to handle trigger pipeline from HTTP request

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -54,7 +54,21 @@ func TestConfigureAndPingRoute(t *testing.T) {
 	assert.Equal(t, "pong", body)
 
 }
+func TestConfigureAndVersionRoute(t *testing.T) {
 
+	webserver := WebServer{
+		LoggingClient: logClient,
+	}
+	webserver.ConfigureStandardRoutes()
+
+	req, _ := http.NewRequest("GET", clients.ApiVersionRoute, nil)
+	rr := httptest.NewRecorder()
+	webserver.router.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	assert.Equal(t, "{\"version\":\"0.0.0\",\"sdk_version\":\"0.0.0\"}\n", body)
+
+}
 func TestConfigureAndConfigRoute(t *testing.T) {
 
 	webserver := WebServer{

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ MICROSERVICES=examples/simple-filter-xml/simple-filter-xml examples/simple-cbor-
 
 VERSION=$(shell cat ./VERSION)
 
-GOFLAGS=-ldflags "-X app-functions-sdk-go.Version=$(VERSION)"
+GOFLAGS=-ldflags "-X github.com/edgexfoundry/app-functions-sdk-go/internal.SDKVersion=$(VERSION) -X github.com/edgexfoundry/app-functions-sdk-go/internal.ApplicationVersion=$(VERSION)"
 
 GIT_SHA=$(shell git rev-parse HEAD)
 


### PR DESCRIPTION
This endpoint will provide both version of the SDK that is in use as well as the version of the application service. These version values are intended to be set at build time leveraging -ldflags.

closes #152

Signed-off-by: Mike Johanson <michael.johanson@intel.com>