### PR TITLE
fix: backwards compatibility broken by #406, fixes #408

### DIFF
--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -344,11 +344,6 @@ func listenAndServe(webserver *WebServer, serviceTimeout time.Duration, errChann
 	// this allows env overrides to explicitly set the value used
 	// for ListenAndServe, as needed for different deployments
 	addr := fmt.Sprintf("%v:%d", webserver.Config.Service.ServerBindAddr, webserver.Config.Service.Port)
-	// for backwards compatibility, the Host value is the default value if
-	// the ServerBindAddr value is not specified
-	if webserver.Config.Service.ServerBindAddr == "" {
-		addr = fmt.Sprintf("%v:%d", webserver.Config.Service.Host, webserver.Config.Service.Port)
-	}
 
 	if webserver.Config.Service.Protocol == "https" {
 		webserver.LoggingClient.Info(fmt.Sprintf("Starting HTTPS Web Server on address %v", addr))


### PR DESCRIPTION
Signed-off-by: charles-knox-intel <44684517+charles-knox-intel@users.noreply.github.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

When setting `ServerBindAddr` (newly introduced in #406), setting a blank value causes `app-functions-sdk-go` to default to the `Service.Host` value instead. This is actually not a backwards-compatible change.

Issue Number: #408 


## What is the new behavior?

The new behavior is intended to actually be backwards-compatible this time. If `ServerBindAddr` is set to blank value, then the value that is sent to `ListenAndServe` is `:<port>`. This is the previous behavior of `app-functions-sdk-go`.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

No

## Are there any specific instructions or things that should be known prior to reviewing?

No

## Other information