### PR TITLE
feat(StoreAndFoward): Add core implementation for store and Forward

### DIFF
--- a/appsdk/sdk.go
+++ b/appsdk/sdk.go
@@ -17,7 +17,7 @@
 package appsdk
 
 import (
-	syscontext "context"
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -37,6 +37,8 @@ import (
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/common"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/config"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/runtime"
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/store"
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/store/db/interfaces"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/telemetry"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/trigger"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/trigger/http"
@@ -51,7 +53,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/notifications"
 	coreTypes "github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
-	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
+	"github.com/edgexfoundry/go-mod-registry/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
@@ -91,6 +93,10 @@ type AppFunctionsSDK struct {
 	edgexClients              common.EdgeXClients
 	registryClient            registry.Client
 	config                    common.ConfigurationStruct
+	storeClient               interfaces.StoreClient
+	storeForwardCancelCtx     context.CancelFunc
+	appCtx                    context.Context
+	appCancelCtx              context.CancelFunc
 }
 
 // AddRoute allows you to leverage the existing webserver to add routes.
@@ -105,12 +111,6 @@ func (sdk *AppFunctionsSDK) AddRoute(route string, handler func(nethttp.Response
 	sdk.webserver.AddRoute(route, sdk.addContext(handler), methods...)
 	return nil
 }
-func (sdk *AppFunctionsSDK) addContext(next func(nethttp.ResponseWriter, *nethttp.Request)) func(nethttp.ResponseWriter, *nethttp.Request) {
-	return nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
-		ctx := syscontext.WithValue(r.Context(), SDKKey, sdk)
-		next(w, r.WithContext(ctx))
-	})
-}
 
 // MakeItRun will initialize and start the trigger as specifed in the
 // configuration. It will also configure the webserver and start listening on
@@ -119,16 +119,27 @@ func (sdk *AppFunctionsSDK) MakeItRun() error {
 	httpErrors := make(chan error)
 	defer close(httpErrors)
 
-	sdk.runtime = &runtime.GolangRuntime{TargetType: sdk.TargetType} //Transforms: sdk.transforms
+	sdk.runtime = &runtime.GolangRuntime{
+		TargetType: sdk.TargetType,
+		ServiceKey: sdk.ServiceKey,
+	}
+
+	sdk.runtime.Initialize(sdk.storeClient)
 	sdk.runtime.SetTransforms(sdk.transforms)
 
 	// determine input type and create trigger for it
 	trigger := sdk.setupTrigger(sdk.config, sdk.runtime)
 
 	// Initialize the trigger (i.e. start a web server, or connect to message bus)
-	err := trigger.Initialize()
+	err := trigger.Initialize(sdk.appCtx)
 	if err != nil {
 		sdk.LoggingClient.Error(err.Error())
+	}
+
+	if sdk.config.Writable.StoreAndForward.Enabled {
+		sdk.startStoreForward()
+	} else {
+		sdk.LoggingClient.Info("StoreAndForward disabled. Not running retry loop.")
 	}
 
 	sdk.LoggingClient.Info(sdk.config.Service.StartupMsg)
@@ -141,14 +152,14 @@ func (sdk *AppFunctionsSDK) MakeItRun() error {
 	select {
 	case httpError := <-sdk.httpErrors:
 		sdk.LoggingClient.Info("Terminating: ", httpError.Error())
-		return httpError
+		err = httpError
 
 	case signalReceived := <-signals:
 		sdk.LoggingClient.Info("Terminating: " + signalReceived.String())
-
 	}
 
-	return nil
+	sdk.appCancelCtx() // Cancel all long running go funcs
+	return err
 }
 
 // LoadConfigurablePipeline ...
@@ -243,23 +254,6 @@ func (sdk *AppFunctionsSDK) ApplicationSettings() map[string]string {
 	return sdk.config.ApplicationSettings
 }
 
-// setupTrigger configures the appropriate trigger as specified by configuration.
-func (sdk *AppFunctionsSDK) setupTrigger(configuration common.ConfigurationStruct, runtime *runtime.GolangRuntime) trigger.Trigger {
-	var trigger trigger.Trigger
-	// Need to make dynamic, search for the binding that is input
-
-	switch strings.ToUpper(configuration.Binding.Type) {
-	case "HTTP":
-		sdk.LoggingClient.Info("HTTP trigger selected")
-		trigger = &http.Trigger{Configuration: configuration, Runtime: runtime, Webserver: sdk.webserver, EdgeXClients: sdk.edgexClients}
-	case "MESSAGEBUS":
-		sdk.LoggingClient.Info("MessageBus trigger selected")
-		trigger = &messagebus.Trigger{Configuration: configuration, Runtime: runtime, EdgeXClients: sdk.edgexClients}
-	}
-
-	return trigger
-}
-
 // Initialize will parse command line flags, register for interrupts,
 // initialize the logging system, and ingest configuration.
 func (sdk *AppFunctionsSDK) Initialize() error {
@@ -291,7 +285,9 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 		}
 	}
 
+	clientsInitialized := false
 	loggerInitialized := false
+	databaseInitialized := false
 	configurationInitialized := false
 	bootstrapComplete := false
 
@@ -316,13 +312,29 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 			}
 
 			sdk.LoggingClient = logger.NewClient(sdk.ServiceKey, sdk.config.Logging.EnableRemote, loggingTarget, sdk.config.Writable.LogLevel)
