### PR TITLE
refactor(tests): Fix order of expected vs actual and other clean up

### DIFF
--- a/internal/config/environment_test.go
+++ b/internal/config/environment_test.go
@@ -74,7 +74,7 @@ func TestKeyMatchOverwritesValue(t *testing.T) {
 
 			result := sut.OverrideFromEnvironment(tree)
 
-			assert.Equal(t, result.Get(test.key), test.envValue)
+			assert.Equal(t, test.envValue, result.Get(test.key))
 		})
 	}
 }
@@ -97,7 +97,7 @@ func TestNonMatchingKeyDoesNotOverwritesValue(t *testing.T) {
 
 			result := sut.OverrideFromEnvironment(tree)
 
-			assert.Equal(t, result.Get(test.key), test.envValue)
+			assert.Equal(t, test.envValue, result.Get(test.key))
 		})
 	}
 }
@@ -131,9 +131,9 @@ func TestEnvVariableUpdatesRegistryInfo(t *testing.T) {
 
 	registryInfo = sut.OverrideRegistryInfoFromEnvironment(registryInfo)
 
-	assert.Equal(t, registryInfo.Host, expectedRegistryHostValue)
-	assert.Equal(t, registryInfo.Port, expectedRegistryPortValue)
-	assert.Equal(t, registryInfo.Type, expectedRegistryTypeValue)
+	assert.Equal(t, expectedRegistryHostValue, registryInfo.Host)
+	assert.Equal(t, expectedRegistryPortValue, registryInfo.Port)
+	assert.Equal(t, expectedRegistryTypeValue, registryInfo.Type)
 }
 
 func TestEnvVariableUpdatesServiceInfo(t *testing.T) {
@@ -147,9 +147,9 @@ func TestEnvVariableUpdatesServiceInfo(t *testing.T) {
 
 	serviceInfo = sut.OverrideServiceInfoFromEnvironment(serviceInfo)
 
-	assert.Equal(t, serviceInfo.Host, expectedServiceHostValue)
-	assert.Equal(t, serviceInfo.Port, expectedServicePortValue)
-	assert.Equal(t, serviceInfo.Protocol, expectedServiceProtocolValue)
+	assert.Equal(t, expectedServiceHostValue, serviceInfo.Host)
+	assert.Equal(t, expectedServicePortValue, serviceInfo.Port)
+	assert.Equal(t, expectedServiceProtocolValue, serviceInfo.Protocol)
 }
 
 func TestNoEnvVariableDoesNotUpdateRegistryInfo(t *testing.T) {
@@ -158,7 +158,7 @@ func TestNoEnvVariableDoesNotUpdateRegistryInfo(t *testing.T) {
 
 	registryInfo = sut.OverrideRegistryInfoFromEnvironment(registryInfo)
 
-	assert.Equal(t, registryInfo.Host, defaultHostValue)
-	assert.Equal(t, registryInfo.Port, defaultPortValue)
-	assert.Equal(t, registryInfo.Type, defaultTypeValue)
+	assert.Equal(t, defaultHostValue, registryInfo.Host)
+	assert.Equal(t, defaultPortValue, registryInfo.Port)
+	assert.Equal(t, defaultTypeValue, registryInfo.Type)
 }

--- a/internal/runtime/storeforward_test.go
+++ b/internal/runtime/storeforward_test.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -52,13 +54,9 @@ func TestProcessRetryItems(t *testing.T) {
 		targetTransformWasCalled = true
 
 		actualPayload, ok := params[0].([]byte)
-		if !ok {
-			t.Fatal("Expected []byte payload")
-		}
 
-		if !assert.Equal(t, expectedPayload, string(actualPayload)) {
-			t.Fatal()
-		}
+		require.True(t, ok, "Expected []byte payload")
+		require.Equal(t, expectedPayload, string(actualPayload))
 
 		return false, nil
 	}

--- a/internal/security/authtokenloader/methods_test.go
+++ b/internal/security/authtokenloader/methods_test.go
@@ -39,7 +39,7 @@ func TestReadCreateTokenJSON(t *testing.T) {
 	p := NewAuthTokenLoader(mockFileIoPerformer)
 
 	token, err := p.Load("/dev/null")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expectedToken, token)
 }
 
@@ -51,7 +51,7 @@ func TestReadVaultInitJSON(t *testing.T) {
 	p := NewAuthTokenLoader(mockFileIoPerformer)
 
 	token, err := p.Load("/dev/null")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expectedToken, token)
 }
 

