### PR TITLE
fix: JSONLogic now runs rules everytime insted of 1st time

### DIFF
--- a/pkg/transforms/jsonlogic.go
+++ b/pkg/transforms/jsonlogic.go
@@ -14,13 +14,13 @@ import (
 
 // JSONLogic ...
 type JSONLogic struct {
-	Rule *strings.Reader
+	Rule string
 }
 
 // NewJSONLogic creates, initializes and returns a new instance of HTTPSender
 func NewJSONLogic(rule string) JSONLogic {
 	return JSONLogic{
-		Rule: strings.NewReader(rule),
+		Rule: rule,
 	}
 }
 
@@ -37,16 +37,17 @@ func (logic JSONLogic) Evaluate(edgexcontext *appcontext.Context, params ...inte
 	}
 
 	data := strings.NewReader(string(coercedData))
+	rule := strings.NewReader(logic.Rule)
 	var logicresult bytes.Buffer
 	edgexcontext.LoggingClient.Debug("Applying JSONLogic Rule")
-	err = jsonlogic.Apply(logic.Rule, data, &logicresult)
+	err = jsonlogic.Apply(rule, data, &logicresult)
 	if err != nil {
 		return false, err
 	}
 	var result bool
 	decoder := json.NewDecoder(&logicresult)
 	decoder.Decode(&result)
-	edgexcontext.LoggingClient.Debug("Condition met: %" + strconv.FormatBool(result))
+	edgexcontext.LoggingClient.Debug("Condition met: " + strconv.FormatBool(result))
 
 	return result, params[0]
 }


### PR DESCRIPTION
closes #346

Signed-off-by: Mike <michael.johanson@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

JSONLogic rule executes once

## What is the new behavior?

JSONLogic rule executes as its supposed to

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information