### PR TITLE
feat(configuration) Environment variable override of the Service connection information

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Table of contents
    * [Error Handling](#error-handling)
    * [Advanced Topics](#advanced-topics)
      * [Target Type](#target-type)
+     * [Command Line Options](#command_line_options)
+     * [Environment Variable Overrides](#environment_variable_overrides)
+       * [edgex_registry](#edgex_registry)
+       * [edgex_service](#edgex_service)
 
   <!--te-->
 
@@ -302,3 +306,88 @@ func MyPersonFunction(edgexcontext *appcontext.Context, params ...interface{}) (
 The SDK supports unmarshaling JSON or CBOR encoded data into an instance of the target type. If your incoming data is not JSON or CBOR encoded, you then need to set the `TargetType` to  `&[]byte`.
 
 If the target type is set to `&[]byte` the incoming data will not be unmarshaled.  The content type, if set, will be passed as the second parameter to the first function in your pipeline.  Your first function will be responsible for decoding the data or not.
+
+### Command Line Options
+
+The following command line options are available
+
+```
+  -c=<path>
+        Specify an alternate configuration directory.
+  -confdir=<path>
+        Specify an alternate configuration directory.
+  -p=<profile>
+        Specify a profile other than default.
+  -profile=<profile>
+        Specify a profile other than default.
+  -r    Indicates the service should use registry.
+  -registry
+        Indicates the service should use the registry.
+```
+
+Examples:
+
+```
+simple-filter-xml -r -c=./res -p=docker
+```
+
+or
+
+```
+simple-filter-xml --registry --confdir=./res --profile=docker
+```
+
+### Environment Variable Overrides
+
+All the configuration settings from the configuration.toml file can be overridden by environment variables. Except for two special cases listed below, the overrides **only** occur when the configuration values are first pushed into the Registry. Once the values are in the Registry, the Registry values are always used. 
+
+The environment variable names have the following format:
+
+```
+<TOML Key>
+<TOML Section>_<TOML Key>
+<TOML Section>_<TOML Sub-Section>_<TOML Key>
+```
+
+Examples:
+
+```
+TOML   : FailLimit = 30
+ENVVAR : FailLimit=100
+
+TOML   : [Logging]
+		 EnableRemote = false
+ENVVAR : Logging.EnableRemote=true
+
+TOML   : [Clients]
+  			[Clients.CoreData]
+  			Host = 'localhost'
+ENVVAR : Clients_CoreData_Host=edgex-core-data
+```
+
+#### edgex_registry
+
+This environment variable overrides the Registry connection information and occurs every time the application service starts. The value is in the format of a URL.
+
+```
+edgex_registry=consul://edgex-core-consul:8500
+
+This sets the Registry information fields as follows:
+    Type: consul
+    Host: edgex-core-consul
+    Port: 8500
+```
+
+#### edgex_service
+
+This environment variable overrides the Service connection information and occurs every time the application service starts. The value is in the format of a URL.
+
+```
+edgex_service=http://192.168.1.2:4903
+
+This sets the Service information fields as follows:
+    Protocol: http
+    Host: 192.168.1.2
+    Port: 4903
+```
+

--- a/appsdk/sdk.go
+++ b/appsdk/sdk.go
@@ -299,6 +299,7 @@ func (sdk *AppFunctionsSDK) initializeConfiguration() error {
 	if sdk.useRegistry {
 		e := config.NewEnvironment()
 		configuration.Registry = e.OverrideRegistryInfoFromEnvironment(configuration.Registry)
+		configuration.Service = e.OverrideServiceInfoFromEnvironment(configuration.Service)
 
 		registryConfig := registryTypes.Config{
 			Host:          configuration.Registry.Host,
@@ -316,17 +317,12 @@ func (sdk *AppFunctionsSDK) initializeConfiguration() error {
 		if err != nil {
 			return fmt.Errorf("Connection to Registry could not be made: %v", err)
 		}
+
 		//set registryClient
 		sdk.registryClient = client
 
 		if !sdk.registryClient.IsAlive() {
 			return fmt.Errorf("Registry (%s) is not running", registryConfig.Type)
-		}
-
-		// Register the service with Registry
-		err = sdk.registryClient.Register()
-		if err != nil {
-			return fmt.Errorf("Could not register service with Registry: %v", err)
 		}
 
 		hasConfig, err := sdk.registryClient.HasConfiguration()
@@ -374,6 +370,11 @@ func (sdk *AppFunctionsSDK) initializeConfiguration() error {
 			fmt.Println("Configuration pushed to registry with service key: " + sdk.ServiceKey)
 		}
 
+		// Register the service with Registry
+		err = sdk.registryClient.Register()
+		if err != nil {
+			return fmt.Errorf("Could not register service with Registry: %v", err)
+		}
 	}
 
 	sdk.config = *configuration

--- a/internal/config/environment.go
+++ b/internal/config/environment.go
@@ -25,7 +25,8 @@ import (
 )
 
 const (
-	envKeyUrl = "edgex_registry"
+	envKeyRegistryUrl = "edgex_registry"
+	envKeyServiceUrl  = "edgex_service"
 )
 
 // environment is receiver that holds environment variables and encapsulates toml.Tree-based configuration field
@@ -57,7 +58,7 @@ func NewEnvironment() *environment {
 
 // OverrideRegistryInfoFromEnvironment method overrides registry location with environment variables.
 func (e *environment) OverrideRegistryInfoFromEnvironment(registry common.RegistryInfo) common.RegistryInfo {
-	if env := os.Getenv(envKeyUrl); env != "" {
+	if env := os.Getenv(envKeyRegistryUrl); env != "" {
 		if u, err := url.Parse(env); err == nil {
 			if p, err := strconv.ParseInt(u.Port(), 10, 0); err == nil {
 				registry.Port = int(p)
@@ -67,6 +68,20 @@ func (e *environment) OverrideRegistryInfoFromEnvironment(registry common.Regist
 		}
 	}
 	return registry
+}
+
+// OverrideServiceInfoFromEnvironment method overrides Service location with environment variables.
+func (e *environment) OverrideServiceInfoFromEnvironment(service common.ServiceInfo) common.ServiceInfo {
+	if env := os.Getenv(envKeyServiceUrl); env != "" {
+		if u, err := url.Parse(env); err == nil {
+			if p, err := strconv.ParseInt(u.Port(), 10, 0); err == nil {
+				service.Port = int(p)
+				service.Host = u.Hostname()
+				service.Protocol = u.Scheme
+			}
+		}
+	}
+	return service
 }
 
 // OverrideRegistryConfigFromEnvironment method replaces values in the toml.Tree for matching environment variable keys.

--- a/internal/config/environment_test.go
+++ b/internal/config/environment_test.go
@@ -103,9 +103,13 @@ func TestNonMatchingKeyDoesNotOverwritesValue(t *testing.T) {
 }
 
 const (
-	expectedTypeValue = "consul"
-	expectedHostValue = "localhost"
-	expectedPortValue = 8500
+	expectedRegistryTypeValue = "consul"
+	expectedRegistryHostValue = "localhost"
+	expectedRegistryPortValue = 8500
+
+	expectedServiceProtocolValue = "http"
+	expectedServiceHostValue     = "localhost"
+	expectedServicePortValue     = 8500
 
 	defaultHostValue = "defaultHost"
 	defaultPortValue = 987654321
@@ -123,13 +127,29 @@ func initializeTest(t *testing.T) common.RegistryInfo {
 
 func TestEnvVariableUpdatesRegistryInfo(t *testing.T) {
 	registryInfo := initializeTest(t)
-	sut := newSUT(t, map[string]string{envKeyUrl: expectedTypeValue + "://" + expectedHostValue + ":" + strconv.Itoa(expectedPortValue)})
+	sut := newSUT(t, map[string]string{envKeyRegistryUrl: expectedRegistryTypeValue + "://" + expectedRegistryHostValue + ":" + strconv.Itoa(expectedRegistryPortValue)})
 
 	registryInfo = sut.OverrideRegistryInfoFromEnvironment(registryInfo)
 
-	assert.Equal(t, registryInfo.Host, expectedHostValue)
-	assert.Equal(t, registryInfo.Port, expectedPortValue)
-	assert.Equal(t, registryInfo.Type, expectedTypeValue)
+	assert.Equal(t, registryInfo.Host, expectedRegistryHostValue)
+	assert.Equal(t, registryInfo.Port, expectedRegistryPortValue)
+	assert.Equal(t, registryInfo.Type, expectedRegistryTypeValue)
+}
+
+func TestEnvVariableUpdatesServiceInfo(t *testing.T) {
+	os.Clearenv()
+	serviceInfo := common.ServiceInfo{
+		Host:     defaultHostValue,
+		Port:     defaultPortValue,
+		Protocol: defaultTypeValue,
+	}
+	sut := newSUT(t, map[string]string{envKeyServiceUrl: expectedServiceProtocolValue + "://" + expectedServiceHostValue + ":" + strconv.Itoa(expectedServicePortValue)})
+
+	serviceInfo = sut.OverrideServiceInfoFromEnvironment(serviceInfo)
+
+	assert.Equal(t, serviceInfo.Host, expectedServiceHostValue)
+	assert.Equal(t, serviceInfo.Port, expectedServicePortValue)
+	assert.Equal(t, serviceInfo.Protocol, expectedServiceProtocolValue)
 }
 
 func TestNoEnvVariableDoesNotUpdateRegistryInfo(t *testing.T) {


### PR DESCRIPTION
Added special case environment variable override of the Service connection information before the service registers with the Registry.

close #172

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>