### PR TITLE
feat(version): Validate that SDK's major version matches Core Service's major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,9 @@ The following command line options are available
   -r    
   --registry
         Indicates the service should use the registry.
+  -i    
+  -ignoreVersion
+        Indicates the service should ignore version check error.
 ```
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -453,9 +453,9 @@ The following command line options are available
   -r    
   --registry
         Indicates the service should use the registry.
-  -i    
-  -ignoreVersion
-        Indicates the service should ignore version check error.
+  -s    
+  -skipVersionCheck
+        Indicates the service should skip the Core Service's version compatibility check.
 ```
 
 Examples:

--- a/appsdk/sdk.go
+++ b/appsdk/sdk.go
@@ -93,7 +93,7 @@ type AppFunctionsSDK struct {
 	configProfile             string
 	configDir                 string
 	useRegistry               bool
-	ignoreVersionError        bool
+	skipVersionCheck          bool
 	usingConfigurablePipeline bool
 	httpErrors                chan error
 	runtime                   *runtime.GolangRuntime
@@ -284,8 +284,8 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 	flag.StringVar(&sdk.configDir, "confdir", "", "Specify an alternate configuration directory.")
 	flag.StringVar(&sdk.configDir, "c", "", "Specify an alternate configuration directory.")
 
-	flag.BoolVar(&sdk.ignoreVersionError, "ignoreVersion", false, "Indicates the service should ignore version check error.")
-	flag.BoolVar(&sdk.ignoreVersionError, "i", false, "Indicates the service should ignore version check error.")
+	flag.BoolVar(&sdk.skipVersionCheck, "skipVersionCheck", false, "Indicates the service should skip the Core Service's version compatibility check.")
+	flag.BoolVar(&sdk.skipVersionCheck, "s", false, "Indicates the service should skip the Core Service's version compatibility check.")
 
 	flag.Parse()
 
@@ -355,8 +355,8 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 		}
 
 		// Verify that Core Services major version matches this SDK's major version
-		if !sdk.validateVersionMatch(sdk.ignoreVersionError) {
-			return fmt.Errorf("core service's version not compatible with SDK version")
+		if !sdk.validateVersionMatch() {
+			return fmt.Errorf("core service's version is not compatible with SDK's version")
 		}
 
 		// Currently only need the database if store and forward is enabled
@@ -405,18 +405,23 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 	return nil
 }
 
