### PR TITLE
feat(sdk): Add MakeItStop

### DIFF
--- a/appsdk/sdk_test.go
+++ b/appsdk/sdk_test.go
@@ -462,3 +462,20 @@ func TestSetServiceKey(t *testing.T) {
 		})
 	}
 }
+
+func TestMakeItStop(t *testing.T) {
+	stopCalled := false
+
+	sdk := AppFunctionsSDK{
+		stop: func() {
+			stopCalled = true
+		},
+		LoggingClient: logger.NewMockClient(),
+	}
+
+	sdk.MakeItStop()
+	require.True(t, stopCalled, "Cancel function set at sdk.stop should be called if set")
+
+	sdk.stop = nil
+	sdk.MakeItStop() //should avoid nil pointer
+}


### PR DESCRIPTION
Store reference on the sdk to a CancelFunc created in MakeItRun and
expose to enable clean programmatic exits.

Signed-off-by: Alex Ullrich <alexullrich@technotects.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently there is no way to exit the service programmatically.

Issue Number:
#612 

## What is the new behavior?
Adds a MakeItStop method to the sdk instance that allows calling a cancel function managed by MakeItRun.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information