-			sdk.LoggingClient.Info("Configuration and logger successfully initialized")
+			sdk.LoggingClient.Info("Logger successfully initialized")
 			sdk.edgexClients.LoggingClient = sdk.LoggingClient
 			loggerInitialized = true
 		}
 
-		sdk.initializeClients()
-		sdk.LoggingClient.Info("Clients initialized")
+		// Currently only need the database if store and forward is enabled
+		if sdk.config.Writable.StoreAndForward.Enabled {
+			if !databaseInitialized {
+				if sdk.createStoreClient() != nil {
+					// Error already logged
+					goto ContinueWithSleep
+				}
+			}
+
+			databaseInitialized = true
+		}
+
+		if !clientsInitialized {
+			sdk.initializeClients()
+			sdk.LoggingClient.Info("Clients initialized")
+		}
+
+		// This is the last dependency so can break out of the retry loop.
 		bootstrapComplete = true
 		break
 
@@ -334,11 +346,11 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 		return fmt.Errorf("bootstrap retry timed out")
 	}
 
+	sdk.appCtx, sdk.appCancelCtx = context.WithCancel(context.Background())
+
 	if sdk.useRegistry {
 		go sdk.listenForConfigChanges()
 	}
-
-	sdk.initializeClients()
 
 	go telemetry.StartCpuUsageAverage()
 
@@ -346,6 +358,40 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 	sdk.webserver.ConfigureStandardRoutes()
 
 	return nil
