### PR TITLE
fix: Skip compatibility check when Core Data's version is 0.0.0 (developer build)

### DIFF
--- a/internal/bootstrap/handlers/version.go
+++ b/internal/bootstrap/handlers/version.go
@@ -34,6 +34,7 @@ import (
 
 const (
 	CorePreReleaseVersion = "master"
+	CoreDeveloperVersion  = "0.0.0"
 	CoreServiceVersionKey = "version"
 	VersionMajorIndex     = 0
 )
@@ -118,7 +119,15 @@ func (vv *VersionValidator) BootstrapHandler(
 		logger.Info(
 			"Skipping version compatibility check for Core Pre-release version",
 			"version",
-			internal.SDKVersion)
+			coreVersion)
+		return true
+	}
+
+	if coreVersion == CoreDeveloperVersion {
+		logger.Info(
+			"Skipping version compatibility check for Core Developer version",
+			"version",
+			coreVersion)
 		return true
 	}
 

--- a/internal/bootstrap/handlers/version_test.go
+++ b/internal/bootstrap/handlers/version_test.go
@@ -86,6 +86,7 @@ func TestValidateVersionMatch(t *testing.T) {
 		{"SDK Beta Version", "1.0.0", "v0.2.0", false, false},
 		{"SDK Version malformed", "1.0.0", "", false, true},
 		{"Core prerelease version", CorePreReleaseVersion, "v1.0.0", false, false},
+		{"Core developer version", CoreDeveloperVersion, "v1.0.0", false, false},
 		{"Core version malformed", "12", "v1.0.0", false, true},
 		{"Core version JSON bad", "", "v1.0.0", false, true},
 		{"Core version JSON empty", "{}", "v1.0.0", false, true},


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Version compatibility check will fail when core data's version is 0.0.0. This is the version assigned when built locally by developers.

Issue Number: #532


## What is the new behavior?

Version compatibility check is skipped when core data's version is 0.0.0.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

No

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information