### PR TITLE
fix: Trigger API schema type of `text` for errors is invalid, should be `string`

### DIFF
--- a/openapi/v2/app-functions-sdk.yml
+++ b/openapi/v2/app-functions-sdk.yml
@@ -307,7 +307,7 @@ paths:
           content:
             application/text:
               schema:
-                type: text
+                type: string
                 description: message describing the error encountered
         '422':
           description: "Unprocessable Entity"
@@ -317,7 +317,7 @@ paths:
           content:
             application/text:
               schema:
-                type: text
+                type: string
                 description: message describing the error encountered
         '500':
           description: "Interval Server Error"
@@ -327,7 +327,7 @@ paths:
           content:
             application/text:
               schema:
-                type: text
+                type: string
                 description: message describing the error encountered
   /version:
     get:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Swagger for the Trigger API sets the schema type to `text for the error responses. `text is not a valid type.

Issue Number:  #452


## What is the new behavior?

type has been changed to the valid type of `string`

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information