+}
+
+func (sdk *AppFunctionsSDK) createStoreClient() error {
+	var err error
+	sdk.storeClient, err = store.NewStoreClient(sdk.config.Database)
+	if err != nil {
+		sdk.LoggingClient.Error(fmt.Sprintf("unable to initialize Database for Store and Forward: %s", err.Error()))
+	}
+
+	return err
+}
+
+// setupTrigger configures the appropriate trigger as specified by configuration.
+func (sdk *AppFunctionsSDK) setupTrigger(configuration common.ConfigurationStruct, runtime *runtime.GolangRuntime) trigger.Trigger {
+	var trigger trigger.Trigger
+	// Need to make dynamic, search for the binding that is input
+
+	switch strings.ToUpper(configuration.Binding.Type) {
+	case "HTTP":
+		sdk.LoggingClient.Info("HTTP trigger selected")
+		trigger = &http.Trigger{Configuration: configuration, Runtime: runtime, Webserver: sdk.webserver, EdgeXClients: sdk.edgexClients}
+	case "MESSAGEBUS":
+		sdk.LoggingClient.Info("MessageBus trigger selected")
+		trigger = &messagebus.Trigger{Configuration: configuration, Runtime: runtime, EdgeXClients: sdk.edgexClients}
+	}
+
+	return trigger
+}
+
+func (sdk *AppFunctionsSDK) addContext(next func(nethttp.ResponseWriter, *nethttp.Request)) func(nethttp.ResponseWriter, *nethttp.Request) {
+	return nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		ctx := context.WithValue(r.Context(), SDKKey, sdk)
+		next(w, r.WithContext(ctx))
+	})
 }
 
 func (sdk *AppFunctionsSDK) initializeClients() {
@@ -396,7 +442,7 @@ func (sdk *AppFunctionsSDK) initializeConfiguration() error {
 		configuration.Registry = e.OverrideRegistryInfoFromEnvironment(configuration.Registry)
 		configuration.Service = e.OverrideServiceInfoFromEnvironment(configuration.Service)
 
-		registryConfig := registryTypes.Config{
+		registryConfig := types.Config{
 			Host:            configuration.Registry.Host,
 			Port:            configuration.Registry.Port,
 			Type:            configuration.Registry.Type,
@@ -489,6 +535,9 @@ func (sdk *AppFunctionsSDK) listenForConfigChanges() {
 
 	for {
 		select {
+		case <-sdk.appCtx.Done():
+			return
+
 		case err := <-registryErrors:
 			sdk.LoggingClient.Error(err.Error())
 
@@ -505,35 +554,95 @@ func (sdk *AppFunctionsSDK) listenForConfigChanges() {
 			}
 
 			previousLogLevel := sdk.config.Writable.LogLevel
+			previousStoreForward := sdk.config.Writable.StoreAndForward
 
 			sdk.config.Writable = *actual
-			sdk.LoggingClient.SetLogLevel(sdk.config.Writable.LogLevel)
 			sdk.LoggingClient.Info("Writable configuration has been updated from Registry")
 
-			if previousLogLevel != sdk.config.Writable.LogLevel {
-				// Log level changed, not Pipeline, so skip updating the pipeline
-				continue
-			}
+			// Note: Changes occur one setting at a time so if setting not part of the pipeline,
+			//       then skip updating the pipeline
+			switch {
+			case previousLogLevel != sdk.config.Writable.LogLevel:
+				sdk.LoggingClient.SetLogLevel(sdk.config.Writable.LogLevel)
+				sdk.LoggingClient.Info(fmt.Sprintf("Logging level changed to %s", sdk.config.Writable.LogLevel))
 
-			if sdk.usingConfigurablePipeline {
-				transforms, err := sdk.LoadConfigurablePipeline()
-				if err != nil {
-					sdk.LoggingClient.Error("unable to reload Configurable Pipeline from Registry: " + err.Error())
-					continue
+			case previousStoreForward.MaxRetryCount != sdk.config.Writable.StoreAndForward.MaxRetryCount:
+				if sdk.config.Writable.StoreAndForward.MaxRetryCount < 0 {
+					sdk.LoggingClient.Info(fmt.Sprintf("StoreAndForward MaxRetryCount can not be less than 0, defaulting to 1"))
+					sdk.config.Writable.StoreAndForward.MaxRetryCount = 1
 				}
-				err = sdk.SetFunctionsPipeline(transforms...)
-				if err != nil {
-					sdk.LoggingClient.Error("unable to set Configurable Pipeline from Registry: " + err.Error())
-					continue
-				}
+				sdk.LoggingClient.Info(fmt.Sprintf("StoreAndForward MaxRetryCount changed to %d", sdk.config.Writable.StoreAndForward.MaxRetryCount))
 
-				sdk.LoggingClient.Info("ReLoaded Configurable Pipeline from Registry")
+			case previousStoreForward.RetryInterval != sdk.config.Writable.StoreAndForward.RetryInterval:
+				sdk.processConfigChangedStoreForwardRetryInterval()
+
+			case previousStoreForward.Enabled != sdk.config.Writable.StoreAndForward.Enabled:
+				sdk.processConfigChangedStoreForwardEnabled(previousStoreForward)
+
+			default:
+				// Must have been a change to the pipeline configuration, so now attempt to update it.
+				sdk.processConfigChangedPipeline()
 			}
-
-			// TODO: Deal with pub/sub topics may have changed. Save copy of writeable so that we can determine what if anything changed?
 		}
 	}
+}
 
+func (sdk *AppFunctionsSDK) processConfigChangedStoreForwardRetryInterval() {
+	if sdk.config.Writable.StoreAndForward.Enabled {
+		sdk.stopStoreForward()
+		time.Sleep(time.Microsecond * 10)
+		sdk.startStoreForward()
+	}
+}
+
+func (sdk *AppFunctionsSDK) processConfigChangedStoreForwardEnabled(previousStoreForward common.StoreAndForwardInfo) {
+	if sdk.config.Writable.StoreAndForward.Enabled {
+		// StoreClient must be set up for StoreAndForward
+		if sdk.storeClient == nil {
+			if sdk.createStoreClient() != nil {
+				// Error already logged
+				sdk.config.Writable.StoreAndForward.Enabled = false
+				return
+			}
+
+			sdk.runtime.Initialize(sdk.storeClient)
+		}
+
+		sdk.startStoreForward()
+	} else {
+		sdk.stopStoreForward()
+	}
+}
+
+func (sdk *AppFunctionsSDK) processConfigChangedPipeline() {
+	if sdk.usingConfigurablePipeline {
+		transforms, err := sdk.LoadConfigurablePipeline()
+		if err != nil {
+			sdk.LoggingClient.Error("unable to reload Configurable Pipeline from Registry: " + err.Error())
+			return
+		}
+		err = sdk.SetFunctionsPipeline(transforms...)
+		if err != nil {
+			sdk.LoggingClient.Error("unable to set Configurable Pipeline from Registry: " + err.Error())
+			return
+		}
+
+		sdk.LoggingClient.Info("Reloaded Configurable Pipeline from Registry")
+	}
+}
+
+func (sdk *AppFunctionsSDK) startStoreForward() {
+	var storeForwardEnabledCtx context.Context
+	storeForwardEnabledCtx, sdk.storeForwardCancelCtx = context.WithCancel(context.Background())
+	sdk.runtime.StartStoreAndForward(sdk.appCtx, storeForwardEnabledCtx, sdk.ServiceKey, &sdk.config, sdk.edgexClients)
+}
+
+func (sdk *AppFunctionsSDK) stopStoreForward() {
+	// Use the CTX to signal to cancel the retry loop
+	if sdk.storeForwardCancelCtx != nil {
+		sdk.LoggingClient.Info("StoreAndForward disabled. Canceling retry loop")
+		sdk.storeForwardCancelCtx()
+	}
 }
 
 func (sdk *AppFunctionsSDK) setLoggingTarget() (string, error) {

--- a/appsdk/sdk_test.go
+++ b/appsdk/sdk_test.go
@@ -17,9 +17,13 @@
 package appsdk
 
 import (
+	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/common"
@@ -27,18 +31,24 @@ import (
 	triggerHttp "github.com/edgexfoundry/app-functions-sdk-go/internal/trigger/http"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/trigger/messagebus"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/webserver"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
-	"github.com/gorilla/mux"
-	"github.com/stretchr/testify/assert"
 )
 
 var lc logger.LoggingClient
-var context *appcontext.Context
+var params types.EndpointParams
 
 func init() {
 	lc = logger.NewClient("app_functions_sdk_go", false, "./test.log", "DEBUG")
-
+	params = types.EndpointParams{
+		ServiceKey:  clients.SupportSchedulerServiceKey,
+		Path:        clients.ApiIntervalActionRoute,
+		UseRegistry: false,
+		Url:         "http://test" + clients.ApiIntervalActionRoute,
+		Interval:    clients.ClientMonitorDefault,
+	}
 }
 
 func IsInstanceOf(objectPtr, typePtr interface{}) bool {
@@ -73,6 +83,7 @@ func TestSetupHTTPTrigger(t *testing.T) {
 		},
 	}
 	runtime := &runtime.GolangRuntime{}
+	runtime.Initialize(nil)
 	runtime.SetTransforms(sdk.transforms)
 	trigger := sdk.setupTrigger(sdk.config, runtime)
 	result := IsInstanceOf(trigger, (*triggerHttp.Trigger)(nil))
@@ -88,6 +99,7 @@ func TestSetupMessageBusTrigger(t *testing.T) {
 		},
 	}
 	runtime := &runtime.GolangRuntime{}
+	runtime.Initialize(nil)
 	runtime.SetTransforms(sdk.transforms)
 	trigger := sdk.setupTrigger(sdk.config, runtime)
 	result := IsInstanceOf(trigger, (*messagebus.Trigger)(nil))
@@ -120,6 +132,7 @@ func TestSetFunctionsPipelineOneTransform(t *testing.T) {
 		return true, nil
 	}
 
+	sdk.runtime.Initialize(nil)
 	err := sdk.SetFunctionsPipeline(function)
 	assert.Nil(t, err, "There should be no error")
 	assert.Equal(t, 1, len(sdk.transforms))
@@ -382,4 +395,18 @@ func TestInitializeClientsJustData(t *testing.T) {
 
 	assert.Nil(t, sdk.edgexClients.CommandClient)
 	assert.Nil(t, sdk.edgexClients.NotificationsClient)
+}
+
+type mockEventEndpoint struct {
+}
+
+func (e mockEventEndpoint) Monitor(params types.EndpointParams, ch chan string) {
+	switch params.ServiceKey {
+	case clients.SupportSchedulerServiceKey:
+		url := fmt.Sprintf("http://%s:%v%s", "localhost", 48080, params.Path)
+		ch <- url
+		break
+	default:
+		ch <- ""
+	}
 }

--- a/examples/advanced-filter-convert-publish/main.go
+++ b/examples/advanced-filter-convert-publish/main.go
@@ -21,10 +21,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/edgexfoundry/app-functions-sdk-go/pkg/transforms"
-
 	"github.com/edgexfoundry/app-functions-sdk-go/appsdk"
 	"github.com/edgexfoundry/app-functions-sdk-go/examples/advanced-filter-convert-publish/functions"
+	"github.com/edgexfoundry/app-functions-sdk-go/pkg/transforms"
 )
 
 const (

--- a/examples/advanced-filter-convert-publish/res/configuration.toml
+++ b/examples/advanced-filter-convert-publish/res/configuration.toml
@@ -63,6 +63,11 @@ Type="messagebus"
 SubscribeTopic="events"
 PublishTopic="converted"
 
+[StoreAndForward]
+Enabled = false
+RetryInterval = 50000 # 5mins
+MaxRetryCount = 10
+
 [ApplicationSettings]
 ApplicationName = "advanced-filter-convert-publish"
 ValueDescriptors = "RandomValue_Float32, RandomValue_Float64"

--- a/examples/simple-cbor-filter/main.go
+++ b/examples/simple-cbor-filter/main.go
@@ -26,12 +26,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/edgexfoundry/app-functions-sdk-go/pkg/transforms"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/models"
-
 	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
 	"github.com/edgexfoundry/app-functions-sdk-go/appsdk"
+	"github.com/edgexfoundry/app-functions-sdk-go/pkg/transforms"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 const (

--- a/examples/simple-filter-xml-mqtt/main.go
+++ b/examples/simple-filter-xml-mqtt/main.go
@@ -20,10 +20,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/edgexfoundry/app-functions-sdk-go/pkg/transforms"
-
 	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
 	"github.com/edgexfoundry/app-functions-sdk-go/appsdk"
+	"github.com/edgexfoundry/app-functions-sdk-go/pkg/transforms"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 

--- a/examples/simple-filter-xml-post/main.go
+++ b/examples/simple-filter-xml-post/main.go
@@ -20,9 +20,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/edgexfoundry/app-functions-sdk-go/pkg/transforms"
-
 	"github.com/edgexfoundry/app-functions-sdk-go/appsdk"
+	"github.com/edgexfoundry/app-functions-sdk-go/pkg/transforms"
 )
 
 const (

--- a/examples/simple-filter-xml-post/res/configuration.toml
+++ b/examples/simple-filter-xml-post/res/configuration.toml
@@ -44,12 +44,6 @@ File = './logs/simple-filter-xml-post.log'
   Host = "localhost"
   Port = 48061
 
-  # Required when using Store and Forward
-  [Clients.Scheduler]
-  Protocol = 'http'
-  Host = 'localhost'
-  Port = 48085
-
 [MessageBus]
 Type = 'zero'
     [MessageBus.PublishHost]

--- a/internal/runtime/storeforward.go
+++ b/internal/runtime/storeforward.go
@@ -1,0 +1,188 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"runtime"
+	"time"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/common"
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/store/contracts"
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/store/db/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+)
+
+const (
+	DefaultMinRetryInterval = 5000 // 5 secs
+)
+
+type storeForwardInfo struct {
+	runtime      *GolangRuntime
+	storeClient  interfaces.StoreClient
+	pipelineHash string
+}
+
+func (sf *storeForwardInfo) startStoreAndForwardRetryLoop(appCtx context.Context, enabledCtx context.Context, serviceKey string, config *common.ConfigurationStruct, edgeXClients common.EdgeXClients) {
+
+	go func() {
+
+		retryInterval := config.Writable.StoreAndForward.RetryInterval
+		if retryInterval < DefaultMinRetryInterval {
+			retryInterval = DefaultMinRetryInterval
+		}
+
+		if config.Writable.StoreAndForward.MaxRetryCount < 0 {
+			edgeXClients.LoggingClient.Info(fmt.Sprintf("StoreAndForward MaxRetryCount can not be less than 0, defaulting to 1"))
+			config.Writable.StoreAndForward.MaxRetryCount = 1
+		}
+
+		edgeXClients.LoggingClient.Info(fmt.Sprintf("Starting StoreAndForward Retry Loop with %d RetryInterval and %d max retries", retryInterval, config.Writable.StoreAndForward.MaxRetryCount))
+
+	exit:
+		for {
+			select {
+
+			case <-appCtx.Done():
+				// Exit the loop and function when application service is terminating.
+				break exit
+
+			case <-enabledCtx.Done():
+				// Exit the loop and function when Store and Forward has been disabled.
+				break exit
+
+			case <-time.After(time.Millisecond * time.Duration(retryInterval)):
+				sf.retryStoredData(serviceKey, config, edgeXClients)
+			}
+		}
+
+		edgeXClients.LoggingClient.Info("StoreAndForward Retry Loop exited")
+	}()
+}
+
+func (sf *storeForwardInfo) storeForLaterRetry(payload []byte, edgexcontext *appcontext.Context, pipelinePosition int) {
+	item := contracts.NewStoredObject(sf.runtime.ServiceKey, payload, pipelinePosition, sf.pipelineHash)
+	item.CorrelationID = edgexcontext.CorrelationID
+	item.EventID = edgexcontext.EventID
+	item.EventChecksum = edgexcontext.EventChecksum
+
+	edgexcontext.LoggingClient.Trace("Storing data for later retry", clients.CorrelationHeader, edgexcontext.CorrelationID)
+
+	if !edgexcontext.Configuration.Writable.StoreAndForward.Enabled {
+		edgexcontext.LoggingClient.Error("Failed to store item for later retry", "error", "StoreAndForward not enabled", clients.CorrelationHeader, item.CorrelationID)
+		return
+	}
+
+	if _, err := sf.storeClient.Store(item); err != nil {
+		edgexcontext.LoggingClient.Error("Failed to store item for later retry", "error", err, clients.CorrelationHeader, item.CorrelationID)
+	}
+}
+
+func (sf *storeForwardInfo) retryStoredData(serviceKey string, config *common.ConfigurationStruct, edgeXClients common.EdgeXClients) {
+	items, err := sf.storeClient.RetrieveFromStore(serviceKey)
+	if err != nil {
+		edgeXClients.LoggingClient.Error("Unable to load store and forward items from DB", "error", err)
+		return
+	}
+
+	edgeXClients.LoggingClient.Debug(fmt.Sprintf(" %d stored data items found for retrying", len(items)))
+
+	if len(items) > 0 {
+		itemsToRemove, itemsToUpdate := sf.processRetryItems(items, config, edgeXClients)
+
+		edgeXClients.LoggingClient.Debug(fmt.Sprintf(" %d stored data items will be removed post retry", len(itemsToRemove)))
+		edgeXClients.LoggingClient.Debug(fmt.Sprintf(" %d stored data items will be update post retry", len(itemsToUpdate)))
+
+		for _, item := range itemsToRemove {
+			if err := sf.storeClient.RemoveFromStore(item); err != nil {
+				edgeXClients.LoggingClient.Error("Unable to remove stored data item from DB", "error", err, "objectID", item.ID, clients.CorrelationHeader, item.CorrelationID)
+			}
+		}
+
+		for _, item := range itemsToUpdate {
+			if err := sf.storeClient.Update(item); err != nil {
+				edgeXClients.LoggingClient.Error("Unable to update stored data item in DB", "error", err, "objectID", item.ID, clients.CorrelationHeader, item.CorrelationID)
+			}
+		}
+	}
+}
+
+func (sf *storeForwardInfo) processRetryItems(items []contracts.StoredObject, config *common.ConfigurationStruct, edgeXClients common.EdgeXClients) ([]contracts.StoredObject, []contracts.StoredObject) {
+	var itemsToRemove []contracts.StoredObject
+	var itemsToUpdate []contracts.StoredObject
+
+	for _, item := range items {
+		validVersion := item.Version == sf.calculatePipelineHash()
+
+		if validVersion {
+			success := sf.retryExportFunction(item, config, edgeXClients)
+			if !success {
+				item.RetryCount++
+				if config.Writable.StoreAndForward.MaxRetryCount == 0 || item.RetryCount < config.Writable.StoreAndForward.MaxRetryCount {
+					edgeXClients.LoggingClient.Trace("Export retry failed. Incrementing retry count", "retries", item.RetryCount, clients.CorrelationHeader, item.CorrelationID)
+					itemsToUpdate = append(itemsToUpdate, item)
+					continue
+				}
+
+				edgeXClients.LoggingClient.Trace("Max retries exceeded. Removing item from DB", "retries", item.RetryCount, clients.CorrelationHeader, item.CorrelationID)
+				// Note that item will be removed for DB below.
+			} else {
+				edgeXClients.LoggingClient.Trace("Export retry successful. Removing item from DB", clients.CorrelationHeader, item.CorrelationID)
+			}
+		} else {
+			edgeXClients.LoggingClient.Trace("Stored data item's Function Pipeline Version doesn't match current Function Pipeline Version. Removing item from DB", clients.CorrelationHeader, item.CorrelationID)
+		}
+
+		// Will remove from store if version no longer matches current Pipeline or max retries exceeded
+		// or successfully retried
+		itemsToRemove = append(itemsToRemove, item)
+	}
+
+	return itemsToRemove, itemsToUpdate
+}
+
+func (sf *storeForwardInfo) retryExportFunction(item contracts.StoredObject, config *common.ConfigurationStruct,
+	edgeXClients common.EdgeXClients) bool {
+	edgexContext := &appcontext.Context{
+		CorrelationID:         item.CorrelationID,
+		EventChecksum:         item.EventChecksum,
+		EventID:               item.EventID,
+		Configuration:         *config,
+		LoggingClient:         edgeXClients.LoggingClient,
+		EventClient:           edgeXClients.EventClient,
+		ValueDescriptorClient: edgeXClients.ValueDescriptorClient,
+		CommandClient:         edgeXClients.CommandClient,
+		NotificationsClient:   edgeXClients.NotificationsClient,
+	}
+
+	edgexContext.LoggingClient.Trace("Retrying stored data", clients.CorrelationHeader, edgexContext.CorrelationID)
+
+	return sf.runtime.executePipeline(item.Payload, "", edgexContext, sf.runtime.transforms, item.PipelinePosition, true) == nil
+}
+
+func (sf *storeForwardInfo) calculatePipelineHash() string {
+	hash := "Pipeline-functions: "
+	for _, item := range sf.runtime.transforms {
+		name := runtime.FuncForPC(reflect.ValueOf(item).Pointer()).Name()
+		hash = hash + " " + name
+	}
+
+	return hash
+}

--- a/internal/runtime/storeforward_test.go
+++ b/internal/runtime/storeforward_test.go
@@ -1,0 +1,248 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package runtime
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/common"
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/store/contracts"
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/store/db/interfaces"
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/store/db/interfaces/mocks"
+	"github.com/edgexfoundry/app-functions-sdk-go/pkg/transforms"
+)
+
+func TestProcessRetryItems(t *testing.T) {
+
+	targetTransformWasCalled := false
+	expectedPayload := "This is a sample payload"
+
+	config := common.ConfigurationStruct{
+		Writable: common.WritableInfo{
+			LogLevel:        "DEBUG",
+			StoreAndForward: common.StoreAndForwardInfo{MaxRetryCount: 10},
+		},
+	}
+
+	transformPassthru := func(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
+		return true, params[0]
+	}
+
+	successTransform := func(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
+		targetTransformWasCalled = true
+
+		actualPayload, ok := params[0].([]byte)
+		if !ok {
+			t.Fatal("Expected []byte payload")
+		}
+
+		if !assert.Equal(t, expectedPayload, string(actualPayload)) {
+			t.Fatal()
+		}
+
+		return false, nil
+	}
+
+	failureTransform := func(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
+		targetTransformWasCalled = true
+		return false, errors.New("I failed")
+	}
+
+	runtime := GolangRuntime{}
+
+	tests := []struct {
+		Name                     string
+		TargetTransform          appcontext.AppFunction
+		TargetTransformWasCalled bool
+		ExpectedPayload          string
+		RetryCount               int
+		ExpectedRetryCount       int
+		RemoveCount              int
+		BadVersion               bool
+	}{
+		{"Happy Path", successTransform, true, expectedPayload, 0, 0, 1, false},
+		{"RetryCount Increased", failureTransform, true, expectedPayload, 4, 5, 0, false},
+		{"Max Retries", failureTransform, true, expectedPayload, 9, 9, 1, false},
+		{"Bad Version", successTransform, false, expectedPayload, 0, 0, 1, true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			targetTransformWasCalled = false
+
+			runtime.Initialize(creatMockStoreClient())
+			runtime.SetTransforms([]appcontext.AppFunction{transformPassthru, transformPassthru, test.TargetTransform})
+
+			version := runtime.storeForward.pipelineHash
+			if test.BadVersion {
+				version = "some bad version"
+			}
+			storedObject := contracts.NewStoredObject("dummy", []byte(test.ExpectedPayload), 2, version)
+			storedObject.RetryCount = test.RetryCount
+
+			removes, updates := runtime.storeForward.processRetryItems([]contracts.StoredObject{storedObject}, &config, common.EdgeXClients{LoggingClient: lc})
+			assert.Equal(t, test.TargetTransformWasCalled, targetTransformWasCalled, "Target transform not called")
+			if test.RetryCount != test.ExpectedRetryCount {
+				if assert.True(t, len(updates) > 0, "Remove count not as expected") {
+					assert.Equal(t, test.ExpectedRetryCount, updates[0].RetryCount, "Retry Count not as expected")
+				}
+			}
+			assert.Equal(t, test.RemoveCount, len(removes), "Remove count not as expected")
+		})
+	}
+}
+
+func TestDoStoreAndForwardRetry(t *testing.T) {
+	serviceKey := "AppService-UnitTest"
+	payload := []byte("My Payload")
+	config := common.ConfigurationStruct{
+		Writable: common.WritableInfo{
+			LogLevel:        "DEBUG",
+			StoreAndForward: common.StoreAndForwardInfo{MaxRetryCount: 10}},
+	}
+
+	httpPost := transforms.NewHTTPSender("http://nowhere", "", true).HTTPPost
+	successTransform := func(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
+		return false, nil
+	}
+	transformPassthru := func(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
+		return true, params[0]
+	}
+
+	tests := []struct {
+		Name                string
+		TargetTransform     appcontext.AppFunction
+		RetryCount          int
+		ExpectedRetryCount  int
+		ExpectedObjectCount int
+	}{
+		{"RetryCount Increased", httpPost, 1, 2, 1},
+		{"Max Retries", httpPost, 9, 0, 0},
+		{"Retry Success", successTransform, 1, 0, 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			runtime := GolangRuntime{ServiceKey: serviceKey}
+			runtime.Initialize(creatMockStoreClient())
+			runtime.SetTransforms([]appcontext.AppFunction{transformPassthru, test.TargetTransform})
+
+			object := contracts.NewStoredObject(serviceKey, payload, 1, runtime.storeForward.calculatePipelineHash())
+			object.CorrelationID = "CorrelationID"
+			object.EventID = "CorrelationID"
+			object.EventChecksum = "CorrelationID"
+			object.RetryCount = test.RetryCount
+
+			mockStoreObject(object)
+
+			// Target of this test
+			runtime.storeForward.retryStoredData(serviceKey, &config, common.EdgeXClients{LoggingClient: lc})
+
+			objects := mockRetrieveObjects(serviceKey)
+			if assert.Equal(t, test.ExpectedObjectCount, len(objects)) && test.ExpectedObjectCount > 0 {
+				assert.Equal(t, test.ExpectedRetryCount, objects[0].RetryCount)
+				assert.Equal(t, serviceKey, objects[0].AppServiceKey, "AppServiceKey not as expected")
+				assert.Equal(t, object.CorrelationID, objects[0].CorrelationID, "CorrelationID not as expected")
+				assert.Equal(t, object.EventID, objects[0].EventID, "EventID not as expected")
+				assert.Equal(t, object.EventChecksum, objects[0].EventChecksum, "EventChecksum not as expected")
+			}
+		})
+	}
+}
+
+var mockObjectStore map[string]contracts.StoredObject
+
+func creatMockStoreClient() interfaces.StoreClient {
+	mockObjectStore = make(map[string]contracts.StoredObject)
+	storeClient := &mocks.StoreClient{}
+	storeClient.Mock.On("Store", mock.Anything).Return(mockStoreObject)
+	storeClient.Mock.On("RemoveFromStore", mock.Anything).Return(mockRemoveObject)
+	storeClient.Mock.On("Update", mock.Anything).Return(mockUpdateObject)
+	storeClient.Mock.On("RetrieveFromStore", mock.Anything).Return(mockRetrieveObjects, nil)
+
+	return storeClient
+}
+
+func mockStoreObject(object contracts.StoredObject) (string, error) {
+	if err := validateContract(false, object); err != nil {
+		return "", err
+	}
+
+	if object.ID == "" {
+		object.ID = uuid.New().String()
+	}
+
+	mockObjectStore[object.ID] = object
+
+	return object.ID, nil
+}
+
+func mockUpdateObject(object contracts.StoredObject) error {
+
+	if err := validateContract(true, object); err != nil {
+		return err
+	}
+
+	mockObjectStore[object.ID] = object
+	return nil
+}
+
+func mockRemoveObject(object contracts.StoredObject) error {
+	if err := validateContract(true, object); err != nil {
+		return err
+	}
+
+	delete(mockObjectStore, object.ID)
+	return nil
+}
+
+func mockRetrieveObjects(serviceKey string) []contracts.StoredObject {
+	var objects []contracts.StoredObject
+	for _, item := range mockObjectStore {
+		if item.AppServiceKey == serviceKey {
+			objects = append(objects, item)
+		}
+	}
+
+	return objects
+}
+
+// TODO remove this and use verify func on StoredObject when it is available
+func validateContract(IDRequired bool, o contracts.StoredObject) error {
+	if IDRequired {
+		if o.ID == "" {
+			return errors.New("invalid contract, ID cannot be empty")
+		}
+	}
+	if o.AppServiceKey == "" {
+		return errors.New("invalid contract, app service key cannot be empty")
+	}
+	if len(o.Payload) == 0 {
+		return errors.New("invalid contract, payload cannot be empty")
+	}
+	if o.Version == "" {
+		return errors.New("invalid contract, version cannot be empty")
+	}
+
+	return nil
+}

--- a/internal/store/db/interfaces/mocks/StoreClient.go
+++ b/internal/store/db/interfaces/mocks/StoreClient.go
@@ -67,17 +67,12 @@ func (_m *StoreClient) Store(o contracts.StoredObject) (string, error) {
 	ret := _m.Called(o)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(contracts.StoredObject) string); ok {
-		r0 = rf(o)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
 	var r1 error
-	if rf, ok := ret.Get(1).(func(contracts.StoredObject) error); ok {
-		r1 = rf(o)
+
+	if rf, ok := ret.Get(0).(func(contracts.StoredObject) (string, error)); ok {
+		r0, r1 = rf(o)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Error(0)
 	}
 
 	return r0, r1

--- a/internal/trigger/http/rest.go
+++ b/internal/trigger/http/rest.go
@@ -17,6 +17,7 @@
 package http
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -39,7 +40,7 @@ type Trigger struct {
 }
 
 // Initialize initializes the Trigger for logging and REST route
-func (trigger *Trigger) Initialize() error {
+func (trigger *Trigger) Initialize(appCtx context.Context) error {
 	logger := trigger.EdgeXClients.LoggingClient
 
 	logger.Info("Initializing HTTP Trigger")

--- a/internal/trigger/messagebus/messaging.go
+++ b/internal/trigger/messagebus/messaging.go
@@ -17,6 +17,7 @@
 package messagebus
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
@@ -37,7 +38,7 @@ type Trigger struct {
 }
 
 // Initialize ...
-func (trigger *Trigger) Initialize() error {
+func (trigger *Trigger) Initialize(appCtx context.Context) error {
 	var err error
 	logger := trigger.EdgeXClients.LoggingClient
 
@@ -55,6 +56,9 @@ func (trigger *Trigger) Initialize() error {
 	go func() {
 		for receiveMessage {
 			select {
+			case <-appCtx.Done():
+				return
+
 			case msgErr := <-messageErrors:
 				logger.Error(fmt.Sprintf("Failed to receive ZMQ Message, %v", msgErr))
 			case msgs := <-trigger.topics[0].Messages:

--- a/internal/trigger/messagebus/messaging_test.go
+++ b/internal/trigger/messagebus/messaging_test.go
@@ -17,6 +17,7 @@
 package messagebus
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -64,7 +65,7 @@ func TestInitialize(t *testing.T) {
 	runtime := &runtime.GolangRuntime{}
 
 	trigger := Trigger{Configuration: config, Runtime: runtime, EdgeXClients: common.EdgeXClients{LoggingClient: logClient}}
-	trigger.Initialize()
+	trigger.Initialize(context.Background())
 	assert.NotNil(t, trigger.client, "Expected client to be set")
 	assert.Equal(t, 1, len(trigger.topics))
 	assert.Equal(t, "events", trigger.topics[0].Topic)
@@ -98,7 +99,7 @@ func TestInitializeBadConfiguration(t *testing.T) {
 	runtime := &runtime.GolangRuntime{}
 
 	trigger := Trigger{Configuration: config, Runtime: runtime, EdgeXClients: common.EdgeXClients{LoggingClient: logClient}}
-	err := trigger.Initialize()
+	err := trigger.Initialize(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -140,9 +141,10 @@ func TestInitializeAndProcessEventWithNoOutput(t *testing.T) {
 	}
 
 	runtime := &runtime.GolangRuntime{}
+	runtime.Initialize(nil)
 	runtime.SetTransforms([]appcontext.AppFunction{transform1})
 	trigger := Trigger{Configuration: config, Runtime: runtime, EdgeXClients: common.EdgeXClients{LoggingClient: logClient}}
-	trigger.Initialize()
+	trigger.Initialize(context.Background())
 
 	message := types.MessageEnvelope{
 		CorrelationID: expectedCorrelationID,
@@ -215,6 +217,7 @@ func TestInitializeAndProcessEventWithOutput(t *testing.T) {
 	}
 
 	runtime := &runtime.GolangRuntime{}
+	runtime.Initialize(nil)
 	runtime.SetTransforms([]appcontext.AppFunction{transform1})
 	trigger := Trigger{Configuration: config, Runtime: runtime, EdgeXClients: common.EdgeXClients{LoggingClient: logClient}}
 
@@ -241,7 +244,7 @@ func TestInitializeAndProcessEventWithOutput(t *testing.T) {
 
 	testClient.Subscribe(testTopics, testMessageErrors) //subscribe in order to receive transformed output to the bus
 
-	trigger.Initialize()
+	trigger.Initialize(context.Background())
 
 	message := types.MessageEnvelope{
 		CorrelationID: expectedCorrelationID,

--- a/internal/trigger/trigger.go
+++ b/internal/trigger/trigger.go
@@ -16,8 +16,10 @@
 
 package trigger
 
+import "context"
+
 // Trigger interface is used to hold event data and allow function to
 type Trigger interface {
 	// Initialize performs post creation initializations
-	Initialize() error
+	Initialize(ctx context.Context) error
 }


### PR DESCRIPTION
Implement the core portion of Store and Forward. The DB Abstraction, Mongo DB, Configuration and Functions portions have already been implemented and committed.

Closes #111 (final PR)
Also Closes #208 

Previous completed PRs for #111:
- #213
- #211
- #210

Related PRs:
- #204
- #194
- #212
