### PR TITLE
fix: Fix response content type issue 567

### DIFF
--- a/pkg/transforms/compression.go
+++ b/pkg/transforms/compression.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
 	"github.com/edgexfoundry/app-functions-sdk-go/pkg/util"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 )
 
 type Compression struct {
@@ -61,6 +62,9 @@ func (compression *Compression) CompressWithGZIP(edgexcontext *appcontext.Contex
 	compression.gzipWriter.Write([]byte(data))
 	compression.gzipWriter.Close()
 
+	// Set response "content-type" header to "text/plain"
+	edgexcontext.ResponseContentType = clients.ContentTypeText
+
 	return true, bytesBufferToBase64(buf)
 
 }
@@ -87,6 +91,9 @@ func (compression *Compression) CompressWithZLIB(edgexcontext *appcontext.Contex
 
 	compression.zlibWriter.Write([]byte(data))
 	compression.zlibWriter.Close()
+
+	// Set response "content-type" header to "text/plain"
+	edgexcontext.ResponseContentType = clients.ContentTypeText
 
 	return true, bytesBufferToBase64(buf)
 

--- a/pkg/transforms/compression_test.go
+++ b/pkg/transforms/compression_test.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
@@ -58,6 +59,7 @@ func TestGzip(t *testing.T) {
 	continuePipeline2, result2 := comp.CompressWithGZIP(context, []byte(clearString))
 	assert.True(t, continuePipeline2)
 	assert.Equal(t, result.([]byte), result2.([]byte))
+	assert.Equal(t, context.ResponseContentType, clients.ContentTypeText)
 }
 
 func TestZlib(t *testing.T) {
@@ -83,6 +85,7 @@ func TestZlib(t *testing.T) {
 	continuePipeline2, result2 := comp.CompressWithZLIB(context, []byte(clearString))
 	assert.True(t, continuePipeline2)
 	assert.Equal(t, result.([]byte), result2.([]byte))
+	assert.Equal(t, context.ResponseContentType, clients.ContentTypeText)
 }
 
 var result []byte

--- a/pkg/transforms/encryption.go
+++ b/pkg/transforms/encryption.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
 	"github.com/edgexfoundry/app-functions-sdk-go/pkg/util"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 )
 
 type Encryption struct {
@@ -83,6 +84,9 @@ func (aesData Encryption) EncryptWithAES(edgexcontext *appcontext.Context, param
 	ecb.CryptBlocks(crypted, content)
 
 	encodedData := []byte(base64.StdEncoding.EncodeToString(crypted))
+
+	// Set response "content-type" header to "text/plain"
+	edgexcontext.ResponseContentType = clients.ContentTypeText
 
 	return true, encodedData
 }

--- a/pkg/transforms/encryption_test.go
+++ b/pkg/transforms/encryption_test.go
@@ -25,6 +25,7 @@ import (
 
 	"testing"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/stretchr/testify/assert"
 )
@@ -82,6 +83,7 @@ func TestAES(t *testing.T) {
 	decphrd := aesDecrypt(cphrd.([]byte), aesData)
 
 	assert.Equal(t, string(plainString), string(decphrd))
+	assert.Equal(t, context.ResponseContentType, clients.ContentTypeText)
 }
 
 func TestAESNoData(t *testing.T) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
When chaining TransformToJSON and CompressToGZip, the content type by default sets to application/json.

Issue Number:
#567 

## What is the new behavior?
SetOutputData will return an appropriate content-type header based on the chained transforms.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information