### PR TITLE
feat(runtime): Support types other than Event to be sent to function pipeline

### DIFF
--- a/appsdk/sdk.go
+++ b/appsdk/sdk.go
@@ -71,6 +71,7 @@ type AppFunctionsSDK struct {
 	eventClient               coredata.EventClient
 	config                    common.ConfigurationStruct
 	LoggingClient             logger.LoggingClient
+	TargetType                interface{}
 }
 
 // MakeItRun will initialize and start the trigger as specifed in the
@@ -80,7 +81,7 @@ func (sdk *AppFunctionsSDK) MakeItRun() error {
 	httpErrors := make(chan error)
 	defer close(httpErrors)
 
-	sdk.runtime = &runtime.GolangRuntime{} //Transforms: sdk.transforms
+	sdk.runtime = &runtime.GolangRuntime{TargetType: sdk.TargetType} //Transforms: sdk.transforms
 	sdk.runtime.SetTransforms(sdk.transforms)
 	sdk.webserver = &webserver.WebServer{
 		Config:        &sdk.config,

--- a/pkg/transforms/encryption.go
+++ b/pkg/transforms/encryption.go
@@ -23,6 +23,7 @@ import (
 	"crypto/cipher"
 	"crypto/sha1"
 	"encoding/base64"
+	"errors"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
 	"github.com/edgexfoundry/app-functions-sdk-go/pkg/util"
@@ -53,6 +54,9 @@ func pkcs5Padding(ciphertext []byte, blockSize int) []byte {
 // EncryptWithAES encrypts a string, []byte, or json.Marshaller type using AES encryption.
 // It will return a Base64 encode []byte of the encrypted data.
 func (aesData Encryption) EncryptWithAES(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
+	if len(params) < 1 {
+		return false, errors.New("no data received to encrypt")
+	}
 	data, err := util.CoerceType(params[0])
 	if err != nil {
 		return false, err

--- a/pkg/transforms/encryption_test.go
+++ b/pkg/transforms/encryption_test.go
@@ -83,3 +83,17 @@ func TestAES(t *testing.T) {
 
 	assert.Equal(t, string(plainString), string(decphrd))
 }
+
+func TestAESNoData(t *testing.T) {
+	aesData := models.EncryptionDetails{
+		Algo:       "AES",
+		Key:        key,
+		InitVector: iv,
+	}
+
+	enc := NewEncryption(aesData.Key, aesData.InitVector)
+
+	continuePipeline, result := enc.EncryptWithAES(context)
+	assert.False(t, continuePipeline)
+	assert.Error(t, result.(error), "expect an error")
+}

--- a/pkg/transforms/filter.go
+++ b/pkg/transforms/filter.go
@@ -39,14 +39,17 @@ func NewFilter(filterValues []string) Filter {
 // is received or if no data is received.
 func (f Filter) FilterByDeviceName(edgexcontext *appcontext.Context, params ...interface{}) (continuePipeline bool, result interface{}) {
 
-	edgexcontext.LoggingClient.Debug("Filter by DeviceID")
+	edgexcontext.LoggingClient.Debug("Filtering by DeviceID")
 
-	if len(params) != 1 {
-		return false, errors.New("No Event Received")
+	if len(params) < 1 {
+		return false, errors.New("no Event Received")
 	}
 
 	deviceIDs := f.FilterValues
-	event := params[0].(models.Event)
+	event, ok := params[0].(models.Event)
+	if !ok {
+		return false, errors.New("type received is not an Event")
+	}
 
 	// No deviceIDs to filter for, so pass events thru rather than filtering them all out.
 	if len(deviceIDs) == 0 {
@@ -70,13 +73,16 @@ func (f Filter) FilterByDeviceName(edgexcontext *appcontext.Context, params ...i
 // This function will return an error and stop the pipeline if a non-edgex event is received or if no data is received.
 func (f Filter) FilterByValueDescriptor(edgexcontext *appcontext.Context, params ...interface{}) (continuePipeline bool, result interface{}) {
 
-	edgexcontext.LoggingClient.Debug("Filter by ValueDescriptor")
+	edgexcontext.LoggingClient.Debug("Filtering by ValueDescriptor")
 
-	if len(params) != 1 {
-		return false, errors.New("No Event Received")
+	if len(params) < 1 {
+		return false, errors.New("no Event Received")
 	}
 
-	existingEvent := params[0].(models.Event)
+	existingEvent, ok := params[0].(models.Event)
+	if !ok {
+		return false, errors.New("type received is not an Event")
+	}
 
 	// No filter values, so pass all event and all readings thru, rather than filtering them all out.
 	if len(f.FilterValues) == 0 {


### PR DESCRIPTION
Allow the Target Type for the incoming data to be specified by developer. This allows data other than Events to be processed be the function pipeline.

closes #79