### PR TITLE
Use ApiDeviceRoute for command client instead of ApiCommandRoute

### DIFF
--- a/appsdk/sdk.go
+++ b/appsdk/sdk.go
@@ -363,7 +363,7 @@ func (sdk *AppFunctionsSDK) initializeClients() {
 	}
 
 	if _, ok := sdk.config.Clients[common.CoreCommandClientName]; ok {
-		params := sdk.getClientParams(clients.CoreCommandServiceKey, common.CoreCommandClientName, clients.ApiCommandRoute)
+		params := sdk.getClientParams(clients.CoreCommandServiceKey, common.CoreCommandClientName, clients.ApiDeviceRoute)
 		sdk.edgexClients.CommandClient = command.NewCommandClient(params, startup.Endpoint{RegistryClient: &sdk.registryClient})
 	}
 


### PR DESCRIPTION
Fix #218

Signed-off-by: David Chang <david@iotechsys.com>