### PR TITLE
feat(http-export): add support for auth token in header

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,10 +335,13 @@ These are functions that enable interactions with the CoreData REST API.
     > NOTE: If validation is turned on in CoreServices then your `deviceName` and `readingName` must exist in the CoreMetadata and be properly registered in EdgeX. 
 
 ### Export Functions
-There are two export functions included in the SDK that can be added to your pipeline. 
-- `NewHTTPSender(url string, mimeType string, persistOnError bool)` - This function returns a `HTTPSender` instance initialized with the passed in url, mime type and persistOnError values. This `HTTPSender` instance is used to access the following functions that will use the required url and optional mime type and persistOnError:
+There are few export functions included in the SDK that can be added to your pipeline. 
+- `NewHTTPSender(url string, mimeType string, persistOnError bool)` - This function returns a `HTTPSender` instance initialized with the passed in url, mime type and persistOnError values. 
+- `NewHTTPSenderWithSecretHeader(url string, mimeType string, persistOnError bool, httpHeaderSecretName string, secretPath string)` - This function returns a `HTTPSender` instance similar to the above function however will set up the `HTTPSender` to add a header to the HTTP request using the `httpHeaderSecretName` as both the header key  and the key to search for in the secret provider at `secretPath` leveraging secure storage of secrets. 
+This `HTTPSender` instance is used to access the following functions that will use the required url and optional mime type and persistOnError:
   
   - `HTTPPost` - This function receives either a `string`,`[]byte`, or `json.Marshaler` type from the previous function in the pipeline and posts it to the configured endpoint. If no previous function exists, then the event that triggered the pipeline, marshaled to json, will be used. Currently, only unauthenticated endpoints are supported. Authenticated endpoints will be supported in the future. If the post fails and `persistOnError`is `true` and `Store and Forward` is enabled, the data will be stored for later retry. See [Store and Forward](#store-and-forward) for more details
+
 - `NewMQTTSender(logging logger.LoggingClient, addr models.Addressable, keyCertPair *KeyCertPair, mqttConfig MqttConfig, persistOnError bool)` - This function returns a `MQTTSender` instance initialized with the passed in MQTT configuration . This `MQTTSender` instance is used to access the following  function that will use the specified MQTT configuration
   
   - `KeyCertPair` - This structure holds the Key and Certificate information for when using secure **TLS** connection to the broker. Can be `nil` if not using secure **TLS** connection. 

--- a/appsdk/sdk_test.go
+++ b/appsdk/sdk_test.go
@@ -59,7 +59,7 @@ func TestAddRoute(t *testing.T) {
 	sdk := AppFunctionsSDK{
 		webserver: ws,
 	}
-	_ = sdk.AddRoute("/test", func(http.ResponseWriter, *http.Request) {}, "GET")
+	_ = sdk.AddRoute("/test", func(http.ResponseWriter, *http.Request) {}, http.MethodGet)
 	_ = router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
 		path, err := route.GetPathTemplate()
 		if err != nil {

--- a/internal/security/credentials.go
+++ b/internal/security/credentials.go
@@ -38,7 +38,7 @@ func (s *SecretProvider) GetDatabaseCredentials(database db.DatabaseInfo) (commo
 	if !s.isSecurityEnabled() {
 		credentials, err = s.getInsecureSecrets(database.Type, "username", "password")
 	} else {
-		credentials, err = s.secretClient.GetSecrets(database.Type, "username", "password")
+		credentials, err = s.SecretClient.GetSecrets(database.Type, "username", "password")
 	}
 
 	if err != nil {
@@ -64,11 +64,11 @@ func (s *SecretProvider) GetSecrets(path string, keys ...string) (map[string]str
 		return cachedSecrets, nil
 	}
 
-	if s.secretClient == nil {
+	if s.SecretClient == nil {
 		return nil, errors.New("can't get secret(s) 'SecretProvider' is not properly initialized")
 	}
 
-	secrets, err := s.secretClient.GetSecrets(path, keys...)
+	secrets, err := s.SecretClient.GetSecrets(path, keys...)
 	if err != nil {
 		return nil, err
 	}
@@ -174,11 +174,11 @@ func (s *SecretProvider) StoreSecrets(path string, secrets map[string]string) er
 		return errors.New("Storing secrets is not supported when running in insecure mode")
 	}
 
-	if s.secretClient == nil {
+	if s.SecretClient == nil {
 		return errors.New("can't store secret(s) 'SecretProvider' is not properly initialized")
 	}
 
-	err := s.secretClient.StoreSecrets(path, secrets)
+	err := s.SecretClient.StoreSecrets(path, secrets)
 	if err != nil {
 		return err
 	}

--- a/internal/security/credentials_test.go
+++ b/internal/security/credentials_test.go
@@ -160,7 +160,7 @@ func TestGetSecrets(t *testing.T) {
 		i := i
 		test := test
 		t.Run(test.testName, func(t *testing.T) {
-			secretProvider.secretClient.(*mockSecretClient).testIndex = i
+			secretProvider.SecretClient.(*mockSecretClient).testIndex = i
 			secrets, err := secretProvider.GetSecrets(test.path, test.keys...)
 
 			require.Equal(t, test.expectedErr, err)
@@ -235,7 +235,7 @@ func tearDownGetInsecureSecrets(t *testing.T, origEnv string) {
 func newMockSecretProvider(configuration *common.ConfigurationStruct) *SecretProvider {
 	logClient := logger.NewClient("app_functions_sdk_go", false, "./test.log", "DEBUG")
 	mockSP := NewSecretProvider(logClient, configuration)
-	mockSP.secretClient = &mockSecretClient{}
+	mockSP.SecretClient = &mockSecretClient{}
 	return mockSP
 }
 

--- a/internal/security/secret.go
+++ b/internal/security/secret.go
@@ -33,7 +33,7 @@ import (
 
 // SecretProvider cache storage for the secrets
 type SecretProvider struct {
-	secretClient  pkg.SecretClient
+	SecretClient  pkg.SecretClient
 	secretsCache  map[string]map[string]string // secret's path, key, value
 	configuration *common.ConfigurationStruct
 	cacheMuxtex   *sync.Mutex
@@ -62,7 +62,7 @@ func (s *SecretProvider) Initialize(ctx context.Context) bool {
 
 	// attempt to create a new SecretProvider client only if security is enabled.
 	if s.isSecurityEnabled() {
-		s.secretClient, err = client.NewVault(ctx, secretConfig, s.loggingClient).Get(s.configuration.SecretStore)
+		s.SecretClient, err = client.NewVault(ctx, secretConfig, s.loggingClient).Get(s.configuration.SecretStore)
 		if err != nil {
 			s.loggingClient.Error(fmt.Sprintf("unable to create SecretClient: %s", err.Error()))
 			return false

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -76,7 +76,7 @@ func TestConfigureAndPingRoute(t *testing.T) {
 	webserver := NewWebServer(config, sp, logClient, mux.NewRouter())
 	webserver.ConfigureStandardRoutes()
 
-	req, _ := http.NewRequest("GET", clients.ApiPingRoute, nil)
+	req, _ := http.NewRequest(http.MethodGet, clients.ApiPingRoute, nil)
 	rr := httptest.NewRecorder()
 	webserver.router.ServeHTTP(rr, req)
 
@@ -91,7 +91,7 @@ func TestConfigureAndVersionRoute(t *testing.T) {
 	webserver := NewWebServer(config, sp, logClient, mux.NewRouter())
 	webserver.ConfigureStandardRoutes()
 
-	req, _ := http.NewRequest("GET", clients.ApiVersionRoute, nil)
+	req, _ := http.NewRequest(http.MethodGet, clients.ApiVersionRoute, nil)
 	rr := httptest.NewRecorder()
 	webserver.router.ServeHTTP(rr, req)
 
@@ -105,7 +105,7 @@ func TestConfigureAndConfigRoute(t *testing.T) {
 	webserver := NewWebServer(config, sp, logClient, mux.NewRouter())
 	webserver.ConfigureStandardRoutes()
 
-	req, _ := http.NewRequest("GET", clients.ApiConfigRoute, nil)
+	req, _ := http.NewRequest(http.MethodGet, clients.ApiConfigRoute, nil)
 	rr := httptest.NewRecorder()
 	webserver.router.ServeHTTP(rr, req)
 
@@ -120,7 +120,7 @@ func TestConfigureAndMetricsRoute(t *testing.T) {
 	webserver := NewWebServer(config, sp, logClient, mux.NewRouter())
 	webserver.ConfigureStandardRoutes()
 
-	req, _ := http.NewRequest("GET", clients.ApiMetricsRoute, nil)
+	req, _ := http.NewRequest(http.MethodGet, clients.ApiMetricsRoute, nil)
 	rr := httptest.NewRecorder()
 	webserver.router.ServeHTTP(rr, req)
 
@@ -150,7 +150,7 @@ func TestSetupTriggerRoute(t *testing.T) {
 
 	webserver.SetupTriggerRoute(handler)
 
-	req, _ := http.NewRequest("GET", internal.ApiTriggerRoute, nil)
+	req, _ := http.NewRequest(http.MethodGet, internal.ApiTriggerRoute, nil)
 	rr := httptest.NewRecorder()
 	webserver.router.ServeHTTP(rr, req)
 
@@ -196,7 +196,7 @@ func TestPostSecretRoute(t *testing.T) {
 	for _, test := range tests {
 		currentTest := test
 		t.Run(test.name, func(t *testing.T) {
-			req, _ := http.NewRequest("POST", internal.SecretsAPIRoute, bytes.NewReader(currentTest.payload))
+			req, _ := http.NewRequest(http.MethodPost, internal.SecretsAPIRoute, bytes.NewReader(currentTest.payload))
 			rr := httptest.NewRecorder()
 			webserver.router.ServeHTTP(rr, req)
 			assert.Equal(t, currentTest.expectedStatus, rr.Result().StatusCode, "Expected secret doesn't match postSecret")

--- a/pkg/transforms/conversion_test.go
+++ b/pkg/transforms/conversion_test.go
@@ -45,10 +45,12 @@ func init() {
 	eventClient := coredata.NewEventClient(
 		urlclient.New(nil, nil, nil, "", "", 0, "http://test"+clients.ApiEventRoute),
 	)
+	mockSP := newMockSecretProvider(lc, nil)
 
 	context = &appcontext.Context{
-		LoggingClient: lc,
-		EventClient:   eventClient,
+		LoggingClient:  lc,
+		EventClient:    eventClient,
+		SecretProvider: mockSP,
 	}
 }
 func TestTransformToXML(t *testing.T) {

--- a/pkg/transforms/http_test.go
+++ b/pkg/transforms/http_test.go
@@ -17,6 +17,7 @@
 package transforms
 
 import (
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -24,17 +25,30 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/common"
+	"github.com/edgexfoundry/app-functions-sdk-go/internal/security"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	msgStr  = "test message"
+	path    = "/somepath/foo"
+	badPath = "/somepath/bad"
+)
+
+var logClient logger.LoggingClient
+var config *common.ConfigurationStruct
+
+func TestMain(m *testing.M) {
+	logClient = logger.NewClient("app_functions_sdk_go", false, "./test.log", "DEBUG")
+	config = &common.ConfigurationStruct{}
+	m.Run()
+}
+
 func TestHTTPPost(t *testing.T) {
-	const (
-		msgStr  = "test message"
-		path    = "/somepath/foo"
-		badPath = "/somepath/bad"
-	)
 
 	context.CorrelationID = "123"
 
@@ -91,6 +105,60 @@ func TestHTTPPost(t *testing.T) {
 	}
 }
 
+func TestHTTPPostWithSecrets(t *testing.T) {
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+
+		if r.URL.EscapedPath() == badPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+
+		// this should be here on successful secret retrieval
+		if assert.Equal(t, r.Header.Get("Secret-Header-Name"), "value") {
+			t.Errorf("Unexpected header name received %s, expected %s", r.Header.Get("Content-type"), "application/json")
+		}
+	}
+
+	// create test server with handler
+	ts := httptest.NewServer(http.HandlerFunc(handler))
+	defer ts.Close()
+
+	url, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+
+	tests := []struct {
+		Name                 string
+		Path                 string
+		SecretHeaderName     string
+		SecretPath           string
+		ExpectToContinue     bool
+		ExpectedErrorMessage string
+	}{
+		{"unsuccessful post w/o secret header name", path, "", "/path", false, "SecretPath was specified but no header name was provided"},
+		{"unsuccessful post w/o secret path name", path, "Secret-Header-Name", "", false, "HTTP Header Secret Name was provided but no SecretPath was provided"},
+		{"successful post with secrets", path, "Secret-Header-Name", "/path", true, ""},
+		{"successful post without secrets", path, "", "", true, ""},
+		{"unsuccessful post with secrets - retrieval fails", path, "Secret-Header-Name-2", "/path", false, "FAKE NOT FOUND ERROR"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			var sender HTTPSender
+
+			sender = NewHTTPSenderWithSecretHeader(`http://`+url.Host+test.Path, "", false, test.SecretHeaderName, test.SecretPath)
+
+			continuePipeline, err := sender.HTTPPost(context, msgStr)
+			assert.Equal(t, test.ExpectToContinue, continuePipeline)
+			if !test.ExpectToContinue {
+				require.EqualError(t, err.(error), test.ExpectedErrorMessage)
+			}
+		})
+	}
+}
+
 func TestHTTPPostNoParameterPassed(t *testing.T) {
 
 	sender := NewHTTPSender("", "", false)
@@ -112,4 +180,31 @@ func TestHTTPPostInvalidParameter(t *testing.T) {
 	assert.Error(t, result.(error), "Result should be an error")
 	assert.Equal(t, "marshaling input data to JSON failed, "+
 		"passed in data must be of type []byte, string, or support marshaling to JSON", result.(error).Error())
+}
+
+type mockSecretClient struct {
+}
+
+// NewMockSecretProvider provides a mocked version of the mockSecretClient to avoiding using vault in our tests
+func newMockSecretProvider(loggingClient logger.LoggingClient, configuration *common.ConfigurationStruct) *security.SecretProvider {
+	mockSP := security.NewSecretProvider(logClient, config)
+	mockSP.SecretClient = &mockSecretClient{}
+	return mockSP
+}
+
+// GetSecrets mock implementation of GetSecrets
+func (s *mockSecretClient) GetSecrets(path string, keys ...string) (map[string]string, error) {
+	fakeDb := map[string]string{"Secret-Header-Name": "value"}
+	if _, ok := fakeDb[keys[0]]; ok {
+		//do something here
+		return fakeDb, nil
+	} else {
+		return nil, errors.New("FAKE NOT FOUND ERROR")
+	}
+
+}
+
+// StoreSecrets mock implementation of StoreSecrets
+func (s *mockSecretClient) StoreSecrets(path string, secrets map[string]string) error {
+	return nil
 }


### PR DESCRIPTION
Enables retrieval of secret value for use in header in HTTP Export.

Closes #278

Co-authored-by: Walt <walter.a.morton@intel.com>
Co-authored-by: adam-intel <adam.w.mitchell@intel.com>
Signed-off-by: Mike <michael.johanson@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:



## What is the new behavior?
Authentication Header is added to HTTP Post method using key provided from /path in secret provider .
## Are there any specific instructions or things that should be known prior to reviewing?

## Other information