### PR TITLE
fix: Make `path` property required for the Secrets V1 & V2 APIs

### DIFF
--- a/internal/v2/controller/http/controller_test.go
+++ b/internal/v2/controller/http/controller_test.go
@@ -192,8 +192,8 @@ func TestSecretsRequest(t *testing.T) {
 		},
 	}
 
-	validNoPath := validRequest
-	validNoPath.Path = ""
+	NoPath := validRequest
+	NoPath.Path = ""
 	validPathWithSlash := validRequest
 	validPathWithSlash.Path = "/mqtt"
 	validNoRequestId := validRequest
@@ -221,10 +221,10 @@ func TestSecretsRequest(t *testing.T) {
 		ExpectedStatusCode int
 	}{
 		{"Valid - sub-path no trailing slash, SecretsPath has trailing slash", validRequest, expectedRequestId, "my-secrets/", "true", false, http.StatusCreated},
-		{"Valid - no trailing slashes", validNoPath, expectedRequestId, "my-secrets", "true", false, http.StatusCreated},
 		{"Valid - sub-path only with trailing slash", validPathWithSlash, expectedRequestId, "my-secrets", "true", false, http.StatusCreated},
 		{"Valid - both trailing slashes", validPathWithSlash, expectedRequestId, "my-secrets/", "true", false, http.StatusCreated},
 		{"Valid - no requestId", validNoRequestId, "", "", "true", false, http.StatusCreated},
+		{"Invalid - no path", NoPath, "", "", "true", true, http.StatusBadRequest},
 		{"Invalid - bad requestId", badRequestId, "", "", "true", true, http.StatusBadRequest},
 		{"Invalid - no secrets", noSecrets, "", "", "true", true, http.StatusBadRequest},
 		{"Invalid - missing secret key", missingSecretKey, "", "", "true", true, http.StatusBadRequest},

--- a/internal/v2/dtos/requests/secrets.go
+++ b/internal/v2/dtos/requests/secrets.go
@@ -35,7 +35,7 @@ type SecretsKeyValue struct {
 // See detail specified by the V2 API swagger in openapi/v2
 type SecretsRequest struct {
 	common.BaseRequest `json:",inline"`
-	Path               string            `json:"path"`
+	Path               string            `json:"path" validate:"required"`
 	Secrets            []SecretsKeyValue `json:"secrets" validate:"required,gt=0,dive"`
 }
 

--- a/internal/v2/dtos/requests/secrets_test.go
+++ b/internal/v2/dtos/requests/secrets_test.go
@@ -32,7 +32,7 @@ const (
 
 var validRequest = SecretsRequest{
 	BaseRequest: common.BaseRequest{RequestID: TestUUID},
-	Path:        "",
+	Path:        "something",
 	Secrets: []SecretsKeyValue{
 		{Key: "password", Value: "password"},
 	},
@@ -48,8 +48,8 @@ var missingValueSecrets = []SecretsKeyValue{
 
 func TestSecretsRequest_Validate(t *testing.T) {
 	validNoPath := validRequest
+	validNoPath.Path = ""
 	validWithPath := validRequest
-	validWithPath.Path = "mqtt"
 	validNoRequestId := validRequest
 	validNoRequestId.RequestID = ""
 	badRequestId := validRequest
@@ -66,9 +66,9 @@ func TestSecretsRequest_Validate(t *testing.T) {
 		Request       SecretsRequest
 		ErrorExpected bool
 	}{
-		{"valid - with no path", validNoPath, false},
 		{"valid - with with path", validWithPath, false},
 		{"valid - no requestId", validNoRequestId, false},
+		{"invalid - with no path", validNoPath, true},
 		{"invalid - bad requestId", badRequestId, true},
 		{"invalid - no Secrets", noSecrets, true},
 		{"invalid - missing secret key", missingSecretKey, true},

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -182,6 +182,11 @@ func TestPostSecretRoute(t *testing.T) {
 			expectedStatus: http.StatusCreated,
 		},
 		{
+			name:           "PostSecretRoute: missing path",
+			payload:        []byte(`{"secrets":[{"key":"MySecretKey1","value":"MySecretValue1"}, {"key":"MySecretKey2","value":"MySecretValue2"}]}`),
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
 			name:           "PostSecretRoute: missing secrets",
 			payload:        []byte(`{"path":"MyPath"}`),
 			expectedStatus: http.StatusBadRequest,

--- a/internal/webserver/types.go
+++ b/internal/webserver/types.go
@@ -45,6 +45,11 @@ func (secretData SecretData) validateSecretData() error {
 			return errors.New("'Secrets' key should not be empty")
 		}
 	}
+
+	if len(secretData.Path) == 0 {
+		return errors.New("'Secrets' path should not be empty")
+	}
+
 	if _, err := url.Parse(secretData.Path); err != nil {
 		return fmt.Errorf("'Path' is invalid %v", err)
 	}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Secrets API (V1 & V2) `path` property is currently optional, but results in error from Vault due to not having write privs for the base path.

Issue Number:  #476


## What is the new behavior?

 `path` property is now required for both V1 & V2 Secrets API.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

For V1 it results in a n error, so no one could have successfully used Secrets API w/o path set

## Are there any new imports or modules? If so, what are they used for and why?

No
## Are there any specific instructions or things that should be known prior to reviewing?

## Other information