### PR TITLE
feat(configuration): Add overwrite option for force local settings into Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,9 @@ The following command line options are available
   -r    
   --registry
         Indicates the service should use the registry.
+  -o    
+  -overwrite
+        Overwrite configuration in the Registry with local values.
   -s    
   -skipVersionCheck
         Indicates the service should skip the Core Service's version compatibility check.

--- a/appsdk/sdk.go
+++ b/appsdk/sdk.go
@@ -94,6 +94,7 @@ type AppFunctionsSDK struct {
 	configDir                 string
 	useRegistry               bool
 	skipVersionCheck          bool
+	overwriteConfig           bool
 	usingConfigurablePipeline bool
 	httpErrors                chan error
 	runtime                   *runtime.GolangRuntime
@@ -286,6 +287,9 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 
 	flag.BoolVar(&sdk.skipVersionCheck, "skipVersionCheck", false, "Indicates the service should skip the Core Service's version compatibility check.")
 	flag.BoolVar(&sdk.skipVersionCheck, "s", false, "Indicates the service should skip the Core Service's version compatibility check.")
+
+	flag.BoolVar(&sdk.overwriteConfig, "overwrite", false, "Overwrite configuration in the Registry with local values")
+	flag.BoolVar(&sdk.overwriteConfig, "o", false, "Overwrite configuration in the Registry with local values")
 
 	flag.Parse()
 
@@ -580,7 +584,7 @@ func (sdk *AppFunctionsSDK) initializeConfiguration(configuration *common.Config
 			return fmt.Errorf("Could not determine if registry has configuration: %v", err)
 		}
 
-		if hasConfig {
+		if !sdk.overwriteConfig && hasConfig {
 			rawConfig, err := sdk.registryClient.GetConfiguration(configuration)
 			if err != nil {
 				return fmt.Errorf("Could not get configuration from Registry: %v", err)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
SDK pushes local settings into Registry only if the root key doesn't exist in the Registry

Issue Number: #176


## What is the new behavior?
Added -o/--overwrite command-line option to overwrite configuration in Registry with local settings rather than loading the settings from the Registry.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information