### PR TITLE
feat(MqttSend): Add SkipCertVerify setting and refactor MqttSend

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,8 +310,25 @@ These are functions that enable interactions with the CoreData REST API.
 ### Export Functions
 There are two export functions included in the SDK that can be added to your pipeline. 
 - `NewHTTPSender(url string, mimeType string, persistOnError bool)` - This function returns a `HTTPSender` instance initialized with the passed in url, mime type and persistOnError values. This `HTTPSender` instance is used to access the following functions that will use the required url and optional mime type and persistOnError:
+  
   - `HTTPPost` - This function receives either a `string`,`[]byte`, or `json.Marshaler` type from the previous function in the pipeline and posts it to the configured endpoint. If no previous function exists, then the event that triggered the pipeline, marshaled to json, will be used. Currently, only unauthenticated endpoints are supported. Authenticated endpoints will be supported in the future. If the post fails and `persistOnError`is `true` and `Store and Forward` is enabled, the data will be stored for later retry. See [Store and Forward](#store-and-forward) for more details
-- `NewMQTTSender(logging logger.LoggingClient, addr models.Addressable, keyCertPair *KeyCertPair, mqttConfig *MqttConfig, persistOnError bool)` - This function returns a `MQTTSender` instance initialized with the passed in MQTT configuration . This `MQTTSender` instance is used to access the following  function that will use the specified MQTT configuration
+- `NewMQTTSender(logging logger.LoggingClient, addr models.Addressable, keyCertPair *KeyCertPair, mqttConfig MqttConfig, persistOnError bool)` - This function returns a `MQTTSender` instance initialized with the passed in MQTT configuration . This `MQTTSender` instance is used to access the following  function that will use the specified MQTT configuration
+  
+  - `KeyCertPair` - This structure holds the Key and Certificate information for when using secure **TLS** connection to the broker. Can be `nil` if not using secure **TLS** connection. 
+  
+  - `MqttConfig` - This structure holds addition MQTT configuration settings. 
+  
+    ```
+    	Qos            byte
+    	Retain         bool
+    	AutoReconnect  bool
+    	SkipCertVerify bool
+    	User           string
+    	Password       string
+    ```
+  
+    The `GO` complier will default these to `0`, `false` and `""`, so you only need to set the fields that your usage requires that differ from the default.
+  
   - `MQTTSend` - This function receives either a `string`,`[]byte`, or `json.Marshaler` type from the previous function in the pipeline and sends it to the specified MQTT broker. If no previous function exists, then the event that triggered the pipeline, marshaled to json, will be used. If the send fails and `persistOnError`is `true` and `Store and Forward` is enabled, the data will be stored for later retry. See [Store and Forward](#store-and-forward) for more details
 
 ### Output Functions

--- a/examples/simple-filter-xml-mqtt/main.go
+++ b/examples/simple-filter-xml-mqtt/main.go
@@ -55,7 +55,8 @@ func main() {
 		Topic:     "sampleTopic",
 	}
 
-	mqttConfig := transforms.NewMqttConfig()
+	// Using default settings, so not changing any fields in MqttConfig
+	mqttConfig := transforms.MqttConfig{}
 
 	// Make sure you change KeyFile and CertFile here to point to actual key/cert files
 	// or an error will be logged for failing to load key/cert files


### PR DESCRIPTION
Replace hard coding skip verify to `true` with a setting in MqqtConfig struct. Also enable this to be set via the configurable functions pipeline.

Refactor MqttSend code to be more in align with rest of SDK's code

Signed-off-by: lenny <leonard.goodell@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Skip Verify is hard coded to `true`

Issue Number: #233


## What is the new behavior?
Capability to set Skip Verify from code or from pipeline configuration.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information