### PR TITLE
feat(Context): Add useful edgex clients to expose them for pipeline functions and internal use

### DIFF
--- a/appcontext/context_test.go
+++ b/appcontext/context_test.go
@@ -52,9 +52,20 @@ func init() {
 	eventClient = coredata.NewEventClient(params, startup.Endpoint{RegistryClient: nil})
 	lc = logger.NewClient("app_functions_sdk_go", false, "./test.log", "DEBUG")
 }
-func TestMarkAsPushedNoEventIdOrChecksum(t *testing.T) {
+func TestMarkAsPushedNoClient(t *testing.T) {
 	ctx := Context{
 		LoggingClient: lc,
+	}
+	err := ctx.MarkAsPushed()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "'CoreData' is missing from Clients")
+}
+
+func TestMarkAsPushedNoEventIdOrChecksum(t *testing.T) {
+	eventClient = coredata.NewEventClient(params, mockEventEndpoint{})
+	ctx := Context{
+		LoggingClient: lc,
+		EventClient:   eventClient,
 	}
 	err := ctx.MarkAsPushed()
 	assert.NotNil(t, err)
@@ -79,6 +90,7 @@ func TestMarkAsPushedNoChecksum(t *testing.T) {
 	defer ts.Close()
 	params.Url = ts.URL + clients.ApiEventRoute
 	eventClient = coredata.NewEventClient(params, mockEventEndpoint{})
+
 	ctx := Context{
 		EventChecksum: testChecksum,
 		CorrelationID: "correlationId",

--- a/appsdk/sdk_test.go
+++ b/appsdk/sdk_test.go
@@ -255,3 +255,44 @@ func TestUseTargetTypeOfByteArrayFalse(t *testing.T) {
 	assert.NoError(t, err, "")
 	assert.Nil(t, sdk.TargetType)
 }
+
+func TestInitializeClientsAll(t *testing.T) {
+	clients := make(map[string]common.ClientInfo)
+	clients[common.CoreDataClientName] = common.ClientInfo{}
+	clients[common.NotificationsClientName] = common.ClientInfo{}
+	clients[common.CoreCommandClientName] = common.ClientInfo{}
+
+	sdk := AppFunctionsSDK{
+		LoggingClient: lc,
+		config: common.ConfigurationStruct{
+			Clients: clients,
+		},
+	}
+
+	sdk.initializeClients()
+
+	assert.NotNil(t, sdk.edgexClients.EventClient)
+	assert.NotNil(t, sdk.edgexClients.CommandClient)
+	assert.NotNil(t, sdk.edgexClients.ValueDescriptorClient)
+	assert.NotNil(t, sdk.edgexClients.NotificationsClient)
+}
+
+func TestInitializeClientsJustData(t *testing.T) {
+	clients := make(map[string]common.ClientInfo)
+	clients[common.CoreDataClientName] = common.ClientInfo{}
+
+	sdk := AppFunctionsSDK{
+		LoggingClient: lc,
+		config: common.ConfigurationStruct{
+			Clients: clients,
+		},
+	}
+
+	sdk.initializeClients()
+
+	assert.NotNil(t, sdk.edgexClients.EventClient)
+	assert.NotNil(t, sdk.edgexClients.ValueDescriptorClient)
+
+	assert.Nil(t, sdk.edgexClients.CommandClient)
+	assert.Nil(t, sdk.edgexClients.NotificationsClient)
+}

--- a/internal/common/clients.go
+++ b/internal/common/clients.go
@@ -1,0 +1,39 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package common
+
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/command"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/notifications"
+)
+
+const (
+	LoggingClientName       = "Logging"
+	CoreCommandClientName   = "Command"
+	CoreDataClientName      = "CoreData"
+	NotificationsClientName = "Notifications"
+)
+
+type EdgeXClients struct {
+	LoggingClient         logger.LoggingClient
+	EventClient           coredata.EventClient
+	CommandClient         command.CommandClient
+	ValueDescriptorClient coredata.ValueDescriptorClient
+	NotificationsClient   notifications.NotificationsClient
+}

--- a/internal/trigger/messagebus/messaging_test.go
+++ b/internal/trigger/messagebus/messaging_test.go
@@ -63,8 +63,8 @@ func TestInitialize(t *testing.T) {
 
 	runtime := &runtime.GolangRuntime{}
 
-	trigger := Trigger{Configuration: config, Runtime: runtime}
-	trigger.Initialize(logClient)
+	trigger := Trigger{Configuration: config, Runtime: runtime, EdgeXClients: common.EdgeXClients{LoggingClient: logClient}}
+	trigger.Initialize()
 	assert.NotNil(t, trigger.client, "Expected client to be set")
 	assert.Equal(t, 1, len(trigger.topics))
 	assert.Equal(t, "events", trigger.topics[0].Topic)
@@ -97,8 +97,8 @@ func TestInitializeBadConfiguration(t *testing.T) {
 
 	runtime := &runtime.GolangRuntime{}
 
-	trigger := Trigger{Configuration: config, Runtime: runtime}
-	err := trigger.Initialize(logClient)
+	trigger := Trigger{Configuration: config, Runtime: runtime, EdgeXClients: common.EdgeXClients{LoggingClient: logClient}}
+	err := trigger.Initialize()
 	assert.NotNil(t, err)
 }
 
@@ -141,8 +141,8 @@ func TestInitializeAndProcessEventWithNoOutput(t *testing.T) {
 
 	runtime := &runtime.GolangRuntime{}
 	runtime.SetTransforms([]appcontext.AppFunction{transform1})
-	trigger := Trigger{Configuration: config, Runtime: runtime}
-	trigger.Initialize(logClient)
+	trigger := Trigger{Configuration: config, Runtime: runtime, EdgeXClients: common.EdgeXClients{LoggingClient: logClient}}
+	trigger.Initialize()
 
 	message := types.MessageEnvelope{
 		CorrelationID: expectedCorrelationID,
@@ -216,7 +216,7 @@ func TestInitializeAndProcessEventWithOutput(t *testing.T) {
 
 	runtime := &runtime.GolangRuntime{}
 	runtime.SetTransforms([]appcontext.AppFunction{transform1})
-	trigger := Trigger{Configuration: config, Runtime: runtime}
+	trigger := Trigger{Configuration: config, Runtime: runtime, EdgeXClients: common.EdgeXClients{LoggingClient: logClient}}
 
 	testClientConfig := types.MessageBusConfig{
 		SubscribeHost: types.HostInfo{
@@ -241,7 +241,7 @@ func TestInitializeAndProcessEventWithOutput(t *testing.T) {
 
 	testClient.Subscribe(testTopics, testMessageErrors) //subscribe in order to receive transformed output to the bus
 
-	trigger.Initialize(logClient)
+	trigger.Initialize()
 
 	message := types.MessageEnvelope{
 		CorrelationID: expectedCorrelationID,

--- a/internal/trigger/trigger.go
+++ b/internal/trigger/trigger.go
@@ -16,12 +16,8 @@
 
 package trigger
 
-import (
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-)
-
 // Trigger interface is used to hold event data and allow function to
 type Trigger interface {
 	// Initialize performs post creation initializations
-	Initialize(logger.LoggingClient) error
+	Initialize() error
 }


### PR DESCRIPTION
Add ValueDescriptorClient, CommandClient and NotificationsClient to context for functions to use.

EventClient already exist on the context.

closes #124