### PR TITLE
bug(CommandClient): Use proper API Route for Command Client

### DIFF
--- a/appsdk/sdk.go
+++ b/appsdk/sdk.go
@@ -363,7 +363,7 @@ func (sdk *AppFunctionsSDK) initializeClients() {
 	}
 
 	if _, ok := sdk.config.Clients[common.CoreCommandClientName]; ok {
-		params := sdk.getClientParams(clients.CoreCommandServiceKey, common.CoreCommandClientName, clients.ApiCommandRoute)
+		params := sdk.getClientParams(clients.CoreCommandServiceKey, common.CoreCommandClientName, clients.ApiDeviceRoute)
 		sdk.edgexClients.CommandClient = command.NewCommandClient(params, startup.Endpoint{RegistryClient: &sdk.registryClient})
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,9 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.2.0
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.14
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.25
 	github.com/edgexfoundry/go-mod-messaging v0.1.11
 	github.com/edgexfoundry/go-mod-registry v0.1.11
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/google/uuid v1.1.0


### PR DESCRIPTION
Must use clients.ApiDeviceRoute, not clients.ApiCommandRoute for Command Client to send commands.

Closes #219 
