### PR TITLE
fix(TargetType): Make copy of target type before using it.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.14
 	github.com/edgexfoundry/go-mod-messaging v0.1.11
-	github.com/edgexfoundry/go-mod-registry v0.1.0
+	github.com/edgexfoundry/go-mod-registry v0.1.11
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gorilla/mux v1.7.2
 	github.com/pelletier/go-toml v1.2.0

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -53,13 +53,15 @@ func (gr *GolangRuntime) ProcessMessage(edgexcontext *appcontext.Context, envelo
 	if gr.TargetType == nil {
 		gr.TargetType = &models.Event{}
 	}
-	target := gr.TargetType
 
-	if reflect.TypeOf(target).Kind() != reflect.Ptr {
+	if reflect.TypeOf(gr.TargetType).Kind() != reflect.Ptr {
 		err := fmt.Errorf("TargetType must be a pointer, not a value of the target type.")
 		edgexcontext.LoggingClient.Error(err.Error())
 		return &MessageError{Err: err, ErrorCode: http.StatusInternalServerError}
 	}
+
+	// Must make a copy of the type so that data isn't retained between calls.
+	target := reflect.New(reflect.ValueOf(gr.TargetType).Elem().Type()).Interface()
 
 	// Only set when the data is binary so function receiving it knows how to deal with it.
 	var contentType string


### PR DESCRIPTION
Must make a copy of the target type so that data isn't retained between calls.

closes #189
