### PR TITLE
fix: V2 Secrets return proper 201, 400 or 500 status codes, not 207.

### DIFF
--- a/internal/v2/controller/http/controller.go
+++ b/internal/v2/controller/http/controller.go
@@ -120,7 +120,7 @@ func (v2c *V2HttpController) Secrets(writer http.ResponseWriter, request *http.R
 	err := json.NewDecoder(request.Body).Decode(&secretRequest)
 	if err != nil {
 		response := common.NewBaseResponse("unknown", err.Error(), http.StatusBadRequest)
-		v2c.sendResponse(writer, request, internal.ApiV2SecretsRoute, response, http.StatusMultiStatus)
+		v2c.sendResponse(writer, request, internal.ApiV2SecretsRoute, response, http.StatusBadRequest)
 		return
 	}
 
@@ -129,12 +129,12 @@ func (v2c *V2HttpController) Secrets(writer http.ResponseWriter, request *http.R
 	if err := v2c.secretProvider.StoreSecrets(path, secrets); err != nil {
 		msg := fmt.Sprintf("Storing secrets failed: %v", err)
 		response := common.NewBaseResponse(secretRequest.RequestID, msg, http.StatusInternalServerError)
-		v2c.sendResponse(writer, request, internal.ApiV2SecretsRoute, response, http.StatusMultiStatus)
+		v2c.sendResponse(writer, request, internal.ApiV2SecretsRoute, response, http.StatusInternalServerError)
 		return
 	}
 
 	response := common.NewBaseResponseNoMessage(secretRequest.RequestID, http.StatusCreated)
-	v2c.sendResponse(writer, request, internal.ApiV2SecretsRoute, response, http.StatusMultiStatus)
+	v2c.sendResponse(writer, request, internal.ApiV2SecretsRoute, response, http.StatusCreated)
 }
 
 // sendResponse puts together the response packet for the V2 API

--- a/internal/v2/controller/http/controller_test.go
+++ b/internal/v2/controller/http/controller_test.go
@@ -251,8 +251,9 @@ func TestSecretsRequest(t *testing.T) {
 			err = json.Unmarshal(recorder.Body.Bytes(), &actualResponse)
 			require.NoError(t, err)
 
+			assert.Equal(t, testCase.ExpectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
 			assert.Equal(t, contractsV2.ApiVersion, actualResponse.ApiVersion, "Api Version not as expected")
-			assert.Equal(t, testCase.ExpectedStatusCode, int(actualResponse.StatusCode), "Response status code not as expected")
+			assert.Equal(t, testCase.ExpectedStatusCode, int(actualResponse.StatusCode), "BaseResponse status code not as expected")
 
 			if testCase.ErrorExpected {
 				assert.NotEmpty(t, actualResponse.Message, "Message is empty")

--- a/openapi/v2/app-functions-sdk.yml
+++ b/openapi/v2/app-functions-sdk.yml
@@ -248,19 +248,33 @@ paths:
                 - $ref: '#/components/schemas/SecretsRequest'
         required: true
       responses:
-        '207':
-          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+        '201':
+          description: "Created"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  anyOf:
-                    - $ref: '#/components/schemas/BaseResponse'
-                    - $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/BaseResponse'
+        '400':
+          description: "Invalid request."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: "An unexpected error happened on the server."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /trigger:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

 V2 Secrets returns 207 for the HTTP Response and then has the appropriate status code in the BaseResponse object returned in the body.
207 in meant for when there are multiple responses in the body for multiple requests in the request body, which is not the case here. 

Issue Number: #442


## What is the new behavior?

Returns the appropriate 201, 400, or 500 status code as the HTTP response and also in the BaseResponse object in the response body

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information