-func (sdk *AppFunctionsSDK) validateVersionMatch(ignoreVersionError bool) bool {
+func (sdk *AppFunctionsSDK) validateVersionMatch() bool {
+	if sdk.skipVersionCheck {
+		sdk.LoggingClient.Info("Skipping core service version compatibility check")
+		return true
+	}
+
 	// SDK version is set via the SemVer TAG at build time
 	// and has the format "v{major}.{minor}.{patch}[-dev.{build}]"
 	sdkVersionParts := strings.Split(internal.SDKVersion, ".")
 	if len(sdkVersionParts) < 3 {
 		sdk.LoggingClient.Error("SDK version is malformed", "version", internal.SDKVersion)
-		return ignoreVersionError
+		return false
 	}
 
 	sdkVersionParts[MajorIndex] = strings.Replace(sdkVersionParts[MajorIndex], "v", "", 1)
 	if sdkVersionParts[MajorIndex] == "0" {
-		sdk.LoggingClient.Info("Skipping core service version match check for SDK Beta version or running in debugger", "version", internal.SDKVersion)
+		sdk.LoggingClient.Info("Skipping core service version compatibility check for SDK Beta version or running in debugger", "version", internal.SDKVersion)
 		return true
 	}
 
@@ -424,40 +429,40 @@ func (sdk *AppFunctionsSDK) validateVersionMatch(ignoreVersionError bool) bool {
 	data, err := clients.GetRequest(url, context.Background())
 	if err != nil {
 		sdk.LoggingClient.Error("Unable to get version of Core Services", "error", err)
-		return ignoreVersionError
+		return false
 	}
 
 	versionJson := map[string]string{}
 	err = json.Unmarshal(data, &versionJson)
 	if err != nil {
 		sdk.LoggingClient.Error("Unable to un-marshal Core Services version data", "error", err)
-		return ignoreVersionError
+		return false
 	}
 
 	version, ok := versionJson[CoreServiceVersionKey]
 	if !ok {
 		sdk.LoggingClient.Error(fmt.Sprintf("Core Services version data missing '%s' information", CoreServiceVersionKey))
-		return ignoreVersionError
+		return false
 	}
 
 	// Core Service version is reported as "{major}.{minor}.{patch}"
 	coreVersionParts := strings.Split(version, ".")
 	if len(coreVersionParts) != 3 {
 		sdk.LoggingClient.Error("Core Services version is malformed", "version", version)
-		return ignoreVersionError
+		return false
 	}
 
 	// Do Major versions match?
 	if coreVersionParts[0] == sdkVersionParts[0] {
 		sdk.LoggingClient.Debug(
-			fmt.Sprintf("Confirmed Core Services Version (%s) matches the SDK's major version (%s)",
+			fmt.Sprintf("Confirmed Core Services version (%s) is compatible with SDK's version (%s)",
 				version, internal.SDKVersion))
 		return true
 	}
 
-	sdk.LoggingClient.Error(fmt.Sprintf("Core services major version (%s) doesn't match the SDK major version(%s)",
+	sdk.LoggingClient.Error(fmt.Sprintf("Core services version (%s) is not compatible with SDK's version(%s)",
 		version, internal.SDKVersion))
-	return ignoreVersionError
+	return false
 }
 
 func (sdk *AppFunctionsSDK) createStoreClient() error {

--- a/appsdk/sdk.go
+++ b/appsdk/sdk.go
@@ -18,6 +18,7 @@ package appsdk
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -62,6 +63,8 @@ const (
 	// ProfileSuffixPlaceholder is used to create unique names for profiles
 	ProfileSuffixPlaceholder   = "<profile>"
 	ProfileEnvironmentVariable = "edgex_profile"
+	CoreServiceVersionKey      = "version"
+	MajorIndex                 = 0
 )
 
 // The key type is unexported to prevent collisions with context keys defined in
@@ -90,6 +93,7 @@ type AppFunctionsSDK struct {
 	configProfile             string
 	configDir                 string
 	useRegistry               bool
+	ignoreVersionError        bool
 	usingConfigurablePipeline bool
 	httpErrors                chan error
 	runtime                   *runtime.GolangRuntime
@@ -280,6 +284,9 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 	flag.StringVar(&sdk.configDir, "confdir", "", "Specify an alternate configuration directory.")
 	flag.StringVar(&sdk.configDir, "c", "", "Specify an alternate configuration directory.")
 
+	flag.BoolVar(&sdk.ignoreVersionError, "ignoreVersion", false, "Indicates the service should ignore version check error.")
+	flag.BoolVar(&sdk.ignoreVersionError, "i", false, "Indicates the service should ignore version check error.")
+
 	flag.Parse()
 
 	// Service keys must be unique. If an executable is run multiple times, it must have a different
@@ -311,12 +318,14 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 	if err != nil {
 		return err
 	}
+
 	bootTimeout, err := time.ParseDuration(configuration.Service.BootTimeout)
 	if err != nil {
 		fmt.Printf("warning- failed to parse Service.BootTimeout, use the default %s: %v\n",
 			internal.BootTimeoutDefault.String(), err)
 		bootTimeout = internal.BootTimeoutDefault
 	}
+
 	timeElapsed := time.Since(timeStart)
 
 	// Bootstrap retry loop to ensure all dependencies are ready before continuing.
@@ -343,6 +352,11 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 			sdk.LoggingClient.Info("Logger successfully initialized")
 			sdk.edgexClients.LoggingClient = sdk.LoggingClient
 			loggerInitialized = true
+		}
+
+		// Verify that Core Services major version matches this SDK's major version
+		if !sdk.validateVersionMatch(sdk.ignoreVersionError) {
+			return fmt.Errorf("core service's version not compatible with SDK version")
 		}
 
 		// Currently only need the database if store and forward is enabled
@@ -389,6 +403,61 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 	sdk.webserver.ConfigureStandardRoutes()
 
 	return nil
+}
+
+func (sdk *AppFunctionsSDK) validateVersionMatch(ignoreVersionError bool) bool {
+	// SDK version is set via the SemVer TAG at build time
+	// and has the format "v{major}.{minor}.{patch}[-dev.{build}]"
+	sdkVersionParts := strings.Split(internal.SDKVersion, ".")
+	if len(sdkVersionParts) < 3 {
+		sdk.LoggingClient.Error("SDK version is malformed", "version", internal.SDKVersion)
+		return ignoreVersionError
+	}
+
+	sdkVersionParts[MajorIndex] = strings.Replace(sdkVersionParts[MajorIndex], "v", "", 1)
+	if sdkVersionParts[MajorIndex] == "0" {
+		sdk.LoggingClient.Info("Skipping core service version match check for SDK Beta version or running in debugger", "version", internal.SDKVersion)
+		return true
+	}
+
+	url := sdk.config.Clients[common.CoreDataClientName].Url() + clients.ApiVersionRoute
+	data, err := clients.GetRequest(url, context.Background())
+	if err != nil {
+		sdk.LoggingClient.Error("Unable to get version of Core Services", "error", err)
+		return ignoreVersionError
+	}
+
+	versionJson := map[string]string{}
+	err = json.Unmarshal(data, &versionJson)
+	if err != nil {
+		sdk.LoggingClient.Error("Unable to un-marshal Core Services version data", "error", err)
+		return ignoreVersionError
+	}
+
+	version, ok := versionJson[CoreServiceVersionKey]
+	if !ok {
+		sdk.LoggingClient.Error(fmt.Sprintf("Core Services version data missing '%s' information", CoreServiceVersionKey))
+		return ignoreVersionError
+	}
+
+	// Core Service version is reported as "{major}.{minor}.{patch}"
+	coreVersionParts := strings.Split(version, ".")
+	if len(coreVersionParts) != 3 {
+		sdk.LoggingClient.Error("Core Services version is malformed", "version", version)
+		return ignoreVersionError
+	}
+
+	// Do Major versions match?
+	if coreVersionParts[0] == sdkVersionParts[0] {
+		sdk.LoggingClient.Debug(
+			fmt.Sprintf("Confirmed Core Services Version (%s) matches the SDK's major version (%s)",
+				version, internal.SDKVersion))
+		return true
+	}
+
+	sdk.LoggingClient.Error(fmt.Sprintf("Core services major version (%s) doesn't match the SDK major version(%s)",
+		version, internal.SDKVersion))
+	return ignoreVersionError
 }
 
 func (sdk *AppFunctionsSDK) createStoreClient() error {

--- a/appsdk/sdk_test.go
+++ b/appsdk/sdk_test.go
@@ -426,16 +426,16 @@ func TestValidateVersionMatch(t *testing.T) {
 	}
 
 	tests := []struct {
-		Name               string
-		CoreVersion        string
-		SdkVersion         string
-		IgnoreVersionError bool
-		ExpectFailure      bool
+		Name             string
+		CoreVersion      string
+		SdkVersion       string
+		skipVersionCheck bool
+		ExpectFailure    bool
 	}{
-		{"Released match", "1.1.0", "v1.0.0", false, false},
-		{"Dev WIP Match", "2.0.0", "v2.0.0-dev.11", false, false},
-		{"Released mis-Match", "2.0.0", "v1.0.0", false, true},
-		{"Ignore Released mis-Match", "2.0.0", "v1.0.0", true, false},
+		{"Compatible Versions", "1.1.0", "v1.0.0", false, false},
+		{"Dev Compatible Versions", "2.0.0", "v2.0.0-dev.11", false, false},
+		{"Un-compatible Versions", "2.0.0", "v1.0.0", false, true},
+		{"Skip Version Check", "2.0.0", "v1.0.0", true, false},
 		{"Running in Debugger", "1.0.0", "v0.0.0", false, false},
 		{"SDK Beta Version", "1.0.0", "v0.2.0", false, false},
 		{"SDK Version malformed", "1.0.0", "", false, true},
@@ -448,6 +448,7 @@ func TestValidateVersionMatch(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 
 			internal.SDKVersion = test.SdkVersion
+			sdk.skipVersionCheck = test.skipVersionCheck
 
 			handler := func(w http.ResponseWriter, r *http.Request) {
 				var versionJson string
@@ -473,7 +474,7 @@ func TestValidateVersionMatch(t *testing.T) {
 			coreService.Port = port
 			sdk.config.Clients[common.CoreDataClientName] = coreService
 
-			result := sdk.validateVersionMatch(test.IgnoreVersionError)
+			result := sdk.validateVersionMatch()
 			assert.Equal(t, test.ExpectFailure, !result)
 		})
 	}

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -25,7 +25,6 @@ const (
 	ConfigRegistryStem   = "edgex/appservices/1.0/"
 	WritableKey          = "/Writable"
 	ApiTriggerRoute      = "/api/v1/trigger"
-	LogDurationKey       = "duration"
 	DatabaseName         = "application-service"
 )
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: #151 

## What is the new behavior?
Validates that the SDK's major version matches Core Service's major version.

Includes a -i/--ignoreVersion command-line option to override version check errors.

SDK version starting with "0" is always valid as it is either a Beta Version or being run in the debugger.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information