### PR TITLE
Implement StoreSecrets endpoint in app functions SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ It is not uncommon to require your own API endpoints when building an app servic
 - /api/v1/metrics
 - /api/v1/config
 - /api/v1/trigger
-To add your own route, use the `AddRoute(route string, handler func(nethttp.ResponseWriter, *nethttp.Request), methods ...string)` function provided on the sdk. Here's an example:
+To add your own route, use the `AddRoute(route string, handler func(nethttp.ResponseWriter, *nethttp.Request), methods ...string) error` function provided on the sdk. Here's an example:
 ```golang
 edgexSdk.AddRoute("/myroute", func(writer http.ResponseWriter, req *http.Request) {
     context := req.Context().Value(appsdk.SDKKey).(*appsdk.AppFunctionsSDK) 
@@ -672,4 +672,18 @@ When running in insecure mode, the secrets are retrieved from the *Writable.Inse
 
 #### Storing Secrets
 
-<placeholder>
+When running an application service in secure mode, secrets for can be stored in the secret store (Vault) by making an HTTP `POST` call to `http://[host]:[port]/secrets`.  If running in insecure mode, secrets can be configured in consul or in the config yaml file, for more information on insecure secrets see [Insecure Secrets](#insecure-secrets).
+
+An example of the message body JSON is below.  Once a secret is stored, only the service that added the secret will be able to retrieve it.  For secret retrieval see [Getting Secrets](#getting-secrets) above.
+
+```json
+{
+  "path" : "MyPath",
+  "secrets" : [
+    {
+      "key" : "MySecretKey",
+      "value" : "MySecretValue"
+    }
+  ]
+}
+```

--- a/appsdk/sdk_test.go
+++ b/appsdk/sdk_test.go
@@ -42,8 +42,9 @@ import (
 
 var lc logger.LoggingClient
 
-func init() {
+func TestMain(m *testing.M) {
 	lc = logger.NewClient("app_functions_sdk_go", false, "./test.log", "DEBUG")
+	m.Run()
 }
 
 func IsInstanceOf(objectPtr, typePtr interface{}) bool {
@@ -51,7 +52,7 @@ func IsInstanceOf(objectPtr, typePtr interface{}) bool {
 }
 func TestAddRoute(t *testing.T) {
 	router := mux.NewRouter()
-	ws := webserver.NewWebServer(&common.ConfigurationStruct{}, lc, router)
+	ws := webserver.NewWebServer(&common.ConfigurationStruct{}, nil, lc, router)
 
 	sdk := AppFunctionsSDK{
 		webserver: ws,

--- a/internal/security/credentials_test.go
+++ b/internal/security/credentials_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -233,19 +234,16 @@ func tearDownGetInsecureSecrets(t *testing.T, origEnv string) {
 }
 
 func newMockSecretProvider(configuration *common.ConfigurationStruct) *SecretProvider {
-	return &SecretProvider{
-		secretClient:  &mockSecretClient{},
-		secretsCache:  make(map[string]map[string]string),
-		configuration: configuration,
-	}
+	logClient := logger.NewClient("app_functions_sdk_go", false, "./test.log", "DEBUG")
+	mockSP := NewSecretProvider(logClient, configuration)
+	mockSP.secretClient = &mockSecretClient{}
+	return mockSP
 }
 
 func (s *mockSecretClient) GetSecrets(path string, keys ...string) (map[string]string, error) {
-
 	return getSecretsTestData[s.testIndex].expectedSecrets, getSecretsTestData[s.testIndex].expectedErr
 }
 
 func (s *mockSecretClient) StoreSecrets(path string, secrets map[string]string) error {
-
 	return nil
 }

--- a/internal/security/secret_test.go
+++ b/internal/security/secret_test.go
@@ -37,11 +37,14 @@ import (
 )
 
 func TestNewSecretProvider(t *testing.T) {
-	secretProvider := NewSecretProvider()
+	config := &common.ConfigurationStruct{}
+	lc := logger.NewClient("app_functions_sdk_go", false, "./test.log", "DEBUG")
+
+	secretProvider := NewSecretProvider(lc, config)
 	assert.NotNil(t, secretProvider, "secretProvider from NewSecretProvider should not be nil")
 }
 
-func TestCreateClientFromSecretProvider(t *testing.T) {
+func TestInitializeClientFromSecretProvider(t *testing.T) {
 	// setup
 	tokenPeriod := 6
 	tokenDataMap := initTokenData(tokenPeriod)
@@ -69,7 +72,6 @@ func TestCreateClientFromSecretProvider(t *testing.T) {
 		},
 	}
 
-	secretProvider := NewSecretProvider()
 	tests := []struct {
 		name        string
 		tokenFile   string
@@ -101,7 +103,7 @@ func TestCreateClientFromSecretProvider(t *testing.T) {
 		// inject testing data
 		testSecretStoreInfo.TokenFile = test.tokenFile
 
-		config := common.ConfigurationStruct{
+		config := &common.ConfigurationStruct{
 			SecretStore: testSecretStoreInfo,
 		}
 
@@ -109,7 +111,8 @@ func TestCreateClientFromSecretProvider(t *testing.T) {
 		currentTest := test
 
 		t.Run(test.name, func(t *testing.T) {
-			ok := secretProvider.CreateClient(ctx, lc, config)
+			secretProvider := NewSecretProvider(lc, config)
+			ok := secretProvider.Initialize(ctx)
 
 			if currentTest.expectError {
 				assert.False(t, ok, "Expect error but none was received")

--- a/internal/webserver/types.go
+++ b/internal/webserver/types.go
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package webserver
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// SecretData the structure to store post secret requests
+type SecretData struct {
+	Path    string     `json:"path"`
+	Secrets []KeyValue `json:"secrets"`
+}
+
+// KeyValue stores the key value pair of the secret
+type KeyValue struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func (secretData SecretData) validateSecretData() error {
+
+	if len(secretData.Secrets) == 0 {
+		return errors.New("Missing required field 'Secrets'")
+	}
+
+	for _, kv := range secretData.Secrets {
+		if kv.Key == "" {
+			return errors.New("'Secrets' key should not be empty")
+		}
+	}
+	if _, err := url.Parse(secretData.Path); err != nil {
+		return fmt.Errorf("'Path' is invalid %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
There is currently no way to push secrets via an app function. 

Issue Number: [269](https://github.com/edgexfoundry/app-functions-sdk-go/issues/269)


## What is the new behavior?
Now users can use the secret client to push secrets into Vault.  The secrets pushed in are only available to the app function that pushed them in.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Also included is a slight change to the 'AddRoute' function definition now this function returns an error as opposed before when the error messages were suppressed. 

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information