### PR TITLE
feat(configuration) : Add UseTargetTypeOfByteArray to Pipeline confguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,10 @@ Similar to other EdgeX services, configuration is first determined by the `confi
 
 The following items discuss topics that are a bit beyond the basic use cases of the Application Functions SDK when interacting with EdgeX.
 
+### Configurable Functions Pipeline
+
+This SDK provides the capability to define the functions pipeline via configuration rather than code using the **app-service-configurable** application service. See **app-service-configurable** [README](https://github.com/edgexfoundry/app-service-configurable/blob/master/README.md) for more details.
+
 ### Target Type
 
 The target type is the object type of the incoming data that is sent to the first function in the function pipeline. By default this is an EdgeX `Event` since typical usage is receiving `events` from Core Data via Message Bus. 

--- a/appsdk/sdk_test.go
+++ b/appsdk/sdk_test.go
@@ -207,3 +207,51 @@ func TestLoadConfigurablePipelineNumFunctions(t *testing.T) {
 	assert.NotNil(t, appFunctions, "expected app functions list to be set")
 	assert.Equal(t, 3, len(appFunctions))
 }
+
+func TestUseTargetTypeOfByteArrayTrue(t *testing.T) {
+	functions := make(map[string]common.PipelineFunction)
+	functions["CompressWithGZIP"] = common.PipelineFunction{}
+	functions["SetOutputData"] = common.PipelineFunction{}
+
+	sdk := AppFunctionsSDK{
+		LoggingClient: lc,
+		config: common.ConfigurationStruct{
+			Writable: common.WritableInfo{
+				Pipeline: common.PipelineInfo{
+					ExecutionOrder:           "CompressWithGZIP, SetOutputData",
+					UseTargetTypeOfByteArray: true,
+					Functions:                functions,
+				},
+			},
+		},
+	}
+
+	_, err := sdk.LoadConfigurablePipeline()
+	assert.NoError(t, err, "")
+	assert.NotNil(t, sdk.TargetType)
+	assert.Equal(t, reflect.Ptr, reflect.TypeOf(sdk.TargetType).Kind())
+	assert.Equal(t, reflect.TypeOf([]byte{}).Kind(), reflect.TypeOf(sdk.TargetType).Elem().Kind())
+}
+
+func TestUseTargetTypeOfByteArrayFalse(t *testing.T) {
+	functions := make(map[string]common.PipelineFunction)
+	functions["CompressWithGZIP"] = common.PipelineFunction{}
+	functions["SetOutputData"] = common.PipelineFunction{}
+
+	sdk := AppFunctionsSDK{
+		LoggingClient: lc,
+		config: common.ConfigurationStruct{
+			Writable: common.WritableInfo{
+				Pipeline: common.PipelineInfo{
+					ExecutionOrder:           "CompressWithGZIP, SetOutputData",
+					UseTargetTypeOfByteArray: false,
+					Functions:                functions,
+				},
+			},
+		},
+	}
+
+	_, err := sdk.LoadConfigurablePipeline()
+	assert.NoError(t, err, "")
+	assert.Nil(t, sdk.TargetType)
+}

--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -91,8 +91,9 @@ type BindingInfo struct {
 }
 
 type PipelineInfo struct {
-	ExecutionOrder string
-	Functions      map[string]PipelineFunction
+	ExecutionOrder           string
+	UseTargetTypeOfByteArray bool
+	Functions                map[string]PipelineFunction
 }
 
 type PipelineFunction struct {

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -81,7 +81,7 @@ func TestConfigureAndConfigRoute(t *testing.T) {
 	rr := httptest.NewRecorder()
 	webserver.router.ServeHTTP(rr, req)
 
-	expected := `{"Writable":{"LogLevel":"","Pipeline":{"ExecutionOrder":"","Functions":null}},"Logging":{"EnableRemote":false,"File":""},"Registry":{"Host":"","Port":0,"Type":""},"Service":{"BootTimeout":0,"CheckInterval":"","ClientMonitor":0,"Host":"","Port":0,"Protocol":"","StartupMsg":"","ReadMaxLimit":0,"Timeout":0},"MessageBus":{"PublishHost":{"Host":"","Port":0,"Protocol":""},"SubscribeHost":{"Host":"","Port":0,"Protocol":""},"Type":"","Optional":null},"Binding":{"Type":"","Name":"","SubscribeTopic":"","PublishTopic":""},"ApplicationSettings":null,"Clients":null}` + "\n"
+	expected := `{"Writable":{"LogLevel":"","Pipeline":{"ExecutionOrder":"","UseTargetTypeOfByteArray":false,"Functions":null}},"Logging":{"EnableRemote":false,"File":""},"Registry":{"Host":"","Port":0,"Type":""},"Service":{"BootTimeout":0,"CheckInterval":"","ClientMonitor":0,"Host":"","Port":0,"Protocol":"","StartupMsg":"","ReadMaxLimit":0,"Timeout":0},"MessageBus":{"PublishHost":{"Host":"","Port":0,"Protocol":""},"SubscribeHost":{"Host":"","Port":0,"Protocol":""},"Type":"","Optional":null},"Binding":{"Type":"","Name":"","SubscribeTopic":"","PublishTopic":""},"ApplicationSettings":null,"Clients":null}` + "\n"
 	body := rr.Body.String()
 	assert.Equal(t, expected, body)
 }


### PR DESCRIPTION
With the addition of the UseTargetTypeOfByteArray boolean setting the functions pipeline can be configured to accept a byte array as input to the first function in the pipeline. This is instead of the default EdgeX Event object. Having this setting in the Writable Pipeline section allows it to be changed appropriately to match the first function in the pipeline as it is changed.

closes #177

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>