### PR TITLE
refact(sdk): Update usage of NewSecretClient to use the latest go-mod-secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.25
 	github.com/edgexfoundry/go-mod-messaging v0.1.11
 	github.com/edgexfoundry/go-mod-registry v0.1.11
-	github.com/edgexfoundry/go-mod-secrets v0.0.14
+	github.com/edgexfoundry/go-mod-secrets v0.0.15
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/go-cmp v0.3.1 // indirect
@@ -26,5 +26,4 @@ require (
 	go.mongodb.org/mongo-driver v1.1.1
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/internal/security/client/testdata/expiredToken.json
+++ b/internal/security/client/testdata/expiredToken.json
@@ -1,0 +1,9 @@
+{
+    "keys": [
+      "test-keys"
+    ],
+    "keys_base64": [
+      "test-keys-base64"
+    ],
+    "root_token": "expired-token"
+}

--- a/internal/security/client/testdata/replacement.json
+++ b/internal/security/client/testdata/replacement.json
@@ -1,0 +1,9 @@
+{
+    "keys": [
+      "test-keys"
+    ],
+    "keys_base64": [
+      "test-keys-base64"
+    ],
+    "root_token": "replacement-token"
+}

--- a/internal/security/client/testdata/testToken.json
+++ b/internal/security/client/testdata/testToken.json
@@ -1,0 +1,9 @@
+{
+    "keys": [
+      "test-keys"
+    ],
+    "keys_base64": [
+      "test-keys-base64"
+    ],
+    "root_token": "test-token"
+}

--- a/internal/security/client/vaultclient.go
+++ b/internal/security/client/vaultclient.go
@@ -1,0 +1,89 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/common"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg"
+	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/authtokenloader"
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
+)
+
+// Vault is the structure to get the secret client from go-mod-secrets vault package
+type Vault struct {
+	ctx    context.Context
+	config vault.SecretConfig
+	lc     logger.LoggingClient
+}
+
+// NewVault is the constructor for Vault in order to get the Vault secret client
+func NewVault(ctx context.Context, config vault.SecretConfig, lc logger.LoggingClient) Vault {
+	return Vault{
+		ctx:    ctx,
+		config: config,
+		lc:     lc,
+	}
+}
+
+// Get is the getter for Vault secret client from go-mod-secrets
+func (c Vault) Get(secretStoreInfo common.SecretStoreInfo) (pkg.SecretClient, error) {
+	return vault.NewSecretClientFactory().NewSecretClient(
+		c.ctx,
+		c.config,
+		c.lc,
+		c.getDefaultTokenExpiredCallback(secretStoreInfo))
+}
+
+// getDefaultTokenExpiredCallback is the default implementation of tokenExpiredCallback function
+// It utilizes the tokenFile to re-read the token and enable retry if any update from the expired token
+func (c Vault) getDefaultTokenExpiredCallback(
+	secretStoreInfo common.SecretStoreInfo) func(expiredToken string) (replacementToken string, retry bool) {
+	// if there is no tokenFile, then no replacement token can be used and hence no callback
+	if secretStoreInfo.TokenFile == "" {
+		return nil
+	}
+
+	tokenFile := secretStoreInfo.TokenFile
+
+	return func(expiredToken string) (replacementToken string, retry bool) {
+		// during the callback, we want to re-read the token from the disk
+		// specified by tokenFile and set the retry to true if a new token
+		// is different from the expiredToken
+		fileIoPerformer := fileioperformer.NewDefaultFileIoPerformer()
+		authTokenLoader := authtokenloader.NewAuthTokenLoader(fileIoPerformer)
+		reReadToken, err := authTokenLoader.Load(tokenFile)
+
+		if err != nil {
+			c.lc.Error(fmt.Sprintf("fail to load auth token from tokenFile %s: %v", tokenFile, err))
+			return "", false
+		}
+
+		if reReadToken == expiredToken {
+			c.lc.Error("No new replacement token found for the expired token")
+			return reReadToken, false
+		}
+
+		return reReadToken, true
+	}
+}

