### PR TITLE
feat: Add ability for command-line and environment override of service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,51 +520,76 @@ The following command line options are available
   -s    
   -skipVersionCheck
         Indicates the service should skip the Core Service's version compatibility check.
+  -n
+  --serviceName                
+        Overrides the service name, aka service key, to be used with Registry and/or 
+        Configuration Providers. If the name provided contains the text `<profile>`, 
+        this text will be replaced with the name of the profile used..
 ```
 
 Examples:
 
 ```
-simple-filter-xml -r -c=./res -p=docker
+simple-filter-xml -r -c=./res -p=http-export
 ```
 
 or
 
 ```
-simple-filter-xml --registry --confdir=./res --profile=docker
+simple-filter-xml --registry --confdir=./res --profile=mqtt-export
 ```
 
 ### Environment Variable Overrides
 
-All the configuration settings from the configuration.toml file can be overridden by environment variables. Except for two special cases listed below, the overrides **only** occur when the configuration values are first pushed into the Registry. Once the values are in the Registry, the Registry values are always used. 
+All the configuration settings from the configuration.toml file can be overridden by environment variables.  
 
 The environment variable names have the following format:
 
 ```
-<TOML Key>
-<TOML Section>_<TOML Key>
-<TOML Section>_<TOML Sub-Section>_<TOML Key>
+<TOML KEY>
+<TOML SECTION>_<TOML KEY>
+<TOML SECTION>_<TOML SUB-SECTION>_<TOML KEY>
 ```
+
+> *Note: With the Geneva release CamelCased environment variable names are deprecated. Instead use all upper case environment variable names as in the example below.*
 
 Examples:
 
 ```
 TOML   : FailLimit = 30
-ENVVAR : FailLimit=100
+ENVVAR : FAILLIMIT=100
 
 TOML   : [Logging]
 		 EnableRemote = false
-ENVVAR : Logging.EnableRemote=true
+ENVVAR : LOGGING.ENABLEREMOTE=true
 
 TOML   : [Clients]
   			[Clients.CoreData]
   			Host = 'localhost'
-ENVVAR : Clients_CoreData_Host=edgex-core-data
+ENVVAR : CLIENTS_COREDATA_HOST=edgex-core-data
+```
+
+#### EDGEX_SERVICE_NAME
+
+This environment variable overrides the service name, aka service key, to be used with Registry and/or Configuration Provider.
+
+If the name provided contains the text `<profile>` , this text will be replaced with the name of the profile used.
+
+Example:
+
+```
+EDGEX_SERVICE_NAME=AppService-<profile>-mycloud
+and profile used is http-export 
+then the service name will be:
+
+   AppService-http-export-mycloud
 ```
 
 #### edgex_registry
 
-This environment variable overrides the Registry connection information and occurs every time the application service starts. The value is in the format of a URL.
+**[Deprecated]** This environment variable overrides the Registry connection information and occurs every time the application service starts. The value is in the format of a URL.
+
+> *Note: This environment variable override has been deprecated in the Geneva Release. Instead, use configuration overrides of **REGISTRY_PROTOCOL** and/or **REGISTRY_HOST** and/or **REGISTRY_PORT***
 
 ```
 edgex_registry=consul://edgex-core-consul:8500
@@ -577,7 +602,9 @@ This sets the Registry information fields as follows:
 
 #### edgex_service
 
-This environment variable overrides the Service connection information and occurs every time the application service starts. The value is in the format of a URL.
+**[Deprecated]** This environment variable overrides the Service connection information and occurs every time the application service starts. The value is in the format of a URL.
+
+> *Note: This environment variable override has been deprecated in the Geneva Release. Instead, use configuration overrides of **SERVICE_PROTOCOL** and/or **SERVICE_HOST** and/or **SERVICE_PORT***
 
 ```
 edgex_service=http://192.168.1.2:4903
@@ -588,9 +615,11 @@ This sets the Service information fields as follows:
     Port: 4903
 ```
 
-#### edgex_profile
+#### edgex_profile / EDGEX_PROFILE
 
 This environment variable overrides the command line `profile` argument. It will replace the current value passed via the `-p` or `--profile`, if one exists. If not specified it will add the `--profile` argument. This is useful when running the service via docker-compose.
+
+> *Note: The lower case version has been deprecated* in the Geneva release. Instead use upper case version **EDGEX_PROFILE**
 
 Using docker-compose:
 
@@ -598,7 +627,7 @@ Using docker-compose:
   app-service-configurable-rules:
     image: edgexfoundry/docker-app-service-configurable:1.1.0
     environment: 
-      - edgex_profile : "rules-engine"
+      - EDGEX_PROFILE : "rules-engine"
     ports:
       - "48095:48095"
     container_name: edgex-app-service-configurable


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

No support for for overriding the service key

Issue Number: #355


## What is the new behavior?

have ability for command-line and environment override of service key

Command line options are -sk/--serviceKey
Environment varable is EDGEX_SERVICE_KEY

Includes support for the <profile> replacement text placeholder

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [] No

Inserting preceding "-" when replacing `<profile>` in the service key has been removed so the use is more flexible.  The only service using the <profile> replacement text is app-service-configurable which will be updated to add the "-" in the initial service key

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information