### PR TITLE
fix: http trigger response can set content-type

### DIFF
--- a/appcontext/context.go
+++ b/appcontext/context.go
@@ -63,6 +63,8 @@ type Context struct {
 	RetryData []byte
 	// SecretProvider exposes the support for getting and storing secrets
 	SecretProvider security.SecretProvider
+	// ResponseContentType is used for holding custom response type for HTTP trigger
+	ResponseContentType string
 }
 
 // Complete is optional and provides a way to return the specified data.

--- a/appsdk/configurable.go
+++ b/appsdk/configurable.go
@@ -28,31 +28,32 @@ import (
 )
 
 const (
-	ValueDescriptors = "valuedescriptors"
-	DeviceNames      = "devicenames"
-	FilterOut        = "filterout"
-	Key              = "key"
-	InitVector       = "initvector"
-	Url              = "url"
-	MimeType         = "mimetype"
-	PersistOnError   = "persistonerror"
-	Cert             = "cert"
-	SkipVerify       = "skipverify"
-	Qos              = "qos"
-	Retain           = "retain"
-	AutoReconnect    = "autoreconnect"
-	DeviceName       = "devicename"
-	ReadingName      = "readingname"
-	Rule             = "rule"
-	BatchThreshold   = "batchthreshold"
-	TimeInterval     = "timeinterval"
-	SecretHeaderName = "secretheadername"
-	SecretPath       = "secretpath"
-	BrokerAddress    = "brokeraddress"
-	ClientID         = "clientid"
-	Topic            = "topic"
-	AuthMode         = "authmode"
-	Tags             = "tags"
+	ValueDescriptors    = "valuedescriptors"
+	DeviceNames         = "devicenames"
+	FilterOut           = "filterout"
+	Key                 = "key"
+	InitVector          = "initvector"
+	Url                 = "url"
+	MimeType            = "mimetype"
+	PersistOnError      = "persistonerror"
+	Cert                = "cert"
+	SkipVerify          = "skipverify"
+	Qos                 = "qos"
+	Retain              = "retain"
+	AutoReconnect       = "autoreconnect"
+	DeviceName          = "devicename"
+	ReadingName         = "readingname"
+	Rule                = "rule"
+	BatchThreshold      = "batchthreshold"
+	TimeInterval        = "timeinterval"
+	SecretHeaderName    = "secretheadername"
+	SecretPath          = "secretpath"
+	BrokerAddress       = "brokeraddress"
+	ClientID            = "clientid"
+	Topic               = "topic"
+	AuthMode            = "authmode"
+	Tags                = "tags"
+	ResponseContentType = "responsecontenttype"
 )
 
 // AppFunctionsSDKConfigurable contains the helper functions that return the function pointers for building the configurable function pipeline.