--- a/internal/security/client/vaultclient_test.go
+++ b/internal/security/client/vaultclient_test.go
@@ -1,0 +1,248 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package client
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/common"
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/security/mock"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
+)
+
+func TestGetVaultClient(t *testing.T) {
+	// setup
+	tokenPeriod := 6
+	tokenDataMap := initTokenData(tokenPeriod)
+
+	server := mock.GetMockTokenServer(tokenDataMap)
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoErrorf(t, err, "error on parsing server url %s: %s", server.URL, err)
+
+	host, port, _ := net.SplitHostPort(serverURL.Host)
+	portNum, _ := strconv.Atoi(port)
+
+	bkgCtx := context.Background()
+	lc := logger.NewClient("app_functions_sdk_go", false, "./test.log", "DEBUG")
+
+	testSecretStoreInfo := common.SecretStoreInfo{
+		SecretConfig: vault.SecretConfig{
+			Host:       host,
+			Port:       portNum,
+			Path:       "/test",
+			Protocol:   "http",
+			ServerName: "mockVaultServer",
+		},
+	}
+
+	tests := []struct {
+		name                string
+		authToken           string
+		tokenFile           string
+		expectedNewToken    string
+		expectedNilCallback bool
+		expectedRetry       bool
+		expectError         bool
+	}{
+		{
+			name:                "New secret client with testToken1, more than half of TTL remaining",
+			authToken:           "testToken1",
+			tokenFile:           "testdata/replacement.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "replacement-token",
+			expectedRetry:       true,
+			expectError:         false,
+		},
+		{
+			name:                "New secret client with the same first token again",
+			authToken:           "testToken1",
+			tokenFile:           "testdata/replacement.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "replacement-token",
+			expectedRetry:       true,
+			expectError:         false,
+		},
+		{
+			name:                "New secret client with testToken2, half of TTL remaining",
+			authToken:           "testToken2",
+			expectedNilCallback: false,
+			tokenFile:           "testdata/replacement.json",
+			expectedNewToken:    "replacement-token",
+			expectedRetry:       true,
+			expectError:         false,
+		},
+		{
+			name:                "New secret client with testToken3, less than half of TTL remaining",
+			authToken:           "testToken3",
+			tokenFile:           "testdata/replacement.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "replacement-token",
+			expectedRetry:       true,
+			expectError:         false,
+		},
+		{
+			name:                "New secret client with expired token, no TTL remaining",
+			authToken:           "expiredToken",
+			tokenFile:           "testdata/replacement.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "replacement-token",
+			expectedRetry:       true,
+			expectError:         true,
+		},
+		{
+			name:                "New secret client with expired token, non-existing TokenFile path",
+			authToken:           "expiredToken",
+			tokenFile:           "testdata/non-existing.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "",
+			expectedRetry:       false,
+			expectError:         true,
+		},
+		{
+			name:                "New secret client with expired test token, but same expired replacement token",
+			authToken:           "test-token",
+			tokenFile:           "testdata/testToken.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "test-token",
+			expectedRetry:       false,
+			expectError:         true,
+		},
+		{
+			name:                "New secret client with unauthenticated token",
+			authToken:           "test-token",
+			expectedNilCallback: true,
+			expectedNewToken:    "",
+			expectedRetry:       false,
+			expectError:         true,
+		},
+		{
+			name:                "New secret client with unrenewable token",
+			authToken:           "unrenewableToken",
+			expectedNilCallback: true,
+			expectedNewToken:    "",
+			expectedRetry:       true,
+			expectError:         false,
+		},
+		{
+			name:                "New secret client with no TokenFile",
+			authToken:           "testToken1",
+			tokenFile:           "",
+			expectedNilCallback: true,
+			expectedNewToken:    "",
+			expectedRetry:       false,
+			expectError:         false,
+		},
+	}
+
+	for _, test := range tests {
+		testSecretStoreInfo.TokenFile = test.tokenFile
+		cfgHTTP := vault.SecretConfig{
+			Host:           host,
+			Port:           portNum,
+			Protocol:       "http",
+			Authentication: vault.AuthenticationInfo{AuthToken: test.authToken},
+		}
+
+		// pinned local test variable to avoid scopelint warnings
+		currentTest := test
+
+		t.Run(test.name, func(t *testing.T) {
+			sclient := NewVault(bkgCtx, cfgHTTP, lc)
+			_, err := sclient.Get(testSecretStoreInfo)
+
+			if currentTest.expectError {
+				require.Error(t, err, "Expect error but none was received")
+			} else {
+				require.NoError(t, err, "Expect no error but found some error")
+			}
+
+			tokenCallback := sclient.getDefaultTokenExpiredCallback(testSecretStoreInfo)
+			if currentTest.expectedNilCallback {
+				assert.Nil(t, tokenCallback, "found token expired callback func not nil")
+			} else {
+				require.NotNil(t, tokenCallback, "token expired callback func is nil")
+
+				repToken, retry := tokenCallback(currentTest.authToken)
+
+				assert.Equal(t, currentTest.expectedNewToken, repToken,
+					"replacement token not as expected from callback func")
+
+				assert.Equal(t, currentTest.expectedRetry, retry, "retry not as expected from callback func")
+			}
+		})
+	}
+
+	// wait for some time to allow renewToken to be run if any
+	time.Sleep(7 * time.Second)
+}
+
+func initTokenData(tokenPeriod int) *sync.Map {
+	var tokenDataMap sync.Map
+
+	// ttl > half of period
+	tokenDataMap.Store("testToken1", vault.TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       tokenPeriod * 7 / 10,
+		Period:    tokenPeriod,
+	})
+	// ttl = half of period
+	tokenDataMap.Store("testToken2", vault.TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       tokenPeriod / 2,
+		Period:    tokenPeriod,
+	})
+	// ttl < half of period
+	tokenDataMap.Store("testToken3", vault.TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       tokenPeriod * 3 / 10,
+		Period:    tokenPeriod,
+	})
+	// to be expired token
+	tokenDataMap.Store("toToExpiredToken", vault.TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       1,
+		Period:    tokenPeriod,
+	})
+	// expired token
+	tokenDataMap.Store("expiredToken", vault.TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       0,
+		Period:    tokenPeriod,
+	})
+	// not renewable token
+	tokenDataMap.Store("unrenewableToken", vault.TokenLookupMetadata{
+		Renewable: false,
+		Ttl:       0,
+		Period:    tokenPeriod,
+	})
+
+	return &tokenDataMap
+}

