### PR TITLE
fix(trigger): Return error to HTTP trigger response

### DIFF
--- a/internal/trigger/messagebus/messaging.go
+++ b/internal/trigger/messagebus/messaging.go
@@ -69,7 +69,13 @@ func (trigger *Trigger) Initialize(logger logger.LoggingClient) error {
 						CorrelationID: msgs.CorrelationID,
 						EventClient:   trigger.EventClient,
 					}
-					trigger.Runtime.ProcessEvent(edgexContext, msgs)
+
+					messageError := trigger.Runtime.ProcessMessage(edgexContext, msgs)
+					if messageError != nil {
+						// ProcessMessage logs the error, so no need to log it here.
+						return
+					}
+
 					if edgexContext.OutputData != nil {
 						outputEnvelope := types.MessageEnvelope{
 							CorrelationID: edgexContext.CorrelationID,

--- a/internal/trigger/messagebus/messaging_test.go
+++ b/internal/trigger/messagebus/messaging_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/edgexfoundry/go-mod-messaging/messaging"
 	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
-
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Any error during message processing or from pipeline functions should cause an error response from the HTTP trigger.

closes #174