### PR TITLE
feat(sdk): Add helper function to SDK to get string slice from App Settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,37 +64,33 @@ func main() {
 		os.Exit(-1)
 	}
 
-	// 3) Since our FilterByDeviceName Function requires the list of Device Names we would
-	// like to search for, we'll go ahead and define that now.
-	deviceNames := []string{"Random-Float-Device"}
+	// 3) Shows how to access the application's specific configuration settings.
+	deviceNames, err := edgexSdk.GetAppSettingStrings("DeviceNames")
+	if err != nil {
+		edgexSdk.LoggingClient.Error(err.Error())
+		os.Exit(-1)
+	}    
 
 	// 4) This is our pipeline configuration, the collection of functions to
 	// execute every time an event is triggered.
-	if err := edgexSdk.SetFunctionsPipeline(
+	if err = edgexSdk.SetFunctionsPipeline(
 			transforms.NewFilter(deviceNames).FilterByDeviceName, 
 			transforms.NewConversion().TransformToXML,
 		); err != nil {
-			edgexSdk.LoggingClient.Error(fmt.Sprintf("SDK SetPipeline failed: %v\n", err))
-			os.Exit(-1)
-		}
-
-	// 5) shows how to access the application's specific configuration settings.
-	appSettings := edgexSdk.ApplicationSettings()
-	if appSettings != nil {
-		appName, ok := appSettings["ApplicationName"]
-		if ok {
-			edgexSdk.LoggingClient.Info(fmt.Sprintf("%s now running...", appName))
-		} else {
-			edgexSdk.LoggingClient.Error("ApplicationName application setting not found")
-			os.Exit(-1)
-		}
-	} else {
-		edgexSdk.LoggingClient.Error("No application settings found")
+		edgexSdk.LoggingClient.Error(fmt.Sprintf("SDK SetPipeline failed: %v\n", err))
 		os.Exit(-1)
 	}
 
-	// 6) Lastly, we'll go ahead and tell the SDK to "start" and begin listening for events to trigger the pipeline.
-	edgexSdk.MakeItRun()
+	// 5) Lastly, we'll go ahead and tell the SDK to "start" and begin listening for events to trigger the pipeline.
+	err = edgexSdk.MakeItRun()
+	if err != nil {
+		edgexSdk.LoggingClient.Error("MakeItRun returned error: ", err.Error())
+		os.Exit(-1)
+	}
+
+	// Do any required cleanup here
+
+	os.Exit(0)
 }
 ```
 

--- a/appsdk/sdk.go
+++ b/appsdk/sdk.go
@@ -272,6 +272,22 @@ func (sdk *AppFunctionsSDK) ApplicationSettings() map[string]string {
 	return sdk.config.ApplicationSettings
 }
 
+// GetAppSettingStrings returns the strings slice for the specified App Setting.
+func (sdk *AppFunctionsSDK) GetAppSettingStrings(setting string) ([]string, error) {
+	if sdk.config.ApplicationSettings == nil {
+		return nil, fmt.Errorf("%s setting not found: ApplicationSettings section is missing", setting)
+	}
+
+	settingValue, ok := sdk.config.ApplicationSettings[setting]
+	if !ok {
+		return nil, fmt.Errorf("%s setting not found in ApplicationSettings", setting)
+	}
+
+	valueStrings := util.DeleteEmptyAndTrim(strings.FieldsFunc(settingValue, util.SplitComma))
+
+	return valueStrings, nil
+}
+
 // Initialize will parse command line flags, register for interrupts,
 // initialize the logging system, and ingest configuration.
 func (sdk *AppFunctionsSDK) Initialize() error {

--- a/appsdk/sdk_test.go
+++ b/appsdk/sdk_test.go
@@ -179,6 +179,60 @@ func TestApplicationSettingsNil(t *testing.T) {
 	}
 }
 
+func TestGetAppSettingStrings(t *testing.T) {
+	setting := "DeviceNames"
+	expected := []string{"dev1", "dev2"}
+
+	sdk := AppFunctionsSDK{
+		config: common.ConfigurationStruct{
+			ApplicationSettings: map[string]string{
+				"DeviceNames": "dev1,   dev2",
+			},
+		},
+	}
+
+	actual, err := sdk.GetAppSettingStrings(setting)
+	if !assert.NoError(t, err, "unexpected error") {
+		t.Fatal()
+	}
+
+	assert.EqualValues(t, expected, actual, "actual application setting values not as expected")
+}
+
+func TestGetAppSettingStringsSettingMissing(t *testing.T) {
+	setting := "DeviceNames"
+	expected := "setting not found in ApplicationSettings"
+
+	sdk := AppFunctionsSDK{
+		config: common.ConfigurationStruct{
+			ApplicationSettings: map[string]string{},
+		},
+	}
+
+	_, err := sdk.GetAppSettingStrings(setting)
+	if !assert.Error(t, err, "Expected an error") {
+		t.Fatal()
+	}
+
+	assert.Contains(t, err.Error(), expected, "Error not as expected")
+}
+
+func TestGetAppSettingStringsNoAppSettings(t *testing.T) {
+	setting := "DeviceNames"
+	expected := "ApplicationSettings section is missing"
+
+	sdk := AppFunctionsSDK{
+		config: common.ConfigurationStruct{},
+	}
+
+	_, err := sdk.GetAppSettingStrings(setting)
+	if !assert.Error(t, err, "Expected an error") {
+		t.Fatal()
+	}
+
+	assert.Contains(t, err.Error(), expected, "Error not as expected")
+}
+
 func TestLoadConfigurablePipelineFunctionNotFound(t *testing.T) {
 	sdk := AppFunctionsSDK{
 		LoggingClient: lc,


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

All app services will have comma separated list of names in their ApplicationSettings for `device names` or `value descriptors` and need to pares them into string slice for filtering. Each service must repeat the code for this parsing.

Issue Number: #267


## What is the new behavior?

SDK now has helper function to retrieve and parse app settings that are comma separated strings.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information