### PR TITLE
feat(sdk): Add full path to secrets api route

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,7 +678,7 @@ An example of the message body JSON is below.  Once a secret is stored, only the
 
 ```json
 {
-  "path" : "MyPath",
+  "path" : "/MyPath",
   "secrets" : [
     {
       "key" : "MySecretKey",

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -16,7 +16,11 @@
 
 package internal
 
-import "time"
+import (
+	"time"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+)
 
 const (
 	BootTimeoutDefault   = time.Duration(30 * time.Second)
@@ -33,3 +37,6 @@ var SDKVersion string = "0.0.0"
 
 // ApplicationVersion indicates the version of the application itself, not the SDK - will be overwritten by build
 var ApplicationVersion string = "0.0.0"
+
+// SecretsAPIRoute api route for posting secrets
+var SecretsAPIRoute = clients.ApiBase + "/secrets"

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -196,7 +196,7 @@ func TestPostSecretRoute(t *testing.T) {
 	for _, test := range tests {
 		currentTest := test
 		t.Run(test.name, func(t *testing.T) {
-			req, _ := http.NewRequest("POST", secretsRoute, bytes.NewReader(currentTest.payload))
+			req, _ := http.NewRequest("POST", internal.SecretsAPIRoute, bytes.NewReader(currentTest.payload))
 			rr := httptest.NewRecorder()
 			webserver.router.ServeHTTP(rr, req)
 			assert.Equal(t, currentTest.expectedStatus, rr.Result().StatusCode, "Expected secret doesn't match postSecret")


### PR DESCRIPTION
This pr adds the full path to the route and updates the unit tests accordingly.

closes #294

Signed-off-by: adam-w-mitchell <adam.w.mitchell@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, the api route is simply /secrets it should be /api/v1/secrets

Issue Number: 294


## What is the new behavior?
Fixes the route on secrets api

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information