### PR TITLE
fix(configuration): Check Interval is now respected

### DIFF
--- a/appsdk/sdk.go
+++ b/appsdk/sdk.go
@@ -319,7 +319,7 @@ func (sdk *AppFunctionsSDK) initializeConfiguration() error {
 			Port:          configuration.Registry.Port,
 			Type:          configuration.Registry.Type,
 			Stem:          internal.ConfigRegistryStem,
-			CheckInterval: "1s",
+			CheckInterval: configuration.Service.CheckInterval,
 			CheckRoute:    internal.ApiPingRoute,
 			ServiceKey:    sdk.ServiceKey,
 			ServiceHost:   configuration.Service.Host,


### PR DESCRIPTION
Check interval was previously hardcoded to 1s. It is now determined by configuration.

closes #182

Signed-off-by: Mike Johanson <michael.johanson@intel.com>