### PR TITLE
feat(sdk): expose RegistryClient on SDK

### DIFF
--- a/appsdk/sdk.go
+++ b/appsdk/sdk.go
@@ -101,18 +101,19 @@ type AppFunctionsSDK struct {
 	runtime                   *runtime.GolangRuntime
 	webserver                 *webserver.WebServer
 	edgexClients              common.EdgeXClients
-	registryClient            registry.Client
-	config                    *common.ConfigurationStruct
-	storeClient               interfaces.StoreClient
-	secretProvider            security.SecretProvider
-	storeForwardWg            *sync.WaitGroup
-	storeForwardCancelCtx     context.CancelFunc
-	appWg                     *sync.WaitGroup
-	appCtx                    context.Context
-	appCancelCtx              context.CancelFunc
-	deferredFunctions         []bootstrap.Deferred
-	serviceKeyOverride        string
-	backgroundChannel         <-chan types.MessageEnvelope
+	// RegistryClient is the client used by service to communicate with service registry.
+	RegistryClient        registry.Client
+	config                *common.ConfigurationStruct
+	storeClient           interfaces.StoreClient
+	secretProvider        security.SecretProvider
+	storeForwardWg        *sync.WaitGroup
+	storeForwardCancelCtx context.CancelFunc
+	appWg                 *sync.WaitGroup
+	appCtx                context.Context
+	appCancelCtx          context.CancelFunc
+	deferredFunctions     []bootstrap.Deferred
+	serviceKeyOverride    string
+	backgroundChannel     <-chan types.MessageEnvelope
 }
 
 // AddRoute allows you to leverage the existing webserver to add routes.
@@ -390,6 +391,7 @@ func (sdk *AppFunctionsSDK) Initialize() error {
 	sdk.secretProvider = container.SecretProviderFrom(dic.Get)
 	sdk.storeClient = container.StoreClientFrom(dic.Get)
 	sdk.LoggingClient = bootstrapContainer.LoggingClientFrom(dic.Get)
+	sdk.RegistryClient = bootstrapContainer.RegistryFrom(dic.Get)
 	sdk.edgexClients.LoggingClient = sdk.LoggingClient
 	sdk.edgexClients.EventClient = container.EventClientFrom(dic.Get)
 	sdk.edgexClients.ValueDescriptorClient = container.ValueDescriptorClientFrom(dic.Get)


### PR DESCRIPTION
make internal client used for registry communications available to
the service after initialization

Signed-off-by: Alex Ullrich <alexullrich@technotects.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:
 
Expose the registry client on initialized SDK for use by application services

## What is the current behavior?
Registry client on SDK is not exposed

Issue Number: #502


## What is the new behavior?
Registry client on SDK is exposed

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information