### PR TITLE
WIP: Add docker support for simple-cbor-filter

### DIFF
--- a/examples/simple-cbor-filter/Dockerfile
+++ b/examples/simple-cbor-filter/Dockerfile
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM golang:1.12-alpine AS builder
+
+LABEL license='SPDX-License-Identifier: Apache-2.0' \
+  copyright='Copyright (c) 2019: Intel'
+
+# add git for go modules
+RUN apk update && apk add --no-cache make git gcc libc-dev libsodium-dev zeromq-dev
+WORKDIR /app-functions-sdk-go
+
+COPY go.mod .
+
+RUN go mod download
+
+COPY . .
+RUN apk info -a zeromq-dev
+
+RUN make examples/simple-cbor-filter/simple-cbor-filter
+
+# Next image - Copy built Go binary into new workspace
+FROM alpine
+
+LABEL license='SPDX-License-Identifier: Apache-2.0' \
+  copyright='Copyright (c) 2019: Intel'
+
+RUN apk --no-cache add zeromq
+COPY --from=builder /app-functions-sdk-go/examples/simple-cbor-filter/res/docker /res/docker
+COPY --from=builder /app-functions-sdk-go/examples/simple-cbor-filter/simple-cbor-filter /simple-cbor-filter
+
+CMD [ "/simple-cbor-filter" ,"--registry","--profile=docker","--confdir=/res"]

--- a/examples/simple-cbor-filter/res/docker/configuration.toml
+++ b/examples/simple-cbor-filter/res/docker/configuration.toml
@@ -1,0 +1,84 @@
+[Writable]
+LogLevel = 'INFO'
+    [Writable.StoreAndForward]
+    Enabled = false
+    RetryInterval = '5m'
+    MaxRetryCount = 10
+
+[Service]
+BootTimeout = '30s'
+ClientMonitor = '15s'
+CheckInterval = '10s'
+Host = 'simple-cbor-filter'
+Port = 48095
+Protocol = 'http'
+ReadMaxLimit = 100
+StartupMsg = 'Simple CBOR Filter Application Service started'
+Timeout = '30s'
+
+[Registry]
+Host = 'edgex-core-consul'
+Port = 8500
+Type = 'consul'
+
+[Logging]
+EnableRemote = true
+
+[Database]
+Type = "mongodb"
+Host = "edgex-mongo"
+Port = 27017
+Timeout = "30s"
+Username = "appservice"
+Password = "password"
+
+[SecretStore]
+  Host = 'edgex-vault'
+  Port = 8200
+  Path = '/v1/secret/edgex/appservice/'
+  Protocol = 'https'
+  RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+  ServerName = 'edgex-vault'
+  TokenFile = '/vault/config/assets/resp-init.json'
+
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+
+[Clients]
+  [Clients.CoreData]
+  Protocol = 'http'
+  Host = 'edgex-core-data'
+  Port = 48080
+
+  [Clients.Logging]
+  Protocol = "http"
+  Host = "edgex-support-logging"
+  Port = 48061
+
+[MessageBus]
+Type = 'zero'
+    [MessageBus.PublishHost]
+        Host = '*'
+        Port = 5564
+        Protocol = 'tcp'
+    [MessageBus.SubscribeHost]
+        Host = 'edgex-core-data'
+        Port = 5563
+        Protocol = 'tcp'
+
+
+# Choose either an HTTP trigger or MessageBus trigger (aka Binding)
+
+#[Binding]
+#Type="http"
+
+[Binding]
+Type="messagebus"
+SubscribeTopic="events"
+PublishTopic="somewhere"
+
+[ApplicationSettings]
+ValueDescriptors = "onvif_snapshot"
+
+
+


### PR DESCRIPTION
## PR Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [x] Other... Please describe: Integration sample - simplified demonstration of CBOR, with live camera feeds.


## What is the current behavior?
Current behavior requires several native installation steps to run a sample that shows CBOR events from device sdk example.

Issue Number:
[#260](https://github.com/edgexfoundry/app-functions-sdk-go/issues/260)

## What is the new behavior?
This simplifies and makes a useful starting point for innovators looking to consume binary values from device services. To do this it makes a minor change to build docker container (reduces # build and setup steps) and produces a repeatable runtime mechanism to demo EdgeX applications that implement w/ app-functions-sdk.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
We could optionally change the existing default sample. Instructions in associated device-camera-go PR are to manually update the CMD/entrypoint. We discussed that these may belong published in a wiki or other location alongside other cross-cutting samples.

## Other information