--- a/internal/security/credentials_test.go
+++ b/internal/security/credentials_test.go
@@ -43,7 +43,7 @@ var getSecretsTestData []getSecretsTestObj
 
 func TestMain(m *testing.M) {
 	getSecretsTestData = []getSecretsTestObj{
-		getSecretsTestObj{
+		{
 			testName:          "Empty path",
 			path:              "",
 			keys:              []string{"key1", "key2"},
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 			expectedErr:       nil,
 			resetSecretsCache: true,
 		},
-		getSecretsTestObj{
+		{
 			testName:          "Empty path, keys list empty",
 			path:              "",
 			keys:              []string{},
@@ -59,7 +59,7 @@ func TestMain(m *testing.M) {
 			expectedErr:       nil,
 			resetSecretsCache: true,
 		},
-		getSecretsTestObj{
+		{
 			testName:          "Fake path",
 			path:              "fakepath",
 			keys:              []string{"key1", "key2"},
@@ -67,7 +67,7 @@ func TestMain(m *testing.M) {
 			expectedErr:       errors.New("Error, path (fakepath) doesn't exist in secret store"),
 			resetSecretsCache: true,
 		},
-		getSecretsTestObj{
+		{
 			testName:          "Empty keys",
 			path:              "db_secrets",
 			keys:              []string{"", ""},
@@ -75,8 +75,7 @@ func TestMain(m *testing.M) {
 			expectedErr:       errors.New("No value for the keys: [,] exists"),
 			resetSecretsCache: true,
 		},
-
-		getSecretsTestObj{
+		{
 			testName:          "One valid key, one empty key",
 			path:              "db_secrets",
 			keys:              []string{"key1", ""},
@@ -84,7 +83,7 @@ func TestMain(m *testing.M) {
 			expectedErr:       errors.New("No value for the keys: [] exists"),
 			resetSecretsCache: true,
 		},
-		getSecretsTestObj{
+		{
 			testName:          "One valid key one not found key",
 			path:              "db_secrets",
 			keys:              []string{"key1", "notFoundKey"},
@@ -92,7 +91,7 @@ func TestMain(m *testing.M) {
 			expectedErr:       errors.New("No value for the keys: [notFoundKey] exists"),
 			resetSecretsCache: true,
 		},
-		getSecretsTestObj{
+		{
 			testName:          "Not found key",
 			path:              "db_secrets",
 			keys:              []string{"notFoundKey"},
@@ -100,7 +99,7 @@ func TestMain(m *testing.M) {
 			expectedErr:       errors.New("No value for the keys: [notFoundKey] exists"),
 			resetSecretsCache: true,
 		},
-		getSecretsTestObj{
+		{
 			testName:          "Two missing keys",
 			path:              "db_secrets",
 			keys:              []string{"notFoundKey1", "notFoundKey2"},
@@ -108,7 +107,7 @@ func TestMain(m *testing.M) {
 			expectedErr:       errors.New("No value for the keys: [notFoundKey1,notFoundKey2] exists"),
 			resetSecretsCache: true,
 		},
-		getSecretsTestObj{
+		{
 			testName:          "Valid key",
 			path:              "db_secrets",
 			keys:              []string{"key1"},
@@ -116,7 +115,7 @@ func TestMain(m *testing.M) {
 			expectedErr:       nil,
 			resetSecretsCache: true,
 		},
-		getSecretsTestObj{
+		{
 			testName:          "Two valid keys",
 			path:              "db_secrets",
 			keys:              []string{"key1", "key2"},
@@ -124,7 +123,7 @@ func TestMain(m *testing.M) {
 			expectedErr:       nil,
 			resetSecretsCache: true,
 		},
-		getSecretsTestObj{
+		{
 			testName:          "Valid key (key1 not cached)",
 			path:              "db_secrets",
 			keys:              []string{"key1"},
@@ -132,7 +131,7 @@ func TestMain(m *testing.M) {
 			expectedErr:       nil,
 			resetSecretsCache: false,
 		},
-		getSecretsTestObj{
+		{
 			testName:          "One valid key (key1 already cached)",
 			path:              "db_secrets",
 			keys:              []string{"key1"},
@@ -140,7 +139,7 @@ func TestMain(m *testing.M) {
 			expectedErr:       nil,
 			resetSecretsCache: false,
 		},
-		getSecretsTestObj{
+		{
 			testName:          "Two valid keys (key1 cached, key2 not cached)",
 			path:              "db_secrets",
 			keys:              []string{"key1", "key2"},

--- a/internal/security/fileioperformer/methods_test.go
+++ b/internal/security/fileioperformer/methods_test.go
@@ -36,7 +36,7 @@ func TestFileIoPerformerReader(t *testing.T) {
 
 	if isLinux() {
 		reader, err := fileio.OpenFileReader("/dev/null", os.O_RDONLY, 0400)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, fileio)
 		assert.NotNil(t, reader)
 	}
@@ -48,7 +48,7 @@ func TestFileIoPerformerWriter(t *testing.T) {
 
 	if isLinux() {
 		writer, err := fileio.OpenFileWriter("/dev/null", os.O_RDONLY, 0400)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, fileio)
 		assert.NotNil(t, writer)
 	}
@@ -60,7 +60,7 @@ func TestFileIoPerformerMkdirAll(t *testing.T) {
 
 	if isLinux() {
 		err := fileio.MkdirAll("/tmp", 0777)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}
 }
 

--- a/internal/store/db/mongo/models/storedobject_test.go
+++ b/internal/store/db/mongo/models/storedobject_test.go
@@ -18,10 +18,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/store/contracts"
 
-	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/google/uuid"
 )
 
 var TestObjectIDNil = primitive.NilObjectID
@@ -125,17 +128,14 @@ func TestFromContract(t *testing.T) {
 		t.Run(test.testName, func(tt *testing.T) {
 			actual := StoredObject{}
 			err := actual.FromContract(test.fromContract)
-			if test.expectedError && err == nil {
-				t.Fatal("Expected an error")
+			if test.expectedError {
+				require.Error(t, err)
+				return // test complete
+			} else {
+				require.NoError(t, err)
 			}
 
-			if !test.expectedError && err != nil {
-				t.Fatalf("Unexpectedly encountered error: %s", err.Error())
-			}
-
-			if !reflect.DeepEqual(actual, test.expectedResult) {
-				t.Fatalf("Return value doesn't match expected.\nExpected: %v\nActual: %v\n", test.expectedResult, actual)
-			}
+			require.Equal(t, test.expectedResult, actual)
 		})
 	}
 }

--- a/internal/store/db/mongo/store_test.go
+++ b/internal/store/db/mongo/store_test.go
@@ -21,8 +21,9 @@
 package mongo
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/store/contracts"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/store/db"
@@ -125,23 +126,19 @@ func TestClient_NewClient(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			client, connectErr := NewClient(test.config)
 
+			if test.expectedError {
+				require.Error(t, connectErr)
+			} else {
+				require.NoError(t, connectErr)
+			}
+
 			if client != nil {
 				disconnectErr := client.Disconnect()
-				if test.expectedError && disconnectErr == nil {
-					t.Fatal("Expected an error")
+				if test.expectedError {
+					require.Error(t, disconnectErr)
+				} else {
+					require.NoError(t, disconnectErr)
 				}
-
-				if !test.expectedError && disconnectErr != nil {
-					t.Fatalf("Unexpectedly encountered error: %s", disconnectErr.Error())
-				}
-			}
-
-			if test.expectedError && connectErr == nil {
-				t.Fatal("Expected an error")
-			}
-
-			if !test.expectedError && connectErr != nil {
-				t.Fatalf("Unexpectedly encountered error: %s", connectErr.Error())
 			}
 		})
 	}
@@ -214,20 +211,17 @@ func TestClient_Store(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := client.Store(test.toStore)
-			if test.expectedError && err == nil {
-				t.Fatal("Expected an error")
-			}
 
-			if !test.expectedError && err != nil {
-				t.Fatalf("Unexpectedly encountered error: %s", err.Error())
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
 
 	err := client.Disconnect()
-	if err != nil {
-		t.Fatalf("Unexpectedly encountered error: %s", err.Error())
-	}
+	require.NoError(t, err)
 }
 
 func TestClient_RetrieveFromStore(t *testing.T) {
@@ -276,24 +270,18 @@ func TestClient_RetrieveFromStore(t *testing.T) {
 
 			actual, err := client.RetrieveFromStore(test.key)
 
-			if test.expectedError && err == nil {
-				t.Fatal("Expected an error")
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
-			if !test.expectedError && err != nil {
-				t.Fatalf("Unexpectedly encountered error: %s", err.Error())
-			}
-
-			if len(actual) != len(test.toStore) {
-				t.Fatalf("Returned slice length doesn't match expected.\nExpected: %v\nActual: %v\n", len(test.toStore), len(actual))
-			}
+			require.NotEqual(t, len(test.toStore), len(actual))
 		})
 	}
 
 	err := client.Disconnect()
-	if err != nil {
-		t.Fatalf("Unexpectedly encountered error: %s", err.Error())
-	}
+	require.NoError(t, err)
 }
 
 func TestClient_Update(t *testing.T) {
@@ -341,32 +329,23 @@ func TestClient_Update(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			err := client.Update(test.expectedVal)
 
-			if test.expectedError && err == nil {
-				t.Fatal("Expected an error")
-			}
-
-			if !test.expectedError && err != nil {
-				t.Fatalf("Unexpectedly encountered error: %s", err.Error())
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
 			// only do a lookup on tests that we aren't expecting errors
 			if !test.expectedError {
 				actual, _ := client.RetrieveFromStore(test.expectedVal.AppServiceKey)
-				if actual == nil {
-					t.Fatal("No objects retrieved from store")
-				}
-
-				if !reflect.DeepEqual(actual[0], test.expectedVal) {
-					t.Fatalf("Return value doesn't match expected.\nExpected: %v\nActual: %v\n", test.expectedVal, actual[0])
-				}
+				require.NotNil(t, actual, "No objects retrieved from store")
+				require.Equal(t, test.expectedVal, actual[0])
 			}
 		})
 	}
 
 	err := client.Disconnect()
-	if err != nil {
-		t.Fatalf("Unexpectedly encountered error: %s", err.Error())
-	}
+	require.NoError(t, err)
 }
 
 func TestClient_RemoveFromStore(t *testing.T) {
@@ -408,26 +387,20 @@ func TestClient_RemoveFromStore(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			err := client.RemoveFromStore(test.testObject)
 
-			if test.expectedError && err == nil {
-				t.Fatal("Expected an error")
-			}
-
-			if !test.expectedError && err != nil {
-				t.Fatalf("Unexpectedly encountered error: %s", err.Error())
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
 			// only do a lookup on tests that we aren't expecting errors
 			if !test.expectedError {
 				actual, _ := client.RetrieveFromStore(test.testObject.AppServiceKey)
-				if actual != nil {
-					t.Fatal("Object retrieved, should have been nil")
-				}
+				require.NotNil(t, actual, "Object retrieved, should have been nil")
 			}
 		})
 	}
 
 	err := client.Disconnect()
-	if err != nil {
-		t.Fatalf("Unexpectedly encountered error: %s", err.Error())
-	}
+	require.NoError(t, err)
 }

--- a/internal/trigger/messagebus/messaging_test.go
+++ b/internal/trigger/messagebus/messaging_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/common"
 	"github.com/edgexfoundry/app-functions-sdk-go/internal/runtime"
@@ -71,7 +73,6 @@ func TestInitialize(t *testing.T) {
 	assert.Equal(t, 1, len(trigger.topics))
 	assert.Equal(t, "events", trigger.topics[0].Topic)
 	assert.NotNil(t, trigger.topics[0].Messages)
-
 }
 
 func TestInitializeBadConfiguration(t *testing.T) {
@@ -101,7 +102,7 @@ func TestInitializeBadConfiguration(t *testing.T) {
 
 	trigger := Trigger{Configuration: config, Runtime: runtime, EdgeXClients: common.EdgeXClients{LoggingClient: logClient}}
 	err := trigger.Initialize(&sync.WaitGroup{}, context.Background())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestInitializeAndProcessEventWithNoOutput(t *testing.T) {
@@ -163,19 +164,14 @@ func TestInitializeAndProcessEventWithNoOutput(t *testing.T) {
 	}
 
 	testClient, err := messaging.NewMessageClient(testClientConfig)
-	if !assert.NoError(t, err, "Unable to create to publisher") {
-		t.Fatal()
-	}
-
+	require.NoError(t, err, "Unable to create to publisher")
 	assert.False(t, transformWasCalled)
+
 	err = testClient.Publish(message, "") //transform1 should be called after this executes
-	if !assert.NoError(t, err, "Failed to publish message") {
-		t.Fatal()
-	}
+	require.NoError(t, err, "Failed to publish message")
 
 	time.Sleep(3 * time.Second)
 	assert.True(t, transformWasCalled, "Transform never called")
-
 }
 
 func TestInitializeAndProcessEventWithOutput(t *testing.T) {
@@ -236,9 +232,7 @@ func TestInitializeAndProcessEventWithOutput(t *testing.T) {
 		Type: "zero",
 	}
 	testClient, err := messaging.NewMessageClient(testClientConfig) //new client to publish & subscribe
-	if !assert.NoError(t, err, "Failed to create test client") {
-		t.Fatal()
-	}
+	require.NoError(t, err, "Failed to create test client")
 
 	testTopics := []types.TopicChannel{{Topic: trigger.Configuration.Binding.PublishTopic, Messages: make(chan types.MessageEnvelope)}}
 	testMessageErrors := make(chan error)
@@ -255,13 +249,10 @@ func TestInitializeAndProcessEventWithOutput(t *testing.T) {
 
 	assert.False(t, transformWasCalled)
 	err = testClient.Publish(message, "SubscribeTopic")
-	if !assert.NoError(t, err, "Failed to publish message") {
-		t.Fatal()
-	}
+	require.NoError(t, err, "Failed to publish message")
+
 	time.Sleep(3 * time.Second)
-	if !assert.True(t, transformWasCalled, "Transform never called") {
-		t.Fatal()
-	}
+	require.True(t, transformWasCalled, "Transform never called")
 
 	receiveMessage := true
 

--- a/pkg/transforms/compression_test.go
+++ b/pkg/transforms/compression_test.go
@@ -25,6 +25,8 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,32 +43,21 @@ func TestGzip(t *testing.T) {
 	assert.True(t, continuePipeline)
 
 	compressed, err := base64.StdEncoding.DecodeString(string(result.([]byte)))
-	if err != nil {
-		t.Fatal("Error base64 ", err)
-	}
+	require.NoError(t, err)
 
 	var buf bytes.Buffer
 	buf.Write(compressed)
 
 	zr, err := gzip.NewReader(&buf)
-	if err != nil {
-		t.Fatal("Error decoding buffer ", err)
-	}
-	decoded, err := ioutil.ReadAll(zr)
-	if err != nil {
-		t.Fatalf("ReadAll: %v", err)
-	}
+	require.NoError(t, err)
 
-	if string(decoded) != clearString {
-		t.Fatal("Decoded string ", result.([]byte), " is not ", clearString)
-	}
+	decoded, err := ioutil.ReadAll(zr)
+	require.NoError(t, err)
+	require.Equal(t, clearString, string(decoded))
 
 	continuePipeline2, result2 := comp.CompressWithGZIP(context, []byte(clearString))
 	assert.True(t, continuePipeline2)
-
-	if !bytes.Equal(result.([]byte), result2.([]byte)) {
-		t.Fatal("Output should be the same", result.([]byte), " is not ", result2.([]byte))
-	}
+	assert.Equal(t, result.([]byte), result2.([]byte))
 }
 
 func TestZlib(t *testing.T) {
@@ -74,36 +65,24 @@ func TestZlib(t *testing.T) {
 	comp := NewCompression()
 	continuePipeline, result := comp.CompressWithZLIB(context, []byte(clearString))
 	assert.True(t, continuePipeline)
-
-	assert.NotNil(t, result)
+	require.NotNil(t, result)
 
 	compressed, err := base64.StdEncoding.DecodeString(string(result.([]byte)))
-	if err != nil {
-		t.Fatal("Error base64 ", err)
-	}
+	require.NoError(t, err)
 
 	var buf bytes.Buffer
 	buf.Write(compressed)
 
 	zr, err := zlib.NewReader(&buf)
-	if err != nil {
-		t.Fatal("Error decoding buffer ", err)
-	}
-	decoded, err := ioutil.ReadAll(zr)
-	if err != nil {
-		t.Fatalf("ReadAll: %v", err)
-	}
+	require.NoError(t, err)
 
-	if string(decoded) != clearString {
-		t.Fatal("Decoded string ", result.([]byte), " is not ", clearString)
-	}
+	decoded, err := ioutil.ReadAll(zr)
+	require.NoError(t, err)
+	require.Equal(t, clearString, string(decoded))
 
 	continuePipeline2, result2 := comp.CompressWithZLIB(context, []byte(clearString))
 	assert.True(t, continuePipeline2)
-
-	if !bytes.Equal(result.([]byte), result2.([]byte)) {
-		t.Fatal("Output should be the same", result.([]byte), " is not ", result2.([]byte))
-	}
+	assert.Equal(t, result.([]byte), result2.([]byte))
 }
 
 var result []byte

--- a/pkg/transforms/conversion_test.go
+++ b/pkg/transforms/conversion_test.go
@@ -19,6 +19,8 @@ package transforms
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
@@ -86,10 +88,7 @@ func TestTransformToXMLMultipleParametersValid(t *testing.T) {
 	expectedResult := `<Event><ID></ID><Pushed>0</Pushed><Device>id1</Device><Created>0</Created><Modified>0</Modified><Origin>0</Origin></Event>`
 	conv := NewConversion()
 	continuePipeline, result := conv.TransformToXML(context, eventIn, "", "", "")
-	if result == nil {
-		t.Fatal("result should not be nil")
-	}
-
+	require.NotNil(t, result)
 	assert.True(t, continuePipeline)
 	assert.Equal(t, expectedResult, result.(string))
 }
@@ -136,9 +135,7 @@ func TestTransformToJSONNoEvent(t *testing.T) {
 func TestTransformToJSONNotAnEvent(t *testing.T) {
 	conv := NewConversion()
 	continuePipeline, result := conv.TransformToJSON(context, "")
-	if result.(error).Error() != "Unexpected type received" {
-		t.Fatal("Should have an error when wrong type was passed")
-	}
+	require.EqualError(t, result.(error), "Unexpected type received")
 	assert.False(t, continuePipeline)
 
 }

--- a/pkg/transforms/http_test.go
+++ b/pkg/transforms/http_test.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -65,9 +67,7 @@ func TestHTTPPost(t *testing.T) {
 	defer ts.Close()
 
 	url, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatal("Could not parse url")
-	}
+	require.NoError(t, err)
 
 	tests := []struct {
 		Name          string
@@ -98,7 +98,7 @@ func TestHTTPPostNoParameterPassed(t *testing.T) {
 
 	assert.False(t, continuePipeline, "Pipeline should stop")
 	assert.Error(t, result.(error), "Result should be an error")
-	assert.Equal(t, result.(error).Error(), "No Data Received")
+	assert.Equal(t, "No Data Received", result.(error).Error())
 }
 
 func TestHTTPPostInvalidParameter(t *testing.T) {
@@ -110,6 +110,6 @@ func TestHTTPPostInvalidParameter(t *testing.T) {
 
 	assert.False(t, continuePipeline, "Pipeline should stop")
 	assert.Error(t, result.(error), "Result should be an error")
-	assert.Equal(t, result.(error).Error(), "marshaling input data to JSON failed, "+
-		"passed in data must be of type []byte, string, or support marshaling to JSON")
+	assert.Equal(t, "marshaling input data to JSON failed, "+
+		"passed in data must be of type []byte, string, or support marshaling to JSON", result.(error).Error())
 }

--- a/pkg/transforms/mqtt_test.go
+++ b/pkg/transforms/mqtt_test.go
@@ -24,6 +24,8 @@ package transforms
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,7 +60,7 @@ func TestMQTTSend(t *testing.T) {
 	dataToSend := "SOME DATA TO SEND"
 	continuePipeline, result := sender.MQTTSend(context, dataToSend)
 	assert.True(t, continuePipeline, "Should Continue Pipeline")
-	assert.Equal(t, nil, result, "Should be nil")
+	assert.Nil(t, result, "Should be nil")
 
 }
 
@@ -83,11 +85,8 @@ func TestMQTTSendInvalidData(t *testing.T) {
 
 	dataToSend := RandomObject{something: "SOME DATA TO SEND"}
 	continuePipeline, result := sender.MQTTSend(context, dataToSend)
-	if !assert.False(t, continuePipeline, "Should Not Continue Pipeline") {
-		t.Fatal()
-	}
-	assert.Equal(t, expected, result.(error).Error())
-
+	require.False(t, continuePipeline, "Should Not Continue Pipeline")
+	assert.EqualError(t, result.(error), expected)
 }
 
 func TestMQTTSendPersistData(t *testing.T) {
@@ -97,9 +96,7 @@ func TestMQTTSendPersistData(t *testing.T) {
 
 	dataToSend := "Random data"
 	continuePipeline, result := sender.MQTTSend(context, dataToSend)
-	if !assert.False(t, continuePipeline, "Should Not Continue Pipeline") {
-		t.Fatal()
-	}
+	require.False(t, continuePipeline, "Should Not Continue Pipeline")
 	assert.Contains(t, result.(error).Error(), expected)
 	assert.NotNil(t, context.RetryData)
 }

--- a/pkg/transforms/outputdata_test.go
+++ b/pkg/transforms/outputdata_test.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
@@ -39,13 +41,11 @@ func TestSetOutputDataString(t *testing.T) {
 }
 
 func TestSetOutputDataBytes(t *testing.T) {
-
 	var expected []byte
 	expected = []byte(`<Event><ID></ID><Pushed>0</Pushed><Device>id1</Device><Created>0</Created><Modified>0</Modified><Origin>0</Origin></Event>`)
 	target := NewOutputData()
 
 	continuePipeline, result := target.SetOutputData(context, expected)
-
 	assert.True(t, continuePipeline)
 	assert.NotNil(t, result)
 
@@ -63,7 +63,6 @@ func TestSetOutputDataEvent(t *testing.T) {
 	expected, _ := json.Marshal(eventIn)
 
 	continuePipeline, result := target.SetOutputData(context, eventIn)
-
 	assert.True(t, continuePipeline)
 	assert.NotNil(t, result)
 
@@ -74,7 +73,6 @@ func TestSetOutputDataEvent(t *testing.T) {
 func TestSetOutputDataNoData(t *testing.T) {
 	target := NewOutputData()
 	continuePipeline, result := target.SetOutputData(context)
-
 	assert.Nil(t, result)
 	assert.False(t, continuePipeline)
 }
@@ -84,7 +82,6 @@ func TestSetOutputDataMultipleParametersValid(t *testing.T) {
 	target := NewOutputData()
 
 	continuePipeline, result := target.SetOutputData(context, expected, "", "", "")
-
 	assert.True(t, continuePipeline)
 	assert.NotNil(t, result)
 
@@ -97,13 +94,7 @@ func TestSetOutputDataBadType(t *testing.T) {
 
 	// Channels are not marshalable to JSON and generate an error
 	continuePipeline, result := target.SetOutputData(context, make(chan int))
-
 	assert.False(t, continuePipeline)
-	if !assert.NotNil(t, result) {
-		t.Fatal()
-	}
-
-	if !assert.Contains(t, result.(error).Error(), "passed in data must be of type") {
-		t.Fatal()
-	}
+	require.NotNil(t, result)
+	assert.Contains(t, result.(error).Error(), "passed in data must be of type")
 }

--- a/pkg/util/helpers_test.go
+++ b/pkg/util/helpers_test.go
@@ -31,11 +31,11 @@ func TestSplitComma(t *testing.T) {
 	results := strings.FieldsFunc(commaDelimmited, SplitComma)
 	// Should have 4 elements (space counts as an element)
 	assert.Equal(t, 5, len(results))
-	assert.Equal(t, results[0], "Hel lo")
-	assert.Equal(t, results[1], " ")
-	assert.Equal(t, results[2], "Test")
-	assert.Equal(t, results[3], "Hi")
-	assert.Equal(t, results[4], " ")
+	assert.Equal(t, "Hel lo", results[0])
+	assert.Equal(t, " ", results[1])
+	assert.Equal(t, "Test", results[2])
+	assert.Equal(t, "Hi", results[3])
+	assert.Equal(t, " ", results[4])
 }
 func TestSplitCommaEmpty(t *testing.T) {
 	commaDelimmited := ""
@@ -49,8 +49,8 @@ func TestDeleteEmptyAndTrim(t *testing.T) {
 	results := DeleteEmptyAndTrim(strings)
 	// Should have 4 elements (space counts as an element)
 	assert.Equal(t, 2, len(results))
-	assert.Equal(t, results[0], "Hel lo")
-	assert.Equal(t, results[1], "test")
+	assert.Equal(t, "Hel lo", results[0])
+	assert.Equal(t, "test", results[1])
 }
 
 func TestCoerceTypeStringToByteArray(t *testing.T) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Many tests using assert.Equal() have the expected & actual parameters swapped.
Many tests use the follow pattern to fail fatal:
```
if !assert.(..) {
    t.Fatal()
}
```
Many tests use assert.Nil() to check validate errors

Issue Number: #286 

## What is the new behavior?

assert.Equal() parameter order correct
require.() used instead of conditional to fail fatal
require.NoError()/require.Error() used to validate errors and fail fatal

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

None

## Other information