### PR TITLE
fix: Set Redis password in MessageBus.Optional when using redisstreams

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9
 	github.com/eclipse/paho.mqtt.golang v1.2.0
-	github.com/edgexfoundry/go-mod-bootstrap v0.0.46
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.90
-	github.com/edgexfoundry/go-mod-messaging v0.1.23
-	github.com/edgexfoundry/go-mod-registry v0.1.23
+	github.com/edgexfoundry/go-mod-bootstrap v0.0.47
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.94
+	github.com/edgexfoundry/go-mod-messaging v0.1.26
+	github.com/edgexfoundry/go-mod-registry v0.1.25
 	github.com/edgexfoundry/go-mod-secrets v0.0.23
 	github.com/fxamacker/cbor/v2 v2.2.0
 	github.com/golang/snappy v0.0.1 // indirect


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Unable to connect to Redis for redisstreams in secure mode since the random generated Redis password never passed in the MessageBus.Optional properties.

Issue Number: #530


## What is the new behavior?

Now the Password is extracted from the SecretProvider and set in MessageBus.Optional properties when `redisstreams` is used.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information