### PR TITLE
feature(mark-as-pushed): MarkAsPushed is now available as a standalone function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Table of contents
       * [Encryption](#encryption)
       * [Conversion](#conversion)
       * [Compressions](#compressions)
+	  * [Core Data](#CoreData-Functions)
       * [Export Functions](#export-functions)    
    * [Configuration](#configuration)
    * [Error Handling](#error-handling)
@@ -28,6 +29,7 @@ package main
 import (
 	"fmt"
 	"github.com/edgexfoundry/app-functions-sdk-go/appsdk"
+	"github.com/edgexfoundry/app-functions-sdk-go/pkg/transforms"
 	"os"
 )
 
@@ -44,15 +46,15 @@ func main() {
 		os.Exit(-1)
 	}
 
-	// 3) Since our DeviceNameFilter Function requires the list of Device Names we would
+	// 3) Since our FilterByDeviceName Function requires the list of Device Names we would
 	// like to search for, we'll go ahead and define that now.
-	deviceIDs := []string{"Random-Float-Device"}
+	deviceNames := []string{"Random-Float-Device"}
 
 	// 4) This is our pipeline configuration, the collection of functions to
 	// execute every time an event is triggered.
-	if err := edgexSdk.SetPipeline(
+	if err := edgexSdk.SetFunctionsPipeline(
 			transforms.NewFilter(deviceNames).FilterByDeviceName, 
-			transforms.NewConversion().TransformToXML()
+			transforms.NewConversion().TransformToXML,
 		); err != nil {
 			edgexSdk.LoggingClient.Error(fmt.Sprintf("SDK SetPipeline failed: %v\n", err))
 			os.Exit(-1)
@@ -93,9 +95,9 @@ func printXMLToConsole(edgexcontext *excontext.Context, params ...interface{}) (
 After placing the above function in your code, the next step is to modify the pipeline to call this function:
 
 ```golang
-edgexSdk.SetPipeline(
+edgexSdk.SetFunctionsPipeline(
   transforms.NewFilter(deviceNames).FilterByDeviceName, 
-  transforms.NewConversion().TransformToXML(),
+  transforms.NewConversion().TransformToXML,
   printXMLToConsole //notice this is not a function call, but simply a function pointer. 
 )
 ```
@@ -192,30 +194,34 @@ There is one encryption transform included in the SDK that can be added to your 
 ### Conversion
 There are two conversions included in the SDK that can be added to your pipeline. These transforms return a `string`.
 
- - `NewConversion()` - This function returns a `Conversion` instance that is used to access the following conversion functions 
+ - `NewConversion()` - This function returns a `Conversion` instance that is used to access the following conversion functions: 
     - `TransformToXML`  - This function receives an `events.Model` type, converts it to XML format and returns the XML string to the pipeline. 
     - `TransformToJSON` - This function receives an `events.Model` type and converts it to JSON format and returns the JSON string to the pipeline.
 
  ### Compressions
 There are two compression types included in the SDK that can be added to your pipeline. These transforms return a `[]byte`.
 
- - `NewCompression()` - This function returns a `Compression` instance that is used to access the following compression functions 
+ - `NewCompression()` - This function returns a `Compression` instance that is used to access the following compression functions:
     - `CompressWithGZIP`  - This function receives either a `string`,`[]byte`, or `json.Marshaler` type, GZIP compresses the data, converts result to base64 encoded string, which is returned as a `[]byte` to the pipeline.
     - `CompressWithZLIB` - This function receives either a `string`,`[]byte`, or `json.Marshaler` type, ZLIB compresses the data, converts result to base64 encoded string, which is returned as a `[]byte` to the pipeline.
 
+### CoreData Functions
+These are functions that enable interactions with the CoreData REST API. 
+- `NewCoreData()` - This function returns a `CoreData` instance. This `CoreData` instance is used to access the following function(s).
+  - `MarkAsPushed` - This function provides the MarkAsPushed function from the context as a First-Class Transform that can be called in your pipeline. [See Definition Above](#.MarkAsPushed()). The data passed into this function from the pipeline is passed along unmodifed since all required information is provided on the context (EventId, CorrelationId,etc.. )
 
 ### Export Functions
 There are two export functions included in the SDK that can be added to your pipeline. 
-- `NewHTTPSender(url string, mimeType string)` - This function returns a `HTTPSender` instance initialized with the passed in url and mime type values. This `HTTPSender` instance is used to access the following  function that will use the required url and mime type.
-  - `HTTPPost` - This function receives either a `string`,`[]byte`, or `json.Marshaler` type from the previous function in the pipeline and posts it to the configured endpoint. If no previous function exists, then the event that triggered the pipeline, marshaled to json, will be used. Currently, only unauthenticated endpoints are supported. Authenticated endpoints will be supported in the future. This function will mark the received EdgeX event as pushed in Core Data upon a success response code. 
+- `NewHTTPSender(url string, mimeType string)` - This function returns a `HTTPSender` instance initialized with the passed in url and mime type values. This `HTTPSender` instance is used to access the following functions that will use the required url and mime type:
+  - `HTTPPost` - This function receives either a `string`,`[]byte`, or `json.Marshaler` type from the previous function in the pipeline and posts it to the configured endpoint. If no previous function exists, then the event that triggered the pipeline, marshaled to json, will be used. Currently, only unauthenticated endpoints are supported. Authenticated endpoints will be supported in the future.
 - `NewMQTTSender(logging logger.LoggingClient, addr models.Addressable, cert string, key string, qos byte, retain bool, autoreconnect bool)` - This function returns a `MQTTSender` instance initialized with the passed in MQTT configuration . This `MQTTSender` instance is used to access the following  function that will use the specified MQTT configuration
-  - `MQTTSend` - This function receives either a `string`,`[]byte`, or `json.Marshaler` type from the previous function in the pipeline and sends it to the specified MQTT broker. If no previous function exists, then the event that triggered the pipeline, marshaled to json, will be used. This function will mark the received EdgeX event as pushed in Core Data upon a success response code. 
+  - `MQTTSend` - This function receives either a `string`,`[]byte`, or `json.Marshaler` type from the previous function in the pipeline and sends it to the specified MQTT broker. If no previous function exists, then the event that triggered the pipeline, marshaled to json, will be used.
 
 ### Output Functions
 
 There is one output function included in the SDK that can be added to your pipeline. 
 
-- NewOuptut() - This function returns a `Output` instance that is used to access the following output function 
+- NewOuptut() - This function returns a `Output` instance that is used to access the following output function: 
   - `SetOutput` - This function receives either a `string`,`[]byte`, or `json.Marshaler` type from the previous function in the pipeline and sets it as the output data for the pipeline to return to the configured trigger. If configured to use message bus, the data will be published to the message bus as determined by the `MessageBus` and `Binding` configuration. If configured to use HTTP trigger the data is returned as the HTTP response. Note that calling Complete() from the Context API in a custom function can be used in place of adding this function to your pipeline
 
 ## Configuration

--- a/appcontext/context_test.go
+++ b/appcontext/context_test.go
@@ -1,0 +1,114 @@
+package appcontext
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComplete(t *testing.T) {
+	ctx := Context{}
+	testData := "output data"
+	ctx.Complete([]byte(testData))
+	assert.Equal(t, []byte(testData), ctx.OutputData)
+}
+
+var eventClient coredata.EventClient
+var params types.EndpointParams
+
+func init() {
+	params = types.EndpointParams{
+		ServiceKey:  clients.CoreDataServiceKey,
+		Path:        clients.ApiEventRoute,
+		UseRegistry: false,
+		Url:         "http://test" + clients.ApiEventRoute,
+		Interval:    clients.ClientMonitorDefault,
+	}
+
+}
+func TestMarkAsPushedNoEventIdOrChecksum(t *testing.T) {
+	ctx := Context{}
+	err := ctx.MarkAsPushed()
+	assert.NotNil(t, err)
+	assert.Equal(t, "No EventID or EventChecksum Provided", err.Error())
+}
+
+func TestMarkAsPushedNoChecksum(t *testing.T) {
+	testChecksum := "checksumValue"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		if r.Method != http.MethodPut {
+			t.Errorf("expected http method is PUT, active http method is : %s", r.Method)
+		}
+		url := clients.ApiEventRoute + "/checksum/" + testChecksum
+		if r.URL.EscapedPath() != url {
+			t.Errorf("expected uri path is %s, actual uri path is %s", url, r.URL.EscapedPath())
+		}
+	}))
+
+	defer ts.Close()
+	params.Url = ts.URL + clients.ApiEventRoute
+	eventClient = coredata.NewEventClient(params, mockEventEndpoint{})
+	ctx := Context{
+		EventChecksum: testChecksum,
+		CorrelationID: "correlationId",
+		EventClient:   eventClient,
+	}
+	err := ctx.MarkAsPushed()
+
+	assert.Nil(t, err)
+
+}
+
+func TestMarkAsPushedEventId(t *testing.T) {
+	testID := "eventId"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		if r.Method != http.MethodPut {
+			t.Errorf("expected http method is PUT, active http method is : %s", r.Method)
+		}
+		//"http://test/api/v1/event/id/eventId"
+		url := clients.ApiEventRoute + "/id/" + testID
+		if r.URL.EscapedPath() != url {
+			t.Errorf("expected uri path is %s, actual uri path is %s", url, r.URL.EscapedPath())
+		}
+	}))
+
+	defer ts.Close()
+	params.Url = ts.URL + clients.ApiEventRoute
+	eventClient = coredata.NewEventClient(params, mockEventEndpoint{})
+
+	ctx := Context{
+		EventID:       testID,
+		CorrelationID: "correlationId",
+		EventClient:   eventClient,
+	}
+
+	err := ctx.MarkAsPushed()
+
+	assert.Nil(t, err)
+}
+
+type mockEventEndpoint struct {
+}
+
+func (e mockEventEndpoint) Monitor(params types.EndpointParams, ch chan string) {
+	switch params.ServiceKey {
+	case clients.CoreDataServiceKey:
+		url := fmt.Sprintf("http://%s:%v%s", "localhost", 48080, params.Path)
+		ch <- url
+		break
+	default:
+		ch <- ""
+	}
+}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -304,8 +304,8 @@ func TestProcessEventCBOR(t *testing.T) {
 
 	transform1WasCalled := false
 
-	buffer := new(bytes.Buffer)
-	handle := new(codec.CborHandle)
+	buffer := &bytes.Buffer{}
+	handle := &codec.CborHandle{}
 	encoder := codec.NewEncoder(buffer, handle)
 	encoder.Encode(eventIn)
 

--- a/pkg/transforms/coredata.go
+++ b/pkg/transforms/coredata.go
@@ -1,0 +1,24 @@
+package transforms
+
+import (
+	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
+)
+
+type CoreData struct {
+}
+
+// NewCoreData Is provided to interact with CoreData
+func NewCoreData() *CoreData {
+	coredata := &CoreData{}
+	return coredata
+}
+
+// MarkAsPushed will make a request to CoreData to mark the event that triggered the pipeline as pushed.
+// This function will not stop the pipeline if an error is returned from core data, however the error is logged.
+func (cdc *CoreData) MarkAsPushed(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
+	err := edgexcontext.MarkAsPushed()
+	if err != nil {
+		edgexcontext.LoggingClient.Error(err.Error())
+	}
+	return true, params[0]
+}

--- a/pkg/transforms/coredata_test.go
+++ b/pkg/transforms/coredata_test.go
@@ -1,0 +1,17 @@
+package transforms
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarkAsPushed(t *testing.T) {
+	coreData := NewCoreData()
+
+	continuePipeline, result := coreData.MarkAsPushed(context, "something")
+
+	assert.NotNil(t, result)
+	assert.Equal(t, "something", result)
+	assert.True(t, continuePipeline)
+}

--- a/pkg/transforms/filter_test.go
+++ b/pkg/transforms/filter_test.go
@@ -17,8 +17,9 @@
 package transforms
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
@@ -75,9 +76,6 @@ func TestFilterByDeviceNameNoParameters(t *testing.T) {
 	if continuePipeline == true {
 		t.Fatal("Pipeline should stop processing")
 	}
-	// if result != errors.new()("") {
-	// 	t.Fatal("Pipeline should return no paramater error")
-	// }
 }
 
 func TestFilterByValueDescriptor(t *testing.T) {

--- a/pkg/transforms/http.go
+++ b/pkg/transforms/http.go
@@ -77,12 +77,7 @@ func (sender HTTPSender) HTTPPost(edgexcontext *appcontext.Context, params ...in
 
 	// continues the pipeline if we get a 2xx response, stops pipeline if non-2xx response
 	isSuccessfulPost := response.StatusCode >= 200 && response.StatusCode < 300
-	if isSuccessfulPost == true {
-		err = edgexcontext.MarkAsPushed()
-		if err != nil {
-			edgexcontext.LoggingClient.Error(err.Error())
-		}
-	}
+
 	return isSuccessfulPost, bodyBytes
 
 }

--- a/pkg/transforms/mqtt.go
+++ b/pkg/transforms/mqtt.go
@@ -42,7 +42,7 @@ type MqttConfig struct {
 
 // NewMqttConfig returns a new MqttConfig with default values. Use Setter functions to change specific values.
 func NewMqttConfig() *MqttConfig {
-	mqttConfig := new(MqttConfig)
+	mqttConfig := &MqttConfig{}
 	mqttConfig.qos = 0
 	mqttConfig.retain = false
 	mqttConfig.autoreconnect = false
@@ -136,9 +136,6 @@ func (sender MQTTSender) MQTTSend(edgexcontext *appcontext.Context, params ...in
 	}
 	edgexcontext.LoggingClient.Info("Sent data to MQTT Broker")
 	edgexcontext.LoggingClient.Trace("Data exported", "Transport", "MQTT", clients.CorrelationHeader, edgexcontext.CorrelationID)
-	err = edgexcontext.MarkAsPushed()
-	if err != nil {
-		edgexcontext.LoggingClient.Error(err.Error())
-	}
+
 	return true, nil
 }


### PR DESCRIPTION
This PR adds MarkAsPushed as it's own function. This is primarily to support the app service configurable and provides more flexibility for when this action occurs. MarkAsPushed will remain available on the context itself.

BREAKING CHANGE: HTTPPost and MQTTSend no longer automatically call MarkAsPushed upon success. It is upon the developer to ensure the method is called appropriately.

Closes #162

Signed-off-by: Mike Johanson <michael.johanson@intel.com>