### PR TITLE
fix(sdk): Fix version check to handle new core-data `dev` versions.

### DIFF
--- a/internal/bootstrap/handlers/version.go
+++ b/internal/bootstrap/handlers/version.go
@@ -54,8 +54,8 @@ func NewVersionValidator(skip bool, sdkVersion string) *VersionValidator {
 
 // BootstrapHandler verifies that Core Services major version matches this SDK's major version
 func (vv *VersionValidator) BootstrapHandler(
-	ctx context.Context,
-	wg *sync.WaitGroup,
+	_ context.Context,
+	_ *sync.WaitGroup,
 	startupTimer startup.Timer,
 	dic *di.Container) bool {
 
@@ -124,7 +124,7 @@ func (vv *VersionValidator) BootstrapHandler(
 
 	// Core Service version is reported as "{major}.{minor}.{patch}"
 	coreVersionParts := strings.Split(coreVersion, ".")
-	if len(coreVersionParts) != 3 {
+	if len(coreVersionParts) < 3 {
 		logger.Error("Core Services version is malformed", "version", coreVersion)
 		return false
 	}

--- a/internal/bootstrap/handlers/version_test.go
+++ b/internal/bootstrap/handlers/version_test.go
@@ -78,7 +78,9 @@ func TestValidateVersionMatch(t *testing.T) {
 		ExpectFailure    bool
 	}{
 		{"Compatible Versions", "1.1.0", "v1.0.0", false, false},
-		{"Dev Compatible Versions", "2.0.0", "v2.0.0-dev.11", false, false},
+		{"SDK Dev Compatible Versions", "2.0.0", "v2.0.0-dev.11", false, false},
+		{"Core Dev Compatible Versions", "1.2.1-dev.1", "v1.2.0", false, false},
+		{"Both Dev Compatible Versions", "1.2.1-dev.1", "v1.2.0-dev.4", false, false},
 		{"Un-compatible Versions", "2.0.0", "v1.0.0", false, true},
 		{"Skip Version Check", "2.0.0", "v1.0.0", true, false},
 		{"Running in Debugger", "1.0.0", "v0.0.0", false, false},


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Version check expects `master` for Core Data's `dev` version

Issue Number:  #100


## What is the new behavior?

Core Data is now using the semver tag, e.g. `1.2.1-dev.1` , for it's `dev` version.

Version check update to handle new Core Data `dev` version format

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information