### PR TITLE
feat(security): Add second SecurityStore client for service specific secrets

### DIFF
--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -76,6 +76,8 @@ type ConfigurationStruct struct {
 	Database db.DatabaseInfo
 	// SecretStore
 	SecretStore SecretStoreInfo
+	// SecretStoreExclusive
+	SecretStoreExclusive SecretStoreInfo
 }
 
 // RegistryInfo is used for defining settings for connection to the registry.

--- a/internal/security/credentials.go
+++ b/internal/security/credentials.go
@@ -38,7 +38,7 @@ func (s *SecretProvider) GetDatabaseCredentials(database db.DatabaseInfo) (commo
 	if !s.isSecurityEnabled() {
 		credentials, err = s.getInsecureSecrets(database.Type, "username", "password")
 	} else {
-		credentials, err = s.SecretClient.GetSecrets(database.Type, "username", "password")
+		credentials, err = s.SharedSecretClient.GetSecrets(database.Type, "username", "password")
 	}
 
 	if err != nil {
@@ -64,11 +64,11 @@ func (s *SecretProvider) GetSecrets(path string, keys ...string) (map[string]str
 		return cachedSecrets, nil
 	}
 
-	if s.SecretClient == nil {
-		return nil, errors.New("can't get secret(s) 'SecretProvider' is not properly initialized")
+	if s.ExclusiveSecretClient == nil {
+		return nil, errors.New("can't get secret(s), exclusive secret client is not properly initialized")
 	}
 
-	secrets, err := s.SecretClient.GetSecrets(path, keys...)
+	secrets, err := s.ExclusiveSecretClient.GetSecrets(path, keys...)
 	if err != nil {
 		return nil, err
 	}
@@ -174,11 +174,11 @@ func (s *SecretProvider) StoreSecrets(path string, secrets map[string]string) er
 		return errors.New("Storing secrets is not supported when running in insecure mode")
 	}
 
-	if s.SecretClient == nil {
+	if s.ExclusiveSecretClient == nil {
 		return errors.New("can't store secret(s) 'SecretProvider' is not properly initialized")
 	}
 
-	err := s.SecretClient.StoreSecrets(path, secrets)
+	err := s.ExclusiveSecretClient.StoreSecrets(path, secrets)
 	if err != nil {
 		return err
 	}

--- a/internal/security/credentials_test.go
+++ b/internal/security/credentials_test.go
@@ -160,7 +160,7 @@ func TestGetSecrets(t *testing.T) {
 		i := i
 		test := test
 		t.Run(test.testName, func(t *testing.T) {
-			secretProvider.SecretClient.(*mockSecretClient).testIndex = i
+			secretProvider.ExclusiveSecretClient.(*mockSecretClient).testIndex = i
 			secrets, err := secretProvider.GetSecrets(test.path, test.keys...)
 
 			require.Equal(t, test.expectedErr, err)
@@ -235,7 +235,8 @@ func tearDownGetInsecureSecrets(t *testing.T, origEnv string) {
 func newMockSecretProvider(configuration *common.ConfigurationStruct) *SecretProvider {
 	logClient := logger.NewClient("app_functions_sdk_go", false, "./test.log", "DEBUG")
 	mockSP := NewSecretProvider(logClient, configuration)
-	mockSP.SecretClient = &mockSecretClient{}
+	mockSP.SharedSecretClient = &mockSecretClient{}
+	mockSP.ExclusiveSecretClient = &mockSecretClient{}
 	return mockSP
 }
 

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -242,8 +242,12 @@ func (webserver *WebServer) secretHandler(writer http.ResponseWriter, req *http.
 	}
 
 	secretData.Path = strings.TrimSpace(secretData.Path)
-	if secretData.Path != "" && !strings.HasPrefix(secretData.Path, "/") {
+	// add '/' in the full URL path if it's not already at the end of the basepath or subpath
+	if !strings.HasSuffix(webserver.Config.SecretStoreExclusive.Path, "/") && !strings.HasPrefix(secretData.Path, "/") {
 		secretData.Path = "/" + secretData.Path
+	} else if strings.HasSuffix(webserver.Config.SecretStoreExclusive.Path, "/") && strings.HasPrefix(secretData.Path, "/") {
+		// remove extra '/' in the full URL path because secret store's (Vault) APIs don't handle extra '/'.
+		secretData.Path = secretData.Path[1:]
 	}
 
 	if err := webserver.secretProvider.StoreSecrets(secretData.Path, secretsKV); err != nil {

--- a/pkg/transforms/http_test.go
+++ b/pkg/transforms/http_test.go
@@ -188,7 +188,7 @@ type mockSecretClient struct {
 // NewMockSecretProvider provides a mocked version of the mockSecretClient to avoiding using vault in our tests
 func newMockSecretProvider(loggingClient logger.LoggingClient, configuration *common.ConfigurationStruct) *security.SecretProvider {
 	mockSP := security.NewSecretProvider(logClient, config)
-	mockSP.SecretClient = &mockSecretClient{}
+	mockSP.ExclusiveSecretClient = &mockSecretClient{}
 	return mockSP
 }
 


### PR DESCRIPTION
SecretProvider now has an exclusive secret client for retrieving per-service secrets

Closes: #275

Signed-off-by: Enobong Udoko <enobong.n.udoko@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information