@@ -418,8 +419,14 @@ func (dynamic AppFunctionsSDKConfigurable) MQTTSend(parameters map[string]string
 // SetOutputData sets the output data to that passed in from the previous function.
 // It will return an error and stop the pipeline if data passed in is not of type []byte, string or json.Mashaler
 // This function is a configuration function and returns a function pointer.
-func (dynamic AppFunctionsSDKConfigurable) SetOutputData() appcontext.AppFunction {
+func (dynamic AppFunctionsSDKConfigurable) SetOutputData(parameters map[string]string) appcontext.AppFunction {
 	transform := transforms.OutputData{}
+
+	value, ok := parameters[ResponseContentType]
+	if ok && len(value) > 0 {
+		transform.ResponseContentType = value
+	}
+
 	return transform.SetOutputData
 }
 

--- a/appsdk/configurable_test.go
+++ b/appsdk/configurable_test.go
@@ -179,10 +179,32 @@ func TestConfigurableMQTTSend(t *testing.T) {
 }
 
 func TestConfigurableSetOutputData(t *testing.T) {
-	configurable := AppFunctionsSDKConfigurable{}
+	configurable := AppFunctionsSDKConfigurable{
+		Sdk: &AppFunctionsSDK{
+			LoggingClient: lc,
+		},
+	}
 
-	trx := configurable.SetOutputData()
-	assert.NotNil(t, trx, "return result from SetOutputData should not be nil")
+	tests := []struct {
+		name      string
+		params    map[string]string
+		expectNil bool
+	}{
+		{"Non Existent Parameter", map[string]string{}, false},
+		{"Valid Parameter With Value", map[string]string{ResponseContentType: "application/json"}, false},
+		{"Valid Parameter Without Value", map[string]string{ResponseContentType: ""}, false},
+		{"Unknown Parameter", map[string]string{"Unknown": "scary/text"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trx := configurable.SetOutputData(tt.params)
+			if tt.expectNil {
+				assert.Nil(t, trx, "return result from SetOutputData should be nil")
+			} else {
+				assert.NotNil(t, trx, "return result from SetOutputData should not be nil")
+			}
+		})
+	}
 }
 
 func TestConfigurableMarkAsPushed(t *testing.T) {

--- a/internal/trigger/http/rest.go
+++ b/internal/trigger/http/rest.go
@@ -104,6 +104,9 @@ func (trigger *Trigger) requestHandler(writer http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	if len(edgexContext.ResponseContentType) > 0 {
+		writer.Header().Set(clients.ContentType, edgexContext.ResponseContentType)
+	}
 	writer.Write(edgexContext.OutputData)
 
 	if edgexContext.OutputData != nil {

--- a/pkg/transforms/conversion.go
+++ b/pkg/transforms/conversion.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
@@ -46,6 +47,7 @@ func (f Conversion) TransformToXML(edgexcontext *appcontext.Context, params ...i
 		if err != nil {
 			return false, fmt.Errorf("unable to marshal Event to XML: %s", err.Error())
 		}
+		edgexcontext.ResponseContentType = clients.ContentTypeXML
 		return true, xml
 	}
 	return false, errors.New("Unexpected type received")
@@ -64,6 +66,7 @@ func (f Conversion) TransformToJSON(edgexcontext *appcontext.Context, params ...
 			// LoggingClient.Error(fmt.Sprintf("Error parsing JSON. Error: %s", err.Error()))
 			return false, errors.New("Error marshalling JSON")
 		}
+		edgexcontext.ResponseContentType = clients.ContentTypeJSON
 		// should we return a byte[] or string?
 		// return b
 		return true, string(b)

--- a/pkg/transforms/conversion_test.go
+++ b/pkg/transforms/conversion_test.go
@@ -63,6 +63,7 @@ func TestTransformToXML(t *testing.T) {
 
 	assert.NotNil(t, result)
 	assert.True(t, continuePipeline)
+	assert.Equal(t, clients.ContentTypeXML, context.ResponseContentType)
 	assert.Equal(t, expectedResult, result.(string))
 }
 func TestTransformToXMLNoParameters(t *testing.T) {
@@ -122,6 +123,7 @@ func TestTransformToJSON(t *testing.T) {
 
 	assert.NotNil(t, result)
 	assert.True(t, continuePipeline)
+	assert.Equal(t, clients.ContentTypeJSON, context.ResponseContentType)
 	assert.Equal(t, expectedResult, result.(string))
 }
 func TestTransformToJSONNoEvent(t *testing.T) {

--- a/pkg/transforms/outputdata.go
+++ b/pkg/transforms/outputdata.go
@@ -24,6 +24,7 @@ import (
 
 // OutputData houses transform for outputting data to configured trigger response, i.e. message bus
 type OutputData struct {
+	ResponseContentType string
 }
 
 // NewOutputData creates, initializes and returns a new instance of OutputData
@@ -46,6 +47,11 @@ func (f OutputData) SetOutputData(edgexcontext *appcontext.Context, params ...in
 	if err != nil {
 		return false, err
 	}
+
+	if len(f.ResponseContentType) > 0 {
+		edgexcontext.ResponseContentType = f.ResponseContentType
+	}
+
 	// By setting this the data will be posted back to to configured trigger response, i.e. message bus
 	edgexcontext.OutputData = data
 


### PR DESCRIPTION
If content-type is set on the context, the http trigger will use it
and set the appropriate header value on the response.

closes: #512
Signed-off-by: = Beau Frusetta <beau.frusetta@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
HTTP trigger does not set the response content-type

Issue Number: #512 


## What is the new behavior?
Response content-type is now available on context and if set, it will be included in response headers. We also added the OutputDataWithContentType to use with app-service-configurable.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## Are there any new imports or modules? If so, what are they used for and why?
No new packages

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information