### PR TITLE
Add support to pass MQTT key/pair as byte array (Issue 157)

### DIFF
--- a/appsdk/configurable.go
+++ b/appsdk/configurable.go
@@ -242,15 +242,19 @@ func (dynamic AppFunctionsSDKConfigurable) MQTTSend(parameters map[string]string
 	}
 	dynamic.Sdk.LoggingClient.Debug("MQTT Send Parameters", "Address", addr, Qos, qosVal, Retain, retainVal, AutoReconnect, autoreconnectVal, Cert, cert, Key, key)
 
-	pair := transforms.KeyCertPair{}
-	pair.CertFile = cert
-	pair.KeyFile = key
+	var pair *transforms.KeyCertPair
+
+	if len(cert) > 0 && len(key) > 0 {
+		pair = &transforms.KeyCertPair{}
+		pair.CertFile = cert
+		pair.KeyFile = key
+	}
 
 	mqttconfig := transforms.NewMqttConfig()
 	mqttconfig.SetQos(byte(qos))
 	mqttconfig.SetRetain(retain)
 	mqttconfig.SetAutoreconnect(autoreconnect)
-	sender := transforms.NewMQTTSender(dynamic.Sdk.LoggingClient, addr, &pair, mqttconfig)
+	sender := transforms.NewMQTTSender(dynamic.Sdk.LoggingClient, addr, pair, mqttconfig)
 	return sender.MQTTSend
 }
 

--- a/appsdk/configurable.go
+++ b/appsdk/configurable.go
@@ -242,11 +242,15 @@ func (dynamic AppFunctionsSDKConfigurable) MQTTSend(parameters map[string]string
 	}
 	dynamic.Sdk.LoggingClient.Debug("MQTT Send Parameters", "Address", addr, Qos, qosVal, Retain, retainVal, AutoReconnect, autoreconnectVal, Cert, cert, Key, key)
 
+	pair := transforms.KeyCertPair{}
+	pair.CertFile = cert
+	pair.KeyFile = key
+
 	mqttconfig := transforms.NewMqttConfig()
 	mqttconfig.SetQos(byte(qos))
 	mqttconfig.SetRetain(retain)
 	mqttconfig.SetAutoreconnect(autoreconnect)
-	sender := transforms.NewMQTTSender(dynamic.Sdk.LoggingClient, addr, cert, key, mqttconfig)
+	sender := transforms.NewMQTTSender(dynamic.Sdk.LoggingClient, addr, &pair, mqttconfig)
 	return sender.MQTTSend
 }
 

--- a/examples/simple-filter-xml-mqtt/main.go
+++ b/examples/simple-filter-xml-mqtt/main.go
@@ -55,7 +55,10 @@ func main() {
 		Topic:     "sampleTopic",
 	}
 
-	pair := transforms.KeyCertPair{}
+	pair := transforms.KeyCertPair{
+        KeyFile:    "",
+        CertFile:   "",
+    }
 	mqttConfig := transforms.NewMqttConfig()
 	mqttSender := transforms.NewMQTTSender(edgexSdk.LoggingClient, addressable, &pair, mqttConfig)
 

--- a/examples/simple-filter-xml-mqtt/main.go
+++ b/examples/simple-filter-xml-mqtt/main.go
@@ -56,9 +56,9 @@ func main() {
 	}
 
 	pair := transforms.KeyCertPair{
-        KeyFile:    "",
-        CertFile:   "",
-    }
+		KeyFile:  "",
+		CertFile: "",
+	}
 	mqttConfig := transforms.NewMqttConfig()
 	mqttSender := transforms.NewMQTTSender(edgexSdk.LoggingClient, addressable, &pair, mqttConfig)
 

--- a/examples/simple-filter-xml-mqtt/main.go
+++ b/examples/simple-filter-xml-mqtt/main.go
@@ -55,8 +55,9 @@ func main() {
 		Topic:     "sampleTopic",
 	}
 
+	pair := transforms.KeyCertPair{}
 	mqttConfig := transforms.NewMqttConfig()
