### PR TITLE
Support to pass MQTT key/pair as byte array

### DIFF
--- a/appsdk/configurable.go
+++ b/appsdk/configurable.go
@@ -242,11 +242,20 @@ func (dynamic AppFunctionsSDKConfigurable) MQTTSend(parameters map[string]string
 	}
 	dynamic.Sdk.LoggingClient.Debug("MQTT Send Parameters", "Address", addr, Qos, qosVal, Retain, retainVal, AutoReconnect, autoreconnectVal, Cert, cert, Key, key)
 
+	var pair *transforms.KeyCertPair
+
+	if len(cert) > 0 && len(key) > 0 {
+		pair = &transforms.KeyCertPair{
+			CertFile: cert,
+			KeyFile:  key,
+		}
+	}
+
 	mqttconfig := transforms.NewMqttConfig()
 	mqttconfig.SetQos(byte(qos))
 	mqttconfig.SetRetain(retain)
 	mqttconfig.SetAutoreconnect(autoreconnect)
-	sender := transforms.NewMQTTSender(dynamic.Sdk.LoggingClient, addr, cert, key, mqttconfig)
+	sender := transforms.NewMQTTSender(dynamic.Sdk.LoggingClient, addr, pair, mqttconfig)
 	return sender.MQTTSend
 }
 

--- a/examples/simple-filter-xml-mqtt/main.go
+++ b/examples/simple-filter-xml-mqtt/main.go
@@ -56,7 +56,17 @@ func main() {
 	}
 
 	mqttConfig := transforms.NewMqttConfig()
-	mqttSender := transforms.NewMQTTSender(edgexSdk.LoggingClient, addressable, "", "", mqttConfig)
+
+	// Make sure you change KeyFile and CertFile here to point to actual key/cert files
+	// or an error will be logged for failing to load key/cert files
+	// If you don't use key/cert for MQTT authentication, just pass nil to NewMQTTSender() as following:
+	// mqttSender := transforms.NewMQTTSender(edgexSdk.LoggingClient, addressable, nil, mqttConfig)
+	pair := transforms.KeyCertPair{
+		KeyFile:  "PATH_TO_YOUR_KEY_FILE",
+		CertFile: "PATH_TO_YOUR_CERT_FILE",
+	}
+
+	mqttSender := transforms.NewMQTTSender(edgexSdk.LoggingClient, addressable, &pair, mqttConfig)
 
 	// 3) This is our pipeline configuration, the collection of functions to
 	// execute every time an event is triggered.

--- a/pkg/transforms/mqtt_test.go
+++ b/pkg/transforms/mqtt_test.go
@@ -24,7 +24,7 @@ func TestMQTTSend(t *testing.T) {
 	t.SkipNow()
 
 	mqttConfig := NewMqttConfig()
-	sender := NewMQTTSender(lc, addr, "", "", mqttConfig)
+	sender := NewMQTTSender(lc, addr, nil, mqttConfig)
 
 	dataToSend := "SOME DATA TO SEND"
 	continuePipeline, result := sender.MQTTSend(context, dataToSend)
@@ -47,7 +47,7 @@ func TestMQTTSendInvalidData(t *testing.T) {
 
 	expected := "passed in data must be of type []byte, string or implement json.Marshaler"
 	mqttConfig := NewMqttConfig()
-	sender := NewMQTTSender(lc, addr, "", "", mqttConfig)
+	sender := NewMQTTSender(lc, addr, nil, mqttConfig)
 
 	type RandomObject struct {
 		something string
@@ -75,7 +75,7 @@ func TestNewMQTTSender(t *testing.T) {
 	}
 
 	mqttConfig := NewMqttConfig()
-	sender := NewMQTTSender(lc, addr1, "", "", mqttConfig)
+	sender := NewMQTTSender(lc, addr1, nil, mqttConfig)
 	assert.NotNil(t, sender.client, "Client should not be nil")
 	opts := sender.client.OptionsReader()
 	assert.Equal(t, "testMQTTTopic", sender.topic, "Topic should be set to testMQTTTopic")


### PR DESCRIPTION
This is to address issue #157 adding support to allow to pass MQTT key/pair as byte array so that the client can retrieve cert/key from some more secure sources like vault before the SDK supports it.

Signed-off-by: David Chang <david@iotechsys.com>