### PR TITLE
feat: Add logging of service version and total startup time

### DIFF
--- a/appsdk/sdk.go
+++ b/appsdk/sdk.go
@@ -40,7 +40,6 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/config"
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/flags"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/message"
 	bootstrapInterfaces "github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
@@ -327,6 +326,8 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 
 	sdk.setServiceKey(sdkFlags.Profile())
 
+	sdk.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", sdk.ServiceKey, internal.ApplicationVersion))
+
 	// The use of the edgex_service environment variable (only used for App Services) has been deprecated
 	// and not included in the common bootstrap. Have to be handle here before calling into the common bootstrap
 	// so proper overrides are set.
@@ -365,7 +366,6 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 			handlers.NewClients().BootstrapHandler,
 			handlers.NewTelemetry().BootstrapHandler,
 			handlers.NewVersionValidator(sdk.skipVersionCheck, internal.SDKVersion).BootstrapHandler,
-			message.NewBootstrap(sdk.ServiceKey, internal.ApplicationVersion).BootstrapHandler,
 		},
 	)
 
@@ -392,6 +392,8 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 
 	sdk.webserver = webserver.NewWebServer(sdk.config, sdk.secretProvider, sdk.LoggingClient, mux.NewRouter())
 	sdk.webserver.ConfigureStandardRoutes()
+
+	sdk.LoggingClient.Info("Service started in: " + startupTimer.SinceAsString())
 
 	return nil
 }


### PR DESCRIPTION
fixes: #423

Signed-off-by: Enobong Udoko <enobong.n.udoko@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The service startup message is currently logged using the message bootstrap handler during the SDK initialize(). This occurs too early as the SDK does additional processing after the bootstrap handlers run. 

Issue Number:
#423 

## What is the new behavior?
Remove use of message bootstrap handler and just need to log the same messages after the call to the SDK Initialize() completes.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information