### PR TITLE
refactor: Change serviceName override to be ServiceKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,11 +520,11 @@ The following command line options are available
   -s    
   -skipVersionCheck
         Indicates the service should skip the Core Service's version compatibility check.
-  -n
-  --serviceName                
-        Overrides the service name, aka service key, to be used with Registry and/or 
-        Configuration Providers. If the name provided contains the text `<profile>`, 
-        this text will be replaced with the name of the profile used..
+  -sk
+  --serviceKey                
+        Overrides the service key used with Registry and/or Configuration Providers. 
+        If the name provided contains the text `<profile>`, this text will be replaced with 
+        the name of the profile used..
 ```
 
 Examples:
@@ -569,16 +569,16 @@ TOML   : [Clients]
 ENVVAR : CLIENTS_COREDATA_HOST=edgex-core-data
 ```
 
-#### EDGEX_SERVICE_NAME
+#### EDGEX_SERVICE_KEY
 
-This environment variable overrides the service name, aka service key, to be used with Registry and/or Configuration Provider.
+This environment variable overrides the service key, used with Registry and/or Configuration Provider.
 
 If the name provided contains the text `<profile>` , this text will be replaced with the name of the profile used.
 
 Example:
 
 ```
-EDGEX_SERVICE_NAME=AppService-<profile>-mycloud
+EDGEX_SERVICE_KEY=AppService-<profile>-mycloud
 and profile used is http-export 
 then the service name will be:
 

--- a/appsdk/sdk.go
+++ b/appsdk/sdk.go
@@ -64,7 +64,7 @@ const (
 	ProfileSuffixPlaceholder = "<profile>"
 	envV1Profile             = "edgex_profile" // TODO: Remove for release v2.0.0
 	envProfile               = "EDGEX_PROFILE"
-	envServiceName           = "EDGEX_SERVICE_NAME"
+	envServiceKey            = "EDGEX_SERVICE_KEY"
 	envV1Service             = "edgex_service"    // deprecated TODO: Remove for release v2.0.0
 	envServiceProtocol       = "Service_Protocol" // Used for envV1Service processing TODO: Remove for release v2.0.0
 	envServiceHost           = "Service_Host"     // Used for envV1Service processing TODO: Remove for release v2.0.0
@@ -110,7 +110,7 @@ type AppFunctionsSDK struct {
 	appCtx                    context.Context
 	appCancelCtx              context.CancelFunc
 	deferredFunctions         []bootstrap.Deferred
-	serviceNameOverride       string
+	serviceKeyOverride        string
 }
 
 // AddRoute allows you to leverage the existing webserver to add routes.
@@ -309,15 +309,15 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 
 	additionalUsage :=
 		"    -s/--skipVersionCheck           Indicates the service should skip the Core Service's version compatibility check.\n" +
-			"    -n/--serviceName                Overrides the service name, aka service key, to be used with Registry and/or Configuration Providers.\n" +
+			"    -sk/--serviceKey                Overrides the service service key used with Registry and/or Configuration Providers.\n" +
 			"                                    If the name provided contains the text `<profile>`, this text will be replaced with\n" +
 			"                                    the name of the profile used."
 
 	sdkFlags := flags.NewWithUsage(additionalUsage)
 	sdkFlags.FlagSet.BoolVar(&sdk.skipVersionCheck, "skipVersionCheck", false, "")
 	sdkFlags.FlagSet.BoolVar(&sdk.skipVersionCheck, "s", false, "")
-	sdkFlags.FlagSet.StringVar(&sdk.serviceNameOverride, "serviceName", "", "")
-	sdkFlags.FlagSet.StringVar(&sdk.serviceNameOverride, "n", "", "")
+	sdkFlags.FlagSet.StringVar(&sdk.serviceKeyOverride, "serviceKey", "", "")
+	sdkFlags.FlagSet.StringVar(&sdk.serviceKeyOverride, "sk", "", "")
 
 	sdkFlags.Parse(os.Args[1:])
 
@@ -445,18 +445,18 @@ func (sdk *AppFunctionsSDK) addDeferred(deferred bootstrap.Deferred) {
 // setServiceKey creates the service's service key with profile name if the original service key has the
 // appropriate profile placeholder, otherwise it leaves the original service key unchanged
 func (sdk *AppFunctionsSDK) setServiceKey(profile string) {
-	envValue := os.Getenv(envServiceName)
+	envValue := os.Getenv(envServiceKey)
 	if len(envValue) > 0 {
-		sdk.serviceNameOverride = envValue
+		sdk.serviceKeyOverride = envValue
 		sdk.LoggingClient.Info(
 			fmt.Sprintf("Environment profileOverride of '-n/--serviceName' by environment variable: %s=%s",
-				envServiceName,
+				envServiceKey,
 				envValue))
 	}
 
-	// serviceNameOverride may have been set by the -n/--serviceName command-line option and not the environment variable
-	if len(sdk.serviceNameOverride) > 0 {
-		sdk.ServiceKey = sdk.serviceNameOverride
+	// serviceKeyOverride may have been set by the -n/--serviceName command-line option and not the environment variable
+	if len(sdk.serviceKeyOverride) > 0 {
+		sdk.ServiceKey = sdk.serviceKeyOverride
 	}
 
 	if !strings.Contains(sdk.ServiceKey, ProfileSuffixPlaceholder) {

--- a/appsdk/sdk_test.go
+++ b/appsdk/sdk_test.go
@@ -463,12 +463,12 @@ func TestSetServiceKey(t *testing.T) {
 				os.Setenv(test.profileEnvVar, test.profileEnvValue)
 			}
 			if len(test.serviceKeyEnvValue) > 0 {
-				os.Setenv(envServiceName, test.serviceKeyEnvValue)
+				os.Setenv(envServiceKey, test.serviceKeyEnvValue)
 			}
 			defer os.Clearenv()
 
 			if len(test.serviceKeyCommandLineOverride) > 0 {
-				sdk.serviceNameOverride = test.serviceKeyCommandLineOverride
+				sdk.serviceKeyOverride = test.serviceKeyCommandLineOverride
 			}
 
 			sdk.ServiceKey = test.originalServiceKey


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently overrides are named ` -n/--serviceName & EDGEX_SERVICE_NAME`

Issue Number: #363


## What is the new behavior?

Now overrides are named `-sk/--serviceKey & EDGEX_SERVICE_KEY`

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information