### PR TITLE
fix: Use credentials from Database config if not found in InsecureSecrets

### DIFF
--- a/internal/security/credentials.go
+++ b/internal/security/credentials.go
@@ -33,6 +33,14 @@ func (s *SecretProvider) GetDatabaseCredentials(database db.DatabaseInfo) (commo
 	// If security is disabled then we are to use the insecure credentials supplied by the configuration.
 	if !s.isSecurityEnabled() {
 		credentials, err = s.getInsecureSecrets(database.Type, "username", "password")
+		// TODO: Remove for release version v2.0 when DB Credentials are only in new Insecure Secrets
+		if err != nil {
+			// Not found in new InsecureSecrets,so just use old V1 Database settings.
+			return common.Credentials{
+				Username: database.Username,
+				Password: database.Password,
+			}, nil
+		}
 	} else {
 		if s.SharedSecretClient == nil {
 			return common.Credentials{}, errors.New("SharedSecretClient is required but not configured")


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Error on startup if DB credentials not in `[InsecureSecrests]`

Issue Number: #343


## What is the new behavior?
Credentials from `[Database]` config are used if not found in `[InsecureSecrets]`
This fixes backwards breaking change


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information