### PR TITLE
fix(SecurityProvider): Make initialization of secret clients optional

### DIFF
--- a/internal/security/credentials.go
+++ b/internal/security/credentials.go
@@ -38,6 +38,10 @@ func (s *SecretProvider) GetDatabaseCredentials(database db.DatabaseInfo) (commo
 	if !s.isSecurityEnabled() {
 		credentials, err = s.getInsecureSecrets(database.Type, "username", "password")
 	} else {
+		if s.SharedSecretClient == nil {
+			return common.Credentials{}, errors.New("SharedSecretClient is required but not configured")
+		}
+
 		credentials, err = s.SharedSecretClient.GetSecrets(database.Type, "username", "password")
 	}
 

--- a/internal/security/credentials_test.go
+++ b/internal/security/credentials_test.go
@@ -39,10 +39,10 @@ type getSecretsTestObj struct {
 	resetSecretsCache bool
 }
 
-var getSecretsTestData []getSecretsTestObj
+type secretTestData []getSecretsTestObj
 
-func TestMain(m *testing.M) {
-	getSecretsTestData = []getSecretsTestObj{
+func getSecretsTestData() secretTestData {
+	return []getSecretsTestObj{
 		{
 			testName:          "Empty path",
 			path:              "",
@@ -148,15 +148,13 @@ func TestMain(m *testing.M) {
 			resetSecretsCache: false,
 		},
 	}
-
-	m.Run()
 }
 
 func TestGetSecrets(t *testing.T) {
 
 	secretProvider := newMockSecretProvider(nil)
 
-	for i, test := range getSecretsTestData {
+	for i, test := range getSecretsTestData() {
 		i := i
 		test := test
 		t.Run(test.testName, func(t *testing.T) {
@@ -178,7 +176,7 @@ func TestGetInsecureSecrets(t *testing.T) {
 
 	secretProvider, origEnv := setupGetInsecureSecrets(t)
 
-	for _, test := range getSecretsTestData {
+	for _, test := range getSecretsTestData() {
 		test := test
 		t.Run(test.testName, func(t *testing.T) {
 			secrets, err := secretProvider.getInsecureSecrets(test.path, test.keys...)
@@ -241,7 +239,8 @@ func newMockSecretProvider(configuration *common.ConfigurationStruct) *SecretPro
 }
 
 func (s *mockSecretClient) GetSecrets(path string, keys ...string) (map[string]string, error) {
-	return getSecretsTestData[s.testIndex].expectedSecrets, getSecretsTestData[s.testIndex].expectedErr
+	secretTestData := getSecretsTestData()
+	return secretTestData[s.testIndex].expectedSecrets, secretTestData[s.testIndex].expectedErr
 }
 
 func (s *mockSecretClient) StoreSecrets(path string, secrets map[string]string) error {

--- a/internal/security/secret.go
+++ b/internal/security/secret.go
@@ -54,68 +54,73 @@ func NewSecretProvider(loggingClient logger.LoggingClient, configuration *common
 	return sp
 }
 
-// Initialize creates a SecretClient to be used for obtaining secrets from a secrets store manager.
+// Initialize creates SecretClients to be used for obtaining secrets from a secrets store manager.
 func (s *SecretProvider) Initialize(ctx context.Context) bool {
-	sharedSecretConfig, err := s.getSecretConfig(s.configuration.SecretStore)
-	if err != nil {
-		s.loggingClient.Error(fmt.Sprintf("unable to parse secret store configuration: %s", err.Error()))
+	var err error
+
+	// initialize shared secret client if configured
+	if s.SharedSecretClient, err = s.initializeSecretClient(ctx, s.configuration.SecretStore); err != nil {
+		s.loggingClient.Error(fmt.Sprintf("unable to create shared secret client : %s", err.Error()))
 		return false
 	}
 
-	exclusiveSecretConfig, err := s.getSecretConfig(s.configuration.SecretStoreExclusive)
-	if err != nil {
-		s.loggingClient.Error(fmt.Sprintf("unable to parse exclusive secret store configuration: %s", err.Error()))
+	// initialize exclusive secret client if configured
+	if s.ExclusiveSecretClient, err = s.initializeSecretClient(ctx, s.configuration.SecretStoreExclusive); err != nil {
+		s.loggingClient.Error(fmt.Sprintf("unable to create exclusive secret client : %s", err.Error()))
 		return false
 	}
 
-	// attempt to create a new SecretProvider client only if security is enabled.
-	if s.isSecurityEnabled() {
-		for i := 0; i < sharedSecretConfig.AdditionalRetryAttempts; i++ {
-			// create secret client based on SecretStore config for db credentials
-			s.SharedSecretClient, err = client.NewVault(ctx, sharedSecretConfig, s.loggingClient).Get(s.configuration.SecretStore)
-			if err == nil {
-				break
-			} else {
-				waitTIme, err := time.ParseDuration(sharedSecretConfig.RetryWaitPeriod)
-				if err != nil {
-					s.loggingClient.Error(fmt.Sprintf("invalid retry wait period for shared secret store config: %s", err.Error()))
-					return false
-				}
-				time.Sleep(waitTIme)
-				continue
-			}
-		}
-		if err != nil {
-			s.loggingClient.Error(fmt.Sprintf("unable to create shared SecretClient: %s", err.Error()))
-			return false
-		}
-
-		for i := 0; i < exclusiveSecretConfig.AdditionalRetryAttempts; i++ {
-			// create secret client based on SecretStoreExclusive config for per-service credentials
-			s.ExclusiveSecretClient, err = client.NewVault(ctx, exclusiveSecretConfig, s.loggingClient).Get(s.configuration.SecretStoreExclusive)
-			if err == nil {
-				break
-			} else {
-				waitTIme, err := time.ParseDuration(exclusiveSecretConfig.RetryWaitPeriod)
-				if err != nil {
-					s.loggingClient.Error(fmt.Sprintf("invalid retry wait period for exlusive secret store config: %s", err.Error()))
-					return false
-				}
-				time.Sleep(waitTIme)
-				continue
-			}
-		}
-		if err != nil {
-			s.loggingClient.Error(fmt.Sprintf("unable to create exclusive SecretClient: %s", err.Error()))
-			return false
-		}
-	}
 	return true
+}
+
+func (s *SecretProvider) initializeSecretClient(
+	ctx context.Context,
+	secretStoreInfo common.SecretStoreInfo) (pkg.SecretClient, error) {
+	var secretClient pkg.SecretClient
+
+	// secretStoreInfo is optional so that secret config can be empty
+	secretConfig, secretStoreEmpty, err := s.getSecretConfig(secretStoreInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	// no secret client to be created
+	if secretStoreEmpty {
+		return nil, nil
+	}
+
+	if s.isSecurityEnabled() {
+		for i := 0; i < secretConfig.AdditionalRetryAttempts; i++ {
+			secretClient, err = client.NewVault(ctx, secretConfig, s.loggingClient).Get(s.configuration.SecretStoreExclusive)
+			if err == nil {
+				break
+			} else {
+				waitTIme, err := time.ParseDuration(secretConfig.RetryWaitPeriod)
+				if err != nil {
+					return nil, fmt.Errorf("invalid retry wait period for secret config: %s", err.Error())
+				}
+				time.Sleep(waitTIme)
+				continue
+			}
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return secretClient, nil
 }
 
 // getSecretConfig creates a SecretConfig based on the SecretStoreInfo configuration properties.
 // If a tokenfile is present it will override the Authentication.AuthToken value.
-func (s *SecretProvider) getSecretConfig(secretStoreInfo common.SecretStoreInfo) (vault.SecretConfig, error) {
+// the return boolean is used to indicate whether the secret store configuration is empty or not
+func (s *SecretProvider) getSecretConfig(secretStoreInfo common.SecretStoreInfo) (vault.SecretConfig, bool, error) {
+	emptySecretStore := common.SecretStoreInfo{}
+	if secretStoreInfo == emptySecretStore {
+		return vault.SecretConfig{}, true, nil
+	}
+
 	secretConfig := vault.SecretConfig{
 		Host:                    secretStoreInfo.Host,
 		Port:                    secretStoreInfo.Port,
@@ -130,7 +135,7 @@ func (s *SecretProvider) getSecretConfig(secretStoreInfo common.SecretStoreInfo)
 	}
 
 	if !s.isSecurityEnabled() || secretStoreInfo.TokenFile == "" {
-		return secretConfig, nil
+		return secretConfig, false, nil
 	}
 
 	// only bother getting a token if security is enabled and the configuration-provided tokenfile is not empty.
@@ -139,10 +144,12 @@ func (s *SecretProvider) getSecretConfig(secretStoreInfo common.SecretStoreInfo)
 
 	token, err := authTokenLoader.Load(secretStoreInfo.TokenFile)
 	if err != nil {
-		return secretConfig, err
+		return secretConfig, false, err
 	}
+
 	secretConfig.Authentication.AuthToken = token
-	return secretConfig, nil
+
+	return secretConfig, false, nil
 }
 
 // isSecurityEnabled determines if security has been enabled.


### PR DESCRIPTION
This is to fix bug #315: SecretStore clients should only be created is configured.

 - Creation of each of the SecretStore clients is skipped if not configured.

 - The creation is a per SecretStore client decision since the exclusive client may be configured
   when the shared client isn't configured.

 - Add some more test entries on the existing TestInitializeSecretProvider for optional secret stores.

 - Refactor some unit tests to avoid potential threading errors on the existing unit tests.

Fixes: #315

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently, if SecretStore section is not provided in the congfiguration TOML file, then the application service throws error and stops running.  There are some use cases of app services, which do not need any configuration of secret store at all, eg. no need for database connection at all. The app services should still be able to run ok in these cases.

Issue Number: #315 


## What is the new behavior?
Now the creation of secret clients is optional and can be skipped if not provided in the configuration TOMLfile so that in such cases app service can still be up and running.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
This is related to blackbox testing issue [#425](https://github.com/edgexfoundry/blackbox-testing/issues/425).  