-	mqttSender := transforms.NewMQTTSender(edgexSdk.LoggingClient, addressable, "", "", mqttConfig)
+	mqttSender := transforms.NewMQTTSender(edgexSdk.LoggingClient, addressable, &pair, mqttConfig)
 
 	// 3) This is our pipeline configuration, the collection of functions to
 	// execute every time an event is triggered.

--- a/pkg/transforms/mqtt_test.go
+++ b/pkg/transforms/mqtt_test.go
@@ -23,9 +23,8 @@ func init() {
 func TestMQTTSend(t *testing.T) {
 	t.SkipNow()
 
-	pair := KeyCertPair{}
 	mqttConfig := NewMqttConfig()
-	sender := NewMQTTSender(lc, addr, &pair, mqttConfig)
+	sender := NewMQTTSender(lc, addr, nil, mqttConfig)
 
 	dataToSend := "SOME DATA TO SEND"
 	continuePipeline, result := sender.MQTTSend(context, dataToSend)
@@ -47,9 +46,8 @@ func TestMQTTSendInvalidData(t *testing.T) {
 	t.SkipNow()
 
 	expected := "passed in data must be of type []byte, string or implement json.Marshaler"
-	pair := KeyCertPair{}
 	mqttConfig := NewMqttConfig()
-	sender := NewMQTTSender(lc, addr, &pair, mqttConfig)
+	sender := NewMQTTSender(lc, addr, nil, mqttConfig)
 
 	type RandomObject struct {
 		something string
@@ -76,9 +74,8 @@ func TestNewMQTTSender(t *testing.T) {
 		Topic:     "testMQTTTopic",
 	}
 
-	pair := KeyCertPair{}
 	mqttConfig := NewMqttConfig()
-	sender := NewMQTTSender(lc, addr1, &pair, mqttConfig)
+	sender := NewMQTTSender(lc, addr1, nil, mqttConfig)
 	assert.NotNil(t, sender.client, "Client should not be nil")
 	opts := sender.client.OptionsReader()
 	assert.Equal(t, "testMQTTTopic", sender.topic, "Topic should be set to testMQTTTopic")

--- a/pkg/transforms/mqtt_test.go
+++ b/pkg/transforms/mqtt_test.go
@@ -23,8 +23,9 @@ func init() {
 func TestMQTTSend(t *testing.T) {
 	t.SkipNow()
 
+	pair := KeyCertPair{}
 	mqttConfig := NewMqttConfig()
-	sender := NewMQTTSender(lc, addr, "", "", mqttConfig)
+	sender := NewMQTTSender(lc, addr, &pair, mqttConfig)
 
 	dataToSend := "SOME DATA TO SEND"
 	continuePipeline, result := sender.MQTTSend(context, dataToSend)
@@ -46,8 +47,9 @@ func TestMQTTSendInvalidData(t *testing.T) {
 	t.SkipNow()
 
 	expected := "passed in data must be of type []byte, string or implement json.Marshaler"
+	pair := KeyCertPair{}
 	mqttConfig := NewMqttConfig()
-	sender := NewMQTTSender(lc, addr, "", "", mqttConfig)
+	sender := NewMQTTSender(lc, addr, &pair, mqttConfig)
 
 	type RandomObject struct {
 		something string
@@ -74,8 +76,9 @@ func TestNewMQTTSender(t *testing.T) {
 		Topic:     "testMQTTTopic",
 	}
 
+	pair := KeyCertPair{}
 	mqttConfig := NewMqttConfig()
-	sender := NewMQTTSender(lc, addr1, "", "", mqttConfig)
+	sender := NewMQTTSender(lc, addr1, &pair, mqttConfig)
 	assert.NotNil(t, sender.client, "Client should not be nil")
 	opts := sender.client.OptionsReader()
 	assert.Equal(t, "testMQTTTopic", sender.topic, "Topic should be set to testMQTTTopic")


### PR DESCRIPTION
This is to address issue #157. I added a new struct KeyCertPair to encapsulate key/cert in file path and byte array. byte arrays will be used first if available or file names will be used to load key and certificate.
@cloudxxx8 
Signed-off-by: David Chang <david@iotechsys.com>