--- a/internal/security/mock/mockserver.go
+++ b/internal/security/mock/mockserver.go
@@ -1,0 +1,96 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package mock
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
+)
+
+// GetMockTokenServer is a test helper for unit tests of vault token server
+func GetMockTokenServer(tokenDataMap *sync.Map) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		urlPath := req.URL.String()
+		switch req.Method {
+		case http.MethodGet:
+			if urlPath == "/v1/auth/token/lookup-self" {
+				token := req.Header.Get(vault.AuthTypeHeader)
+				sampleTokenLookup, exists := tokenDataMap.Load(token)
+				if !exists {
+					rw.WriteHeader(http.StatusForbidden)
+					_, _ = rw.Write([]byte("permission denied"))
+				} else {
+					resp := &vault.TokenLookupResponse{
+						Data: sampleTokenLookup.(vault.TokenLookupMetadata),
+					}
+					if ret, err := json.Marshal(resp); err != nil {
+						rw.WriteHeader(http.StatusInternalServerError)
+						_, _ = rw.Write([]byte(err.Error()))
+					} else {
+						rw.WriteHeader(http.StatusOK)
+						_, _ = rw.Write(ret)
+					}
+				}
+			} else {
+				returnUnknownPath(rw, urlPath)
+			}
+		case http.MethodPost:
+			if urlPath == "/v1/auth/token/renew-self" {
+				token := req.Header.Get(vault.AuthTypeHeader)
+				sampleTokenLookup, exists := tokenDataMap.Load(token)
+				if !exists {
+					rw.WriteHeader(http.StatusForbidden)
+					_, _ = rw.Write([]byte("permission denied"))
+				} else {
+					currentTTL := sampleTokenLookup.(vault.TokenLookupMetadata).Ttl
+					if currentTTL <= 0 {
+						// already expired
+						rw.WriteHeader(http.StatusForbidden)
+						_, _ = rw.Write([]byte("permission denied"))
+					} else {
+						tokenPeriod := sampleTokenLookup.(vault.TokenLookupMetadata).Period
+
+						tokenDataMap.Store(token, vault.TokenLookupMetadata{
+							Renewable: true,
+							Ttl:       tokenPeriod,
+							Period:    tokenPeriod,
+						})
+						rw.WriteHeader(http.StatusOK)
+						_, _ = rw.Write([]byte("token renewed"))
+					}
+				}
+			} else {
+				returnUnknownPath(rw, urlPath)
+			}
+		default:
+			rw.WriteHeader(http.StatusMethodNotAllowed)
+			_, _ = rw.Write([]byte("method not allowed!"))
+		}
+	}))
+
+	return server
+}
+
+func returnUnknownPath(rw http.ResponseWriter, urlPath string) {
+	rw.WriteHeader(http.StatusNotFound)
+	_, _ = rw.Write([]byte(fmt.Sprintf("Unknown urlPath: %s", urlPath)))
+}

--- a/internal/security/secret.go
+++ b/internal/security/secret.go
@@ -15,13 +15,17 @@
 package security
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/common"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/security/authtokenloader"
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/security/client"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/security/fileioperformer"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
 	"github.com/edgexfoundry/go-mod-secrets/pkg"
 	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
 )
@@ -39,6 +43,7 @@ func NewSecretProvider() *SecretProvider {
 
 // CreateClient creates a SecretClient to be used for obtaining secrets from a secrets store manager.
 func (s *SecretProvider) CreateClient(
+	ctx context.Context,
 	loggingClient logger.LoggingClient,
 	configuration common.ConfigurationStruct) bool {
 
@@ -50,7 +55,7 @@ func (s *SecretProvider) CreateClient(
 
 	// attempt to create a new SecretProvider client only if security is enabled.
 	if s.isSecurityEnabled() {
-		s.secretClient, err = vault.NewSecretClient(secretConfig)
+		s.secretClient, err = client.NewVault(ctx, secretConfig, loggingClient).Get(configuration.SecretStore)
 		if err != nil {
 			loggingClient.Error(fmt.Sprintf("unable to create SecretClient: %s", err.Error()))
 			return false

--- a/internal/security/secret_test.go
+++ b/internal/security/secret_test.go
@@ -1,0 +1,147 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package security
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/common"
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/security/mock"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSecretProvider(t *testing.T) {
+	secretProvider := NewSecretProvider()
+	assert.NotNil(t, secretProvider, "secretProvider from NewSecretProvider should not be nil")
+}
+
+func TestCreateClientFromSecretProvider(t *testing.T) {
+	// setup
+	tokenPeriod := 6
+	tokenDataMap := initTokenData(tokenPeriod)
+
+	server := mock.GetMockTokenServer(tokenDataMap)
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoErrorf(t, err, "error on parsing server url %s: %s", server.URL, err)
+
+	host, port, _ := net.SplitHostPort(serverURL.Host)
+	portNum, _ := strconv.Atoi(port)
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
+	lc := logger.NewClient("app_functions_sdk_go", false, "./test.log", "DEBUG")
+
+	testSecretStoreInfo := common.SecretStoreInfo{
+		SecretConfig: vault.SecretConfig{
+			Host:       host,
+			Port:       portNum,
+			Protocol:   "http",
+			ServerName: "mockVaultServer",
+		},
+	}
+
+	secretProvider := NewSecretProvider()
+	tests := []struct {
+		name        string
+		tokenFile   string
+		expectError bool
+	}{
+		{
+			name:        "Create client with test-token",
+			tokenFile:   "client/testdata/testToken.json",
+			expectError: false,
+		},
+		{
+			name:        "Create client with expired token, no TTL remaining",
+			tokenFile:   "client/testdata/expiredToken.json",
+			expectError: true,
+		},
+		{
+			name:        "Create client with non-existing TokenFile path",
+			tokenFile:   "client/testdata/non-existing.json",
+			expectError: true,
+		},
+		{
+			name:        "New secret client with no TokenFile",
+			tokenFile:   "",
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		// inject testing data
+		testSecretStoreInfo.TokenFile = test.tokenFile
+
+		config := common.ConfigurationStruct{
+			SecretStore: testSecretStoreInfo,
+		}
+
+		// pinned local test variables to avoid scopelint warnings
+		currentTest := test
+
+		t.Run(test.name, func(t *testing.T) {
+			ok := secretProvider.CreateClient(ctx, lc, config)
+
+			if currentTest.expectError {
+				assert.False(t, ok, "Expect error but none was received")
+			} else {
+				assert.True(t, ok, "Expect no error but got not ok")
+			}
+		})
+	}
+	// wait for some time to allow renewToken to be run if any
+	time.Sleep(7 * time.Second)
+}
+
+func initTokenData(tokenPeriod int) *sync.Map {
+	var tokenDataMap sync.Map
+
+	tokenDataMap.Store("test-token", vault.TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       tokenPeriod * 7 / 10,
+		Period:    tokenPeriod,
+	})
+	// expired token
+	tokenDataMap.Store("expired-token", vault.TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       0,
+		Period:    tokenPeriod,
+	})
+	// not renewable token
+	tokenDataMap.Store("unrenewable-token", vault.TokenLookupMetadata{
+		Renewable: false,
+		Ttl:       0,
+		Period:    tokenPeriod,
+	})
+
+	return &tokenDataMap
+}


### PR DESCRIPTION

Refactor and update the usage of NewSecretClient into its own package client Vault to be able to use the latest NewSecretClient constructor with NewSecretClientFactory

- unit tests and related test data added for refactor and updates
- a mock server is added into its own package to facilitate unit testings on both vaultclient_test and secret_test
- update go.mod to use go-mod-secrets version **v0.0.15**

Lots of testing related code added with minimal code changes and implementation.

Fixes issue #277

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The signature of `NewSecretClient()` of go-mod-secrets from older version (v0.0.14 and below) has been changed in version **v0.0.15**.  Current code for `vault.NewSecretClient()` no longer works for using version **v0.0.15**.

Issue Number:
#277 

## What is the new behavior?
In version `v0.0.15` of go-mod-secrets, the constructor to get `NewSecretClient` has been changed with getting a `NewSecretFactory()` call first and also the input arguments of `NewSecretClient` are expanded to take inputs and thus the changes are required here. Furthermore, there is a newly default implementation for token expired callback function.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information