### PR TITLE
feat: Expect V2 Event DTO from triggers.

### DIFF
--- a/appcontext/context_test.go
+++ b/appcontext/context_test.go
@@ -25,7 +25,10 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	localURL "github.com/edgexfoundry/go-mod-core-contracts/v2/clients/urlclient/local"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -65,27 +68,32 @@ func TestPushToCore(t *testing.T) {
 		EventClient:   eventClient,
 		LoggingClient: lc,
 	}
-	newEvent := &models.Event{
-		ID:     "newId",
-		Device: "device-name",
-		Origin: 1567802840199266000,
-		Readings: []models.Reading{
+	expectedEvent := &dtos.Event{
+		Versionable: common.NewVersionable(),
+		DeviceName:  "device-name",
+		Readings: []dtos.BaseReading{
 			{
-				Device:      "device-name",
-				Name:        "device-resource",
-				Value:       "value",
-				BinaryValue: []uint8(nil),
+				Versionable:  common.NewVersionable(),
+				DeviceName:   "device-name",
+				ResourceName: "device-resource",
+				ValueType:    v2.ValueTypeString,
+				SimpleReading: dtos.SimpleReading{
+					Value: "value",
+				},
 			},
 		},
 	}
-	result, err := ctx.PushToCoreData("device-name", "device-resource", "value")
+	actualEvent, err := ctx.PushToCoreData("device-name", "device-resource", "value")
 	require.NoError(t, err)
 
-	assert.NotNil(t, result)
-	assert.Equal(t, newEvent.ID, result.ID)
-	assert.Equal(t, newEvent.Device, result.Device)
-	assert.Equal(t, newEvent.Readings[0].Name, result.Readings[0].Name)
-	assert.Equal(t, newEvent.Readings[0].Value, result.Readings[0].Value)
+	assert.NotNil(t, actualEvent)
+	assert.Equal(t, expectedEvent.ApiVersion, actualEvent.ApiVersion)
+	assert.Equal(t, expectedEvent.DeviceName, actualEvent.DeviceName)
+	assert.Equal(t, expectedEvent.Readings[0].DeviceName, actualEvent.Readings[0].DeviceName)
+	assert.Equal(t, expectedEvent.Readings[0].ResourceName, actualEvent.Readings[0].ResourceName)
+	assert.Equal(t, expectedEvent.Readings[0].Value, actualEvent.Readings[0].Value)
+	assert.Equal(t, expectedEvent.Readings[0].ValueType, actualEvent.Readings[0].ValueType)
+	assert.Equal(t, expectedEvent.Readings[0].ApiVersion, actualEvent.Readings[0].ApiVersion)
 }
 
 func TestSetRetryData(t *testing.T) {

--- a/appcontext/context_test.go
+++ b/appcontext/context_test.go
@@ -89,6 +89,7 @@ func TestPushToCore(t *testing.T) {
 	assert.NotNil(t, actualEvent)
 	assert.Equal(t, expectedEvent.ApiVersion, actualEvent.ApiVersion)
 	assert.Equal(t, expectedEvent.DeviceName, actualEvent.DeviceName)
+	assert.True(t, len(expectedEvent.Readings) == 1)
 	assert.Equal(t, expectedEvent.Readings[0].DeviceName, actualEvent.Readings[0].DeviceName)
 	assert.Equal(t, expectedEvent.Readings[0].ResourceName, actualEvent.Readings[0].ResourceName)
 	assert.Equal(t, expectedEvent.Readings[0].Value, actualEvent.Readings[0].Value)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.2
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.1
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.5
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.1
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.1
 	github.com/fxamacker/cbor/v2 v2.2.0

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/appcontext"
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/internal/common"
@@ -29,6 +30,10 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
+	commonDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/requests"
 	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
 
 	"github.com/fxamacker/cbor/v2"
@@ -39,24 +44,65 @@ import (
 var lc logger.LoggingClient
 
 const (
-	devID1     = "id1"
 	serviceKey = "AppService-UnitTest"
 )
+
+var testEvent = dtos.Event{
+	Versionable: commonDTO.NewVersionable(),
+	Id:          "82eb2e26-0f24-48aa-ae4c-de9dac3fb9bc",
+	DeviceName:  "FamilyRoomThermostat",
+	ProfileName: "Thermostat",
+	Created:     time.Now().Unix(),
+	Origin:      time.Now().Unix(),
+	Readings: []dtos.BaseReading{
+		{
+			Versionable:   commonDTO.NewVersionable(),
+			Id:            "82eb2e26-0f24-48aa-ae4c-de9dac3f1234",
+			Created:       time.Now().Unix(),
+			Origin:        time.Now().Unix(),
+			DeviceName:    "FamilyRoomThermostat",
+			ResourceName:  "Temperature",
+			ProfileName:   "Thermostat",
+			ValueType:     v2.ValueTypeInt64,
+			SimpleReading: dtos.SimpleReading{Value: "72"},
+		},
+	},
+	Tags: nil,
+}
+
+var testAddEventRequest = requests.AddEventRequest{
+	BaseRequest: commonDTO.BaseRequest{},
+	Event:       testEvent,
+}
+
+var testV1Event = models.Event{
+	ID:      "82eb2e26-0f24-48aa-ae4c-de9dac3fb9bc",
+	Device:  "FamilyRoomThermostat",
+	Created: time.Now().Unix(),
+	Origin:  time.Now().Unix(),
+	Readings: []models.Reading{
+		{
+			Id:        "82eb2e26-0f24-48aa-ae4c-de9dac3f1234",
+			Created:   time.Now().Unix(),
+			Origin:    time.Now().Unix(),
+			Device:    "FamilyRoomThermostat",
+			Name:      "Temperature",
+			ValueType: v2.ValueTypeInt64,
+			Value:     "72",
+		},
+	},
+	Tags: nil,
+}
 
 func init() {
 	lc = logger.NewMockClient()
 }
 
 func TestProcessMessageNoTransforms(t *testing.T) {
-	// Event from device 1
-
-	eventIn := models.Event{
-		Device: devID1,
-	}
-	eventInBytes, _ := json.Marshal(eventIn)
+	payload, _ := json.Marshal(testAddEventRequest)
 	envelope := types.MessageEnvelope{
 		CorrelationID: "123-234-345-456",
-		Payload:       eventInBytes,
+		Payload:       payload,
 		ContentType:   clients.ContentTypeJSON,
 	}
 	context := &appcontext.Context{
@@ -70,15 +116,10 @@ func TestProcessMessageNoTransforms(t *testing.T) {
 }
 
 func TestProcessMessageOneCustomTransform(t *testing.T) {
-	// Event from device 1
-
-	eventIn := models.Event{
-		Device: devID1,
-	}
-	eventInBytes, _ := json.Marshal(eventIn)
+	payload, _ := json.Marshal(testAddEventRequest)
 	envelope := types.MessageEnvelope{
 		CorrelationID: "123-234-345-456",
-		Payload:       eventInBytes,
+		Payload:       payload,
 		ContentType:   clients.ContentTypeJSON,
 	}
 	context := &appcontext.Context{
@@ -87,9 +128,9 @@ func TestProcessMessageOneCustomTransform(t *testing.T) {
 	transform1WasCalled := false
 	transform1 := func(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
 		require.True(t, len(params) > 0, "should have been passed the first event from CoreData")
-		if result, ok := params[0].(*models.Event); ok {
-			require.True(t, ok, "Should have receieved CoreData event")
-			require.Equal(t, devID1, result.Device, "Did not receive expected CoreData Event")
+		if result, ok := params[0].(*dtos.Event); ok {
+			require.True(t, ok, "Should have received EdgeX event")
+			require.Equal(t, testEvent.DeviceName, result.DeviceName, "Did not receive expected EdgeX event")
 		}
 		transform1WasCalled = true
 		return true, "Hello"
@@ -103,15 +144,10 @@ func TestProcessMessageOneCustomTransform(t *testing.T) {
 }
 
 func TestProcessMessageTwoCustomTransforms(t *testing.T) {
-	// Event from device 1
-
-	eventIn := models.Event{
-		Device: devID1,
-	}
-	eventInBytes, _ := json.Marshal(eventIn)
+	payload, _ := json.Marshal(testAddEventRequest)
 	envelope := types.MessageEnvelope{
 		CorrelationID: "123-234-345-456",
-		Payload:       eventInBytes,
+		Payload:       payload,
 		ContentType:   clients.ContentTypeJSON,
 	}
 	context := &appcontext.Context{
@@ -123,9 +159,9 @@ func TestProcessMessageTwoCustomTransforms(t *testing.T) {
 	transform1 := func(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
 		transform1WasCalled = true
 		require.True(t, len(params) > 0, "should have been passed the first event from CoreData")
-		if result, ok := params[0].(models.Event); ok {
+		if result, ok := params[0].(dtos.Event); ok {
 			require.True(t, ok, "Should have received Event")
-			assert.Equal(t, devID1, result.Device, "Did not receive expected Event")
+			assert.Equal(t, testEvent.DeviceName, result.DeviceName, "Did not receive expected Event")
 		}
 
 		return true, "Transform1Result"
@@ -148,15 +184,10 @@ func TestProcessMessageTwoCustomTransforms(t *testing.T) {
 }
 
 func TestProcessMessageThreeCustomTransformsOneFail(t *testing.T) {
-	// Event from device 1
-
-	eventIn := models.Event{
-		Device: devID1,
-	}
-	eventInBytes, _ := json.Marshal(eventIn)
+	payload, _ := json.Marshal(testAddEventRequest)
 	envelope := types.MessageEnvelope{
 		CorrelationID: "123-234-345-456",
-		Payload:       eventInBytes,
+		Payload:       payload,
 		ContentType:   clients.ContentTypeJSON,
 	}
 	context := &appcontext.Context{
@@ -170,9 +201,9 @@ func TestProcessMessageThreeCustomTransformsOneFail(t *testing.T) {
 		transform1WasCalled = true
 		require.True(t, len(params) > 0, "should have been passed the first event from CoreData")
 
-		if result, ok := params[0].(*models.Event); ok {
-			require.True(t, ok, "Should have received CoreData event")
-			require.Equal(t, devID1, result.Device, "Did not receive expected CoreData event")
+		if result, ok := params[0].(*dtos.Event); ok {
+			require.True(t, ok, "Should have received EdgeX event")
+			require.Equal(t, testEvent.DeviceName, result.DeviceName, "Did not receive expected EdgeX event")
 		}
 
 		return false, "Transform1Result"
@@ -205,7 +236,7 @@ func TestProcessMessageTransformError(t *testing.T) {
 
 	// Send a RegistryInfo to the pipeline, instead of an Event
 	registryInfo := config.RegistryInfo{
-		Host: devID1,
+		Host: testEvent.DeviceName,
 	}
 	payload, _ := json.Marshal(registryInfo)
 	envelope := types.MessageEnvelope{
@@ -230,20 +261,14 @@ func TestProcessMessageTransformError(t *testing.T) {
 }
 
 func TestProcessMessageJSON(t *testing.T) {
-	// Event from device 1
-	expectedEventID := "1234"
 	expectedCorrelationID := "123-234-345-456"
-	eventIn := models.Event{
-		ID:     expectedEventID,
-		Device: devID1,
-	}
 
 	transform1WasCalled := false
 
-	eventInBytes, _ := json.Marshal(eventIn)
+	payload, _ := json.Marshal(testAddEventRequest)
 	envelope := types.MessageEnvelope{
 		CorrelationID: expectedCorrelationID,
-		Payload:       eventInBytes,
+		Payload:       payload,
 		ContentType:   clients.ContentTypeJSON,
 	}
 
@@ -257,10 +282,10 @@ func TestProcessMessageJSON(t *testing.T) {
 
 		require.Equal(t, expectedCorrelationID, edgexcontext.CorrelationID, "Context doesn't contain expected CorrelationID")
 
-		if result, ok := params[0].(*models.Event); ok {
-			require.True(t, ok, "Should have received CoreData event")
-			assert.Equal(t, devID1, result.Device, "Did not receive expected CoreData event, wrong device")
-			assert.Equal(t, expectedEventID, result.ID, "Did not receive expected CoreData event, wrong ID")
+		if result, ok := params[0].(*dtos.Event); ok {
+			require.True(t, ok, "Should have received EdgeX event")
+			assert.Equal(t, testEvent.DeviceName, result.DeviceName, "Did not receive expected EdgeX event, wrong device")
+			assert.Equal(t, testEvent.Id, result.Id, "Did not receive expected EdgeX event, wrong ID")
 		}
 
 		return false, nil
@@ -271,30 +296,23 @@ func TestProcessMessageJSON(t *testing.T) {
 	runtime.SetTransforms([]appcontext.AppFunction{transform1})
 
 	result := runtime.ProcessMessage(context, envelope)
-	assert.Nil(t, result, "result should be null")
+	assert.Nilf(t, result, "result should be null. Got %v", result)
 	assert.True(t, transform1WasCalled, "transform1 should have been called")
 }
 
 func TestProcessMessageCBOR(t *testing.T) {
-	// Event from device 1
-	expectedEventID := "6789"
 	expectedCorrelationID := "123-234-345-456"
-	expectedChecksum := "1234567890"
-	eventIn := models.Event{
-		ID:     expectedEventID,
-		Device: devID1,
-	}
 
 	transform1WasCalled := false
 
-	eventCborBytes, err := cbor.Marshal(eventIn)
+	// TODO: Change to TestAddEventRequest when V2 has support for CBOR
+	payload, err := cbor.Marshal(testEvent)
 	assert.NoError(t, err, "expected no error when marshalling data")
 
 	envelope := types.MessageEnvelope{
 		CorrelationID: expectedCorrelationID,
-		Payload:       eventCborBytes,
+		Payload:       payload,
 		ContentType:   clients.ContentTypeCBOR,
-		Checksum:      expectedChecksum,
 	}
 
 	context := &appcontext.Context{
@@ -307,10 +325,10 @@ func TestProcessMessageCBOR(t *testing.T) {
 
 		require.Equal(t, expectedCorrelationID, edgexcontext.CorrelationID, "Context doesn't contain expected CorrelationID")
 
-		if result, ok := params[0].(*models.Event); ok {
-			require.True(t, ok, "Should have received CoreData event")
-			assert.Equal(t, devID1, result.Device, "Did not receive expected CoreData event, wrong device")
-			assert.Equal(t, expectedEventID, result.ID, "Did not receive expected CoreData event, wrong ID")
+		if result, ok := params[0].(*dtos.Event); ok {
+			require.True(t, ok, "Should have received EdgeX event")
+			assert.Equal(t, testEvent.DeviceName, result.DeviceName, "Did not receive expected EdgeX event, wrong device")
+			assert.Equal(t, testEvent.Id, result.Id, "Did not receive expected EdgeX event, wrong ID")
 		}
 
 		return false, nil
@@ -329,7 +347,7 @@ type CustomType struct {
 	ID string `json:"id"`
 }
 
-// Must implement the Marshaler interface so SetOutputData will marshal it to JSON
+// Must implement the Marshaller interface so SetOutputData will marshal it to JSON
 func (custom CustomType) MarshalJSON() ([]byte, error) {
 	test := struct {
 		ID string `json:"id"`
@@ -341,18 +359,17 @@ func (custom CustomType) MarshalJSON() ([]byte, error) {
 }
 
 func TestProcessMessageTargetType(t *testing.T) {
-	eventIn := models.Event{
-		Device: devID1,
-	}
-	eventJson, _ := json.Marshal(eventIn)
+	jsonPayload, _ := json.Marshal(testAddEventRequest)
+	eventJson, _ := json.Marshal(testEvent)
 
-	eventCborBytes, err := cbor.Marshal(eventIn)
+	// TODO: Change to TestAddEventRequest when V2 has support for CBOR
+	cborPayload, err := cbor.Marshal(testAddEventRequest)
 	assert.NoError(t, err, "expected no error when marshalling data")
 
 	expected := CustomType{
 		ID: "Id1",
 	}
-	customJson, _ := expected.MarshalJSON()
+	customJsonPayload, _ := expected.MarshalJSON()
 	byteData := []byte("This is my bytes")
 
 	targetTypeTests := []struct {
@@ -363,12 +380,12 @@ func TestProcessMessageTargetType(t *testing.T) {
 		ExpectedOutputData []byte
 		ErrorExpected      bool
 	}{
-		{"Default Nil Target Type", nil, eventJson, clients.ContentTypeJSON, eventJson, false},
-		{"Event as Json", &models.Event{}, eventJson, clients.ContentTypeJSON, eventJson, false},
-		{"Event as Cbor", &models.Event{}, eventCborBytes, clients.ContentTypeCBOR, eventJson, false}, // Not re-encoding as CBOR
-		{"Custom Type Json", &CustomType{}, customJson, clients.ContentTypeJSON, customJson, false},
+		{"Default Nil Target Type", nil, jsonPayload, clients.ContentTypeJSON, eventJson, false},
+		{"Event as Json", &dtos.Event{}, jsonPayload, clients.ContentTypeJSON, eventJson, false},
+		{"Event as Cbor", &dtos.Event{}, cborPayload, clients.ContentTypeCBOR, eventJson, false}, // Not re-encoding as CBOR
+		{"Custom Type Json", &CustomType{}, customJsonPayload, clients.ContentTypeJSON, customJsonPayload, false},
 		{"Byte Slice", &[]byte{}, byteData, "application/binary", byteData, false},
-		{"Target Type Not a pointer", models.Event{}, nil, "", nil, true},
+		{"Target Type Not a pointer", dtos.Event{}, nil, "", nil, true},
 	}
 
 	for _, currentTest := range targetTypeTests {
@@ -401,7 +418,7 @@ func TestProcessMessageTargetType(t *testing.T) {
 
 func TestExecutePipelinePersist(t *testing.T) {
 	expectedItemCount := 1
-	config := common.ConfigurationStruct{
+	configuration := common.ConfigurationStruct{
 		Writable: common.WritableInfo{
 			LogLevel: "DEBUG",
 			StoreAndForward: common.StoreAndForwardInfo{
@@ -411,7 +428,7 @@ func TestExecutePipelinePersist(t *testing.T) {
 	}
 
 	ctx := appcontext.Context{
-		Configuration: &config,
+		Configuration: &configuration,
 		LoggingClient: lc,
 		CorrelationID: "CorrelationID",
 	}
@@ -436,4 +453,139 @@ func TestExecutePipelinePersist(t *testing.T) {
 	require.Equal(t, expectedItemCount, len(storedObjects), "unexpected item count")
 	assert.Equal(t, serviceKey, storedObjects[0].AppServiceKey, "AppServiceKey not as expected")
 	assert.Equal(t, ctx.CorrelationID, storedObjects[0].CorrelationID, "CorrelationID not as expected")
+}
+
+// TODO: Remove once switch completely to V2 Event DTOs
+func TestProcessMessageJSONWithV1Event(t *testing.T) {
+	expectedCorrelationID := "123-234-345-456"
+
+	transform1WasCalled := false
+
+	eventInBytes, _ := json.Marshal(testV1Event)
+	envelope := types.MessageEnvelope{
+		CorrelationID: expectedCorrelationID,
+		Payload:       eventInBytes,
+		ContentType:   clients.ContentTypeJSON,
+	}
+
+	context := &appcontext.Context{
+		LoggingClient: lc,
+		CorrelationID: expectedCorrelationID,
+	}
+
+	transform1 := func(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
+		transform1WasCalled = true
+
+		require.Equal(t, expectedCorrelationID, edgexcontext.CorrelationID, "Context doesn't contain expected CorrelationID")
+
+		if result, ok := params[0].(*dtos.Event); ok {
+			require.True(t, ok, "Should have received EdgeX event")
+			assert.Equal(t, testEvent.DeviceName, result.DeviceName, "Did not receive expected EdgeX event, wrong device")
+			assert.Equal(t, testEvent.Id, result.Id, "Did not receive expected EdgeX event, wrong ID")
+		}
+
+		return false, nil
+	}
+
+	runtime := GolangRuntime{}
+	runtime.Initialize(nil, nil)
+	runtime.SetTransforms([]appcontext.AppFunction{transform1})
+
+	result := runtime.ProcessMessage(context, envelope)
+	assert.Nil(t, result, "result should be null")
+	assert.True(t, transform1WasCalled, "transform1 should have been called")
+}
+
+func TestGolangRuntime_getApiVersion(t *testing.T) {
+	jsonV2Payload, _ := json.Marshal(testAddEventRequest)
+	cborV2Payload, _ := cbor.Marshal(testAddEventRequest)
+	jsonV1Payload, _ := json.Marshal(testV1Event)
+	cborV1Payload, _ := cbor.Marshal(testV1Event)
+
+	tests := []struct {
+		Name        string
+		Payload     []byte
+		ContentType string
+		Expected    string
+	}{
+		{"JSON V2 Event", jsonV2Payload, clients.ContentTypeJSON, ApiV2},
+		{"CBOR V2 Event", cborV2Payload, clients.ContentTypeCBOR, ApiV2},
+		{"JSON V1 Event", jsonV1Payload, clients.ContentTypeJSON, ApiV1},
+		{"CBOR V1 Event", cborV1Payload, clients.ContentTypeCBOR, ApiV1},
+	}
+
+	target := GolangRuntime{}
+
+	for _, testCase := range tests {
+		t.Run(testCase.Name, func(t *testing.T) {
+			envelope := types.MessageEnvelope{}
+			envelope.Payload = testCase.Payload
+			envelope.ContentType = testCase.ContentType
+
+			actual, err := target.getApiVersion(envelope)
+			require.NoError(t, err)
+			require.Equal(t, testCase.Expected, actual)
+		})
+	}
+}
+
+func TestGolangRuntime_unmarshalV1EventToV2Event(t *testing.T) {
+	target := GolangRuntime{}
+
+	jsonV1Payload, _ := json.Marshal(testV1Event)
+	cborV1Payload, _ := cbor.Marshal(testV1Event)
+	expected := testEvent
+	expected.ProfileName = "Unknown"
+	expected.Readings[0].ProfileName = "Unknown"
+
+	tests := []struct {
+		Name        string
+		Payload     []byte
+		ContentType string
+	}{
+		{"JSON V1 Event", jsonV1Payload, clients.ContentTypeJSON},
+		{"CBOR V1 Event", cborV1Payload, clients.ContentTypeCBOR},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.Name, func(t *testing.T) {
+			envelope := types.MessageEnvelope{}
+			envelope.Payload = testCase.Payload
+			envelope.ContentType = testCase.ContentType
+
+			actual, err := target.unmarshalV1EventToV2Event(envelope, lc)
+			require.NoError(t, err)
+			require.Equal(t, expected, *actual)
+		})
+	}
+}
+
+func TestGolangRuntime_unmarshalV2Event(t *testing.T) {
+	jsonV2Payload, _ := json.Marshal(testAddEventRequest)
+	cborV2Payload, _ := cbor.Marshal(testAddEventRequest)
+
+	expected := testEvent
+
+	tests := []struct {
+		Name        string
+		Payload     []byte
+		ContentType string
+	}{
+		{"JSON V2 Event", jsonV2Payload, clients.ContentTypeJSON},
+		{"CBOR V2 Event", cborV2Payload, clients.ContentTypeCBOR},
+	}
+
+	target := GolangRuntime{}
+
+	for _, testCase := range tests {
+		t.Run(testCase.Name, func(t *testing.T) {
+			envelope := types.MessageEnvelope{}
+			envelope.Payload = testCase.Payload
+			envelope.ContentType = testCase.ContentType
+
+			actual, err := target.unmarshalEventDTO(envelope, lc)
+			require.NoError(t, err)
+			require.Equal(t, expected, *actual)
+		})
+	}
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -99,7 +99,8 @@ func init() {
 }
 
 func TestProcessMessageNoTransforms(t *testing.T) {
-	payload, _ := json.Marshal(testAddEventRequest)
+	payload, err := json.Marshal(testAddEventRequest)
+	require.NoError(t, err)
 	envelope := types.MessageEnvelope{
 		CorrelationID: "123-234-345-456",
 		Payload:       payload,
@@ -116,7 +117,9 @@ func TestProcessMessageNoTransforms(t *testing.T) {
 }
 
 func TestProcessMessageOneCustomTransform(t *testing.T) {
-	payload, _ := json.Marshal(testAddEventRequest)
+	payload, err := json.Marshal(testAddEventRequest)
+	require.NoError(t, err)
+
 	envelope := types.MessageEnvelope{
 		CorrelationID: "123-234-345-456",
 		Payload:       payload,
@@ -144,7 +147,9 @@ func TestProcessMessageOneCustomTransform(t *testing.T) {
 }
 
 func TestProcessMessageTwoCustomTransforms(t *testing.T) {
-	payload, _ := json.Marshal(testAddEventRequest)
+	payload, err := json.Marshal(testAddEventRequest)
+	require.NoError(t, err)
+
 	envelope := types.MessageEnvelope{
 		CorrelationID: "123-234-345-456",
 		Payload:       payload,
@@ -184,7 +189,9 @@ func TestProcessMessageTwoCustomTransforms(t *testing.T) {
 }
 
 func TestProcessMessageThreeCustomTransformsOneFail(t *testing.T) {
-	payload, _ := json.Marshal(testAddEventRequest)
+	payload, err := json.Marshal(testAddEventRequest)
+	require.NoError(t, err)
+
 	envelope := types.MessageEnvelope{
 		CorrelationID: "123-234-345-456",
 		Payload:       payload,
@@ -265,7 +272,9 @@ func TestProcessMessageJSON(t *testing.T) {
 
 	transform1WasCalled := false
 
-	payload, _ := json.Marshal(testAddEventRequest)
+	payload, err := json.Marshal(testAddEventRequest)
+	require.NoError(t, err)
+
 	envelope := types.MessageEnvelope{
 		CorrelationID: expectedCorrelationID,
 		Payload:       payload,
@@ -359,8 +368,11 @@ func (custom CustomType) MarshalJSON() ([]byte, error) {
 }
 
 func TestProcessMessageTargetType(t *testing.T) {
-	jsonPayload, _ := json.Marshal(testAddEventRequest)
-	eventJson, _ := json.Marshal(testEvent)
+	jsonPayload, err := json.Marshal(testAddEventRequest)
+	require.NoError(t, err)
+
+	eventJson, err := json.Marshal(testEvent)
+	require.NoError(t, err)
 
 	// TODO: Change to TestAddEventRequest when V2 has support for CBOR
 	cborPayload, err := cbor.Marshal(testAddEventRequest)

--- a/internal/trigger/messagebus/messaging_test.go
+++ b/internal/trigger/messagebus/messaging_test.go
@@ -19,7 +19,6 @@ package messagebus
 import (
 	"context"
 	"encoding/json"
-	"github.com/google/uuid"
 	"sync"
 	"testing"
 	"time"
@@ -30,15 +29,47 @@ import (
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
+	commonDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/requests"
 	"github.com/edgexfoundry/go-mod-messaging/v2/messaging"
 	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 var logClient logger.LoggingClient
+
+var expectedEvent = dtos.Event{
+	Versionable: commonDTO.NewVersionable(),
+	Id:          "7a1707f0-166f-4c4b-bc9d-1d54c74e0137",
+	DeviceName:  "LivingRoomThermostat",
+	ProfileName: "thermostat",
+	Created:     1485364897029,
+	Origin:      1471806386919,
+	Readings: []dtos.BaseReading{
+		{
+			Versionable:   commonDTO.NewVersionable(),
+			Id:            "7a1707f0-166f-4c4b-bc9d-1d54c74e0145",
+			Created:       1485364896983,
+			Origin:        1471806386919,
+			DeviceName:    "LivingRoomThermostat",
+			ResourceName:  "temperature",
+			ProfileName:   "thermostat",
+			ValueType:     v2.ValueTypeInt64,
+			SimpleReading: dtos.SimpleReading{Value: "38"},
+		},
+	},
+	Tags: nil,
+}
+
+var addEventRequest = requests.AddEventRequest{
+	BaseRequest: commonDTO.BaseRequest{},
+	Event:       expectedEvent,
+}
 
 func init() {
 	logClient = logger.NewMockClient()
@@ -132,10 +163,6 @@ func TestInitializeAndProcessEventWithNoOutput(t *testing.T) {
 
 	expectedCorrelationID := "123"
 
-	expectedPayload := []byte(`{"id":"5888dea1bd36573f4681d6f9","created":1485364897029,"modified":1485364897029,"origin":1471806386919,"pushed":0,"device":"livingroomthermostat","readings":[{"id":"5888dea0bd36573f4681d6f8","created":1485364896983,"modified":1485364896983,"origin":1471806386919,"pushed":0,"name":"temperature","value":"38","device":"livingroomthermostat"}]}`)
-	var expectedEvent models.Event
-	_ = json.Unmarshal(expectedPayload, &expectedEvent)
-
 	transformWasCalled := common.AtomicBool{}
 
 	transform1 := func(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
@@ -150,9 +177,11 @@ func TestInitializeAndProcessEventWithNoOutput(t *testing.T) {
 	trigger := Trigger{Configuration: &config, Runtime: goRuntime, EdgeXClients: common.EdgeXClients{LoggingClient: logClient}}
 	_, _ = trigger.Initialize(&sync.WaitGroup{}, context.Background(), nil)
 
+	payload, _ := json.Marshal(addEventRequest)
+
 	message := types.MessageEnvelope{
 		CorrelationID: expectedCorrelationID,
-		Payload:       expectedPayload,
+		Payload:       payload,
 		ContentType:   clients.ContentTypeJSON,
 	}
 
@@ -203,10 +232,6 @@ func TestInitializeAndProcessEventWithOutput(t *testing.T) {
 
 	expectedCorrelationID := "123"
 
-	expectedPayload := []byte(`{"id":"5888dea1bd36573f4681d6f9","created":1485364897029,"modified":1485364897029,"origin":1471806386919,"pushed":0,"device":"livingroomthermostat","readings":[{"id":"5888dea0bd36573f4681d6f8","created":1485364896983,"modified":1485364896983,"origin":1471806386919,"pushed":0,"name":"temperature","value":"38","device":"livingroomthermostat"}]}`)
-	var expectedEvent models.Event
-	_ = json.Unmarshal(expectedPayload, &expectedEvent)
-
 	transformWasCalled := common.AtomicBool{}
 
 	transform1 := func(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
@@ -246,9 +271,11 @@ func TestInitializeAndProcessEventWithOutput(t *testing.T) {
 	require.NoError(t, err)
 	_, _ = trigger.Initialize(&sync.WaitGroup{}, context.Background(), nil)
 
+	payload, _ := json.Marshal(addEventRequest)
+
 	message := types.MessageEnvelope{
 		CorrelationID: expectedCorrelationID,
-		Payload:       expectedPayload,
+		Payload:       payload,
 		ContentType:   clients.ContentTypeJSON,
 	}
 
@@ -299,10 +326,6 @@ func TestInitializeAndProcessEventWithOutput_InferJSON(t *testing.T) {
 
 	expectedCorrelationID := "123"
 
-	expectedPayload := []byte(`{"id":"5888dea1bd36573f4681d6f9","created":1485364897029,"modified":1485364897029,"origin":1471806386919,"pushed":0,"device":"livingroomthermostat","readings":[{"id":"5888dea0bd36573f4681d6f8","created":1485364896983,"modified":1485364896983,"origin":1471806386919,"pushed":0,"name":"temperature","value":"38","device":"livingroomthermostat"}]}`)
-	var expectedEvent models.Event
-	_ = json.Unmarshal(expectedPayload, &expectedEvent)
-
 	transformWasCalled := common.AtomicBool{}
 
 	transform1 := func(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
@@ -341,9 +364,11 @@ func TestInitializeAndProcessEventWithOutput_InferJSON(t *testing.T) {
 	require.NoError(t, err)
 	_, _ = trigger.Initialize(&sync.WaitGroup{}, context.Background(), nil)
 
+	payload, _ := json.Marshal(addEventRequest)
+
 	message := types.MessageEnvelope{
 		CorrelationID: expectedCorrelationID,
-		Payload:       expectedPayload,
+		Payload:       payload,
 		ContentType:   clients.ContentTypeJSON,
 	}
 
@@ -394,10 +419,6 @@ func TestInitializeAndProcessEventWithOutput_AssumeCBOR(t *testing.T) {
 
 	expectedCorrelationID := "123"
 
-	expectedPayload := []byte(`{"id":"5888dea1bd36573f4681d6f9","created":1485364897029,"modified":1485364897029,"origin":1471806386919,"pushed":0,"device":"livingroomthermostat","readings":[{"id":"5888dea0bd36573f4681d6f8","created":1485364896983,"modified":1485364896983,"origin":1471806386919,"pushed":0,"name":"temperature","value":"38","device":"livingroomthermostat"}]}`)
-	var expectedEvent models.Event
-	_ = json.Unmarshal(expectedPayload, &expectedEvent)
-
 	transformWasCalled := common.AtomicBool{}
 
 	transform1 := func(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
@@ -435,9 +456,11 @@ func TestInitializeAndProcessEventWithOutput_AssumeCBOR(t *testing.T) {
 	require.NoError(t, err)
 	_, _ = trigger.Initialize(&sync.WaitGroup{}, context.Background(), nil)
 
+	payload, _ := json.Marshal(addEventRequest)
+
 	message := types.MessageEnvelope{
 		CorrelationID: expectedCorrelationID,
-		Payload:       expectedPayload,
+		Payload:       payload,
 		ContentType:   clients.ContentTypeJSON,
 	}
 
@@ -565,9 +588,6 @@ func TestInitializeAndProcessEventMultipleTopics(t *testing.T) {
 	}
 
 	expectedCorrelationID := "123"
-	expectedPayload := []byte(`{"id":"TBD","created":1485364897029,"modified":1485364897029,"origin":1471806386919,"pushed":0,"device":"livingroomthermostat","readings":[{"id":"5888dea0bd36573f4681d6f8","created":1485364896983,"modified":1485364896983,"origin":1471806386919,"pushed":0,"name":"temperature","value":"38","device":"livingroomthermostat"}]}`)
-	var expectedEvent models.Event
-	_ = json.Unmarshal(expectedPayload, &expectedEvent)
 
 	done := make(chan bool)
 	transform1 := func(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
@@ -583,9 +603,11 @@ func TestInitializeAndProcessEventMultipleTopics(t *testing.T) {
 	_, err := trigger.Initialize(&sync.WaitGroup{}, context.Background(), nil)
 	require.NoError(t, err)
 
+	payload, _ := json.Marshal(addEventRequest)
+
 	message := types.MessageEnvelope{
 		CorrelationID: expectedCorrelationID,
-		Payload:       expectedPayload,
+		Payload:       payload,
 		ContentType:   clients.ContentTypeJSON,
 	}
 
@@ -608,7 +630,7 @@ func TestInitializeAndProcessEventMultipleTopics(t *testing.T) {
 	case <-done:
 		// do nothing, just need to fall out.
 	case <-time.After(3 * time.Second):
-		require.Fail(t, "Transform never called")
+		require.Fail(t, "Transform never called for t1")
 	}
 
 	err = testClient.Publish(message, "t2") //transform1 should be called after this executes
@@ -618,6 +640,6 @@ func TestInitializeAndProcessEventMultipleTopics(t *testing.T) {
 	case <-done:
 		// do nothing, just need to fall out.
 	case <-time.After(3 * time.Second):
-		require.Fail(t, "Transform never called")
+		require.Fail(t, "Transform never called t2")
 	}
 }

--- a/internal/trigger/messagebus/messaging_test.go
+++ b/internal/trigger/messagebus/messaging_test.go
@@ -177,7 +177,8 @@ func TestInitializeAndProcessEventWithNoOutput(t *testing.T) {
 	trigger := Trigger{Configuration: &config, Runtime: goRuntime, EdgeXClients: common.EdgeXClients{LoggingClient: logClient}}
 	_, _ = trigger.Initialize(&sync.WaitGroup{}, context.Background(), nil)
 
-	payload, _ := json.Marshal(addEventRequest)
+	payload, err := json.Marshal(addEventRequest)
+	require.NoError(t, err)
 
 	message := types.MessageEnvelope{
 		CorrelationID: expectedCorrelationID,
@@ -269,9 +270,11 @@ func TestInitializeAndProcessEventWithOutput(t *testing.T) {
 
 	err = testClient.Subscribe(testTopics, testMessageErrors) //subscribe in order to receive transformed output to the bus
 	require.NoError(t, err)
-	_, _ = trigger.Initialize(&sync.WaitGroup{}, context.Background(), nil)
+	_, err = trigger.Initialize(&sync.WaitGroup{}, context.Background(), nil)
+	require.NoError(t, err)
 
-	payload, _ := json.Marshal(addEventRequest)
+	payload, err := json.Marshal(addEventRequest)
+	require.NoError(t, err)
 
 	message := types.MessageEnvelope{
 		CorrelationID: expectedCorrelationID,
@@ -362,9 +365,11 @@ func TestInitializeAndProcessEventWithOutput_InferJSON(t *testing.T) {
 
 	err = testClient.Subscribe(testTopics, testMessageErrors) //subscribe in order to receive transformed output to the bus
 	require.NoError(t, err)
-	_, _ = trigger.Initialize(&sync.WaitGroup{}, context.Background(), nil)
+	_, err = trigger.Initialize(&sync.WaitGroup{}, context.Background(), nil)
+	require.NoError(t, err)
 
-	payload, _ := json.Marshal(addEventRequest)
+	payload, err := json.Marshal(addEventRequest)
+	require.NoError(t, err)
 
 	message := types.MessageEnvelope{
 		CorrelationID: expectedCorrelationID,

--- a/pkg/transforms/conversion.go
+++ b/pkg/transforms/conversion.go
@@ -22,8 +22,9 @@ import (
 	"fmt"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/appcontext"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
 )
 
 // Conversion houses various built in conversion transforms (XML, JSON, CSV)
@@ -42,7 +43,7 @@ func (f Conversion) TransformToXML(edgexcontext *appcontext.Context, params ...i
 		return false, errors.New("No Event Received")
 	}
 	edgexcontext.LoggingClient.Debug("Transforming to XML")
-	if event, ok := params[0].(models.Event); ok {
+	if event, ok := params[0].(dtos.Event); ok {
 		xml, err := event.ToXML()
 		if err != nil {
 			return false, fmt.Errorf("unable to marshal Event to XML: %s", err.Error())
@@ -60,7 +61,7 @@ func (f Conversion) TransformToJSON(edgexcontext *appcontext.Context, params ...
 		return false, errors.New("No Event Received")
 	}
 	edgexcontext.LoggingClient.Debug("Transforming to JSON")
-	if result, ok := params[0].(models.Event); ok {
+	if result, ok := params[0].(dtos.Event); ok {
 		b, err := json.Marshal(result)
 		if err != nil {
 			// LoggingClient.Error(fmt.Sprintf("Error parsing JSON. Error: %s", err.Error()))

--- a/pkg/transforms/conversion_test.go
+++ b/pkg/transforms/conversion_test.go
@@ -20,22 +20,20 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces/mocks"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/urlclient/local"
-	"github.com/stretchr/testify/require"
+	"github.com/edgexfoundry/app-functions-sdk-go/v2/appcontext"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces/mocks"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/urlclient/local"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
+
 	"github.com/stretchr/testify/assert"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
-
-	"github.com/edgexfoundry/app-functions-sdk-go/v2/appcontext"
+	"github.com/stretchr/testify/require"
 )
 
 var context *appcontext.Context
-var lc logger.LoggingClient
 
 const (
 	devID1 = "id1"
@@ -58,10 +56,10 @@ func init() {
 
 func TestTransformToXML(t *testing.T) {
 	// Event from device 1
-	eventIn := models.Event{
-		Device: devID1,
+	eventIn := dtos.Event{
+		DeviceName: devID1,
 	}
-	expectedResult := `<Event><ID></ID><Pushed>0</Pushed><Device>id1</Device><Created>0</Created><Modified>0</Modified><Origin>0</Origin></Event>`
+	expectedResult := `<Event><ApiVersion></ApiVersion><Id></Id><DeviceName>id1</DeviceName><ProfileName></ProfileName><Created>0</Created><Origin>0</Origin></Event>`
 	conv := NewConversion()
 
 	continuePipeline, result := conv.TransformToXML(context, eventIn)
@@ -88,10 +86,10 @@ func TestTransformToXMLNotAnEvent(t *testing.T) {
 }
 func TestTransformToXMLMultipleParametersValid(t *testing.T) {
 	// Event from device 1
-	eventIn := models.Event{
-		Device: devID1,
+	eventIn := dtos.Event{
+		DeviceName: devID1,
 	}
-	expectedResult := `<Event><ID></ID><Pushed>0</Pushed><Device>id1</Device><Created>0</Created><Modified>0</Modified><Origin>0</Origin></Event>`
+	expectedResult := `<Event><ApiVersion></ApiVersion><Id></Id><DeviceName>id1</DeviceName><ProfileName></ProfileName><Created>0</Created><Origin>0</Origin></Event>`
 	conv := NewConversion()
 	continuePipeline, result := conv.TransformToXML(context, eventIn, "", "", "")
 	require.NotNil(t, result)
@@ -100,14 +98,14 @@ func TestTransformToXMLMultipleParametersValid(t *testing.T) {
 }
 func TestTransformToXMLMultipleParametersTwoEvents(t *testing.T) {
 	// Event from device 1
-	eventIn1 := models.Event{
-		Device: devID1,
+	eventIn1 := dtos.Event{
+		DeviceName: devID1,
 	}
 	// Event from device 1
-	eventIn2 := models.Event{
-		Device: devID2,
+	eventIn2 := dtos.Event{
+		DeviceName: devID2,
 	}
-	expectedResult := `<Event><ID></ID><Pushed>0</Pushed><Device>id2</Device><Created>0</Created><Modified>0</Modified><Origin>0</Origin></Event>`
+	expectedResult := `<Event><ApiVersion></ApiVersion><Id></Id><DeviceName>id2</DeviceName><ProfileName></ProfileName><Created>0</Created><Origin>0</Origin></Event>`
 	conv := NewConversion()
 	continuePipeline, result := conv.TransformToXML(context, eventIn2, eventIn1, "", "")
 
@@ -119,10 +117,10 @@ func TestTransformToXMLMultipleParametersTwoEvents(t *testing.T) {
 
 func TestTransformToJSON(t *testing.T) {
 	// Event from device 1
-	eventIn := models.Event{
-		Device: devID1,
+	eventIn := dtos.Event{
+		DeviceName: devID1,
 	}
-	expectedResult := `{"device":"id1"}`
+	expectedResult := `{"id":"","deviceName":"id1","profileName":"","created":0,"origin":0,"readings":null}`
 	conv := NewConversion()
 	continuePipeline, result := conv.TransformToJSON(context, eventIn)
 
@@ -148,10 +146,10 @@ func TestTransformToJSONNotAnEvent(t *testing.T) {
 }
 func TestTransformToJSONMultipleParametersValid(t *testing.T) {
 	// Event from device 1
-	eventIn := models.Event{
-		Device: devID1,
+	eventIn := dtos.Event{
+		DeviceName: devID1,
 	}
-	expectedResult := `{"device":"id1"}`
+	expectedResult := `{"id":"","deviceName":"id1","profileName":"","created":0,"origin":0,"readings":null}`
 	conv := NewConversion()
 	continuePipeline, result := conv.TransformToJSON(context, eventIn, "", "", "")
 	assert.NotNil(t, result)
@@ -161,14 +159,14 @@ func TestTransformToJSONMultipleParametersValid(t *testing.T) {
 }
 func TestTransformToJSONMultipleParametersTwoEvents(t *testing.T) {
 	// Event from device 1
-	eventIn1 := models.Event{
-		Device: devID1,
+	eventIn1 := dtos.Event{
+		DeviceName: devID1,
 	}
 	// Event from device 2
-	eventIn2 := models.Event{
-		Device: devID2,
+	eventIn2 := dtos.Event{
+		DeviceName: devID2,
 	}
-	expectedResult := `{"device":"id2"}`
+	expectedResult := `{"id":"","deviceName":"id2","profileName":"","created":0,"origin":0,"readings":null}`
 	conv := NewConversion()
 	continuePipeline, result := conv.TransformToJSON(context, eventIn2, eventIn1, "", "")
 

--- a/pkg/transforms/filter.go
+++ b/pkg/transforms/filter.go
@@ -21,7 +21,8 @@ import (
 	"fmt"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/appcontext"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
 )
 
 // Filter houses various the parameters for which filter transforms filter on
@@ -48,7 +49,7 @@ func (f Filter) FilterByDeviceName(edgexcontext *appcontext.Context, params ...i
 	}
 
 	deviceIDs := f.FilterValues
-	event, ok := params[0].(models.Event)
+	event, ok := params[0].(dtos.Event)
 	if !ok {
 		return false, errors.New("type received is not an Event")
 	}
@@ -59,18 +60,18 @@ func (f Filter) FilterByDeviceName(edgexcontext *appcontext.Context, params ...i
 	}
 
 	for _, devID := range deviceIDs {
-		if event.Device == devID {
+		if event.DeviceName == devID {
 			if f.FilterOut {
-				edgexcontext.LoggingClient.Trace(fmt.Sprintf("Event not accepted: %s", event.Device))
+				edgexcontext.LoggingClient.Trace(fmt.Sprintf("Event not accepted: %s", event.DeviceName))
 				return false, nil
 			} else {
-				edgexcontext.LoggingClient.Trace(fmt.Sprintf("Event accepted: %s", event.Device))
+				edgexcontext.LoggingClient.Trace(fmt.Sprintf("Event accepted: %s", event.DeviceName))
 				return true, event
 			}
 		}
 	}
 	if f.FilterOut {
-		edgexcontext.LoggingClient.Trace(fmt.Sprintf("Event accepted: %s", event.Device))
+		edgexcontext.LoggingClient.Trace(fmt.Sprintf("Event accepted: %s", event.DeviceName))
 		return true, event
 	}
 	return false, nil
@@ -89,7 +90,7 @@ func (f Filter) FilterByValueDescriptor(edgexcontext *appcontext.Context, params
 		return false, errors.New("no Event Received")
 	}
 
-	existingEvent, ok := params[0].(models.Event)
+	existingEvent, ok := params[0].(dtos.Event)
 	if !ok {
 		return false, errors.New("type received is not an Event")
 	}
@@ -99,21 +100,19 @@ func (f Filter) FilterByValueDescriptor(edgexcontext *appcontext.Context, params
 		return true, existingEvent
 	}
 
-	auxEvent := models.Event{
-		Pushed:   existingEvent.Pushed,
-		Device:   existingEvent.Device,
-		Created:  existingEvent.Created,
-		Modified: existingEvent.Modified,
-		Origin:   existingEvent.Origin,
-		Readings: []models.Reading{},
+	auxEvent := dtos.Event{
+		DeviceName: existingEvent.DeviceName,
+		Created:    existingEvent.Created,
+		Origin:     existingEvent.Origin,
+		Readings:   []dtos.BaseReading{},
 	}
 
 	if f.FilterOut {
 		for _, reading := range existingEvent.Readings {
 			readingFilteredOut := false
 			for _, filterID := range f.FilterValues {
-				if reading.Name == filterID {
-					edgexcontext.LoggingClient.Trace(fmt.Sprintf("Reading filtered out: %s", reading.Name))
+				if reading.ResourceName == filterID {
+					edgexcontext.LoggingClient.Trace(fmt.Sprintf("Reading filtered out: %s", reading.ResourceName))
 					readingFilteredOut = true
 				}
 			}
@@ -124,15 +123,15 @@ func (f Filter) FilterByValueDescriptor(edgexcontext *appcontext.Context, params
 	} else {
 		for _, filterID := range f.FilterValues {
 			for _, reading := range existingEvent.Readings {
-				if reading.Name == filterID {
-					edgexcontext.LoggingClient.Trace(fmt.Sprintf("Reading accepted: %s", reading.Name))
+				if reading.ResourceName == filterID {
+					edgexcontext.LoggingClient.Trace(fmt.Sprintf("Reading accepted: %s", reading.ResourceName))
 					auxEvent.Readings = append(auxEvent.Readings, reading)
 				}
 			}
 		}
 	}
 	thereExistReadings := len(auxEvent.Readings) > 0
-	var returnResult models.Event
+	var returnResult dtos.Event
 	if thereExistReadings {
 		returnResult = auxEvent
 	}

--- a/pkg/transforms/filter.go
+++ b/pkg/transforms/filter.go
@@ -18,7 +18,6 @@ package transforms
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/appcontext"
 
@@ -62,16 +61,16 @@ func (f Filter) FilterByDeviceName(edgexcontext *appcontext.Context, params ...i
 	for _, devID := range deviceIDs {
 		if event.DeviceName == devID {
 			if f.FilterOut {
-				edgexcontext.LoggingClient.Trace(fmt.Sprintf("Event not accepted: %s", event.DeviceName))
+				edgexcontext.LoggingClient.Tracef("Event not accepted: %s", event.DeviceName)
 				return false, nil
 			} else {
-				edgexcontext.LoggingClient.Trace(fmt.Sprintf("Event accepted: %s", event.DeviceName))
+				edgexcontext.LoggingClient.Tracef("Event accepted: %s", event.DeviceName)
 				return true, event
 			}
 		}
 	}
 	if f.FilterOut {
-		edgexcontext.LoggingClient.Trace(fmt.Sprintf("Event accepted: %s", event.DeviceName))
+		edgexcontext.LoggingClient.Tracef("Event accepted: %s", event.DeviceName)
 		return true, event
 	}
 	return false, nil
@@ -112,7 +111,7 @@ func (f Filter) FilterByValueDescriptor(edgexcontext *appcontext.Context, params
 			readingFilteredOut := false
 			for _, filterID := range f.FilterValues {
 				if reading.ResourceName == filterID {
-					edgexcontext.LoggingClient.Trace(fmt.Sprintf("Reading filtered out: %s", reading.ResourceName))
+					edgexcontext.LoggingClient.Tracef("Reading filtered out: %s", reading.ResourceName)
 					readingFilteredOut = true
 				}
 			}
@@ -124,7 +123,7 @@ func (f Filter) FilterByValueDescriptor(edgexcontext *appcontext.Context, params
 		for _, filterID := range f.FilterValues {
 			for _, reading := range existingEvent.Readings {
 				if reading.ResourceName == filterID {
-					edgexcontext.LoggingClient.Trace(fmt.Sprintf("Reading accepted: %s", reading.ResourceName))
+					edgexcontext.LoggingClient.Tracef("Reading accepted: %s", reading.ResourceName)
 					auxEvent.Readings = append(auxEvent.Readings, reading)
 				}
 			}

--- a/pkg/transforms/filter_test.go
+++ b/pkg/transforms/filter_test.go
@@ -255,6 +255,7 @@ func TestFilterByValueDescriptorNoFilterValues(t *testing.T) {
 	require.True(t, ok, "Expected result to be an Event")
 	require.NotNil(t, actual.Readings, "Expected Reading passed thru")
 	assert.Equal(t, expected.DeviceName, actual.DeviceName, "Expected Event to be same as passed in")
+	require.True(t, len(expected.Readings) == 1)
 	assert.Equal(t, expected.Readings[0].ResourceName, actual.Readings[0].ResourceName, "Expected Reading to be same as passed in")
 	assert.True(t, continuePipeline, "Pipeline shouldn't stop processing")
 }

--- a/pkg/transforms/filter_test.go
+++ b/pkg/transforms/filter_test.go
@@ -19,11 +19,10 @@ package transforms
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -33,9 +32,9 @@ const (
 )
 
 func TestFilterByDeviceNameFound(t *testing.T) {
-	// Event from device 1
-	eventIn := models.Event{
-		Device: devID1,
+	// Event from DeviceName 1
+	eventIn := dtos.Event{
+		DeviceName: devID1,
 	}
 
 	filter := NewFilter([]string{"id1"})
@@ -44,15 +43,15 @@ func TestFilterByDeviceNameFound(t *testing.T) {
 	require.NotNil(t, result)
 	require.True(t, continuePipeline)
 
-	if eventOut, ok := result.(*models.Event); ok {
-		assert.Equal(t, "id1", eventOut.Device)
+	if eventOut, ok := result.(*dtos.Event); ok {
+		assert.Equal(t, "id1", eventOut.DeviceName)
 	}
 }
 
 func TestFilterOutByDeviceNameFound(t *testing.T) {
-	// Event from device 1
-	eventIn := models.Event{
-		Device: devID1,
+	// Event from DeviceName 1
+	eventIn := dtos.Event{
+		DeviceName: devID1,
 	}
 
 	filter := NewFilter([]string{devID1})
@@ -64,9 +63,9 @@ func TestFilterOutByDeviceNameFound(t *testing.T) {
 }
 
 func TestFilterByDeviceNameNotFound(t *testing.T) {
-	// Event from device 1
-	eventIn := models.Event{
-		Device: devID1,
+	// Event from DeviceName 1
+	eventIn := dtos.Event{
+		DeviceName: devID1,
 	}
 
 	filter := NewFilter([]string{"id2"})
@@ -77,9 +76,9 @@ func TestFilterByDeviceNameNotFound(t *testing.T) {
 }
 
 func TestFilterOutByDeviceNameNotFound(t *testing.T) {
-	// Event from device 1
-	eventIn := models.Event{
-		Device: devID1,
+	// Event from DeviceName 1
+	eventIn := dtos.Event{
+		DeviceName: devID1,
 	}
 
 	filter := NewFilter([]string{devID2})
@@ -89,8 +88,8 @@ func TestFilterOutByDeviceNameNotFound(t *testing.T) {
 	assert.NotNil(t, result)
 	assert.True(t, continuePipeline)
 
-	if eventOut, ok := result.(*models.Event); ok {
-		assert.Equal(t, devID1, eventOut.Device)
+	if eventOut, ok := result.(*dtos.Event); ok {
+		assert.Equal(t, devID1, eventOut.DeviceName)
 	}
 }
 
@@ -103,8 +102,8 @@ func TestFilterByDeviceNameNoParameters(t *testing.T) {
 }
 
 func TestFilterByDeviceNameNoFilterValues(t *testing.T) {
-	expected := models.Event{
-		Device: devID1,
+	expected := dtos.Event{
+		DeviceName: devID1,
 	}
 
 	filter := NewFilter(nil)
@@ -112,16 +111,16 @@ func TestFilterByDeviceNameNoFilterValues(t *testing.T) {
 	continuePipeline, result := filter.FilterByDeviceName(context, expected)
 	require.NotNil(t, result, "Expected event to be passed thru")
 
-	actual, ok := result.(models.Event)
+	actual, ok := result.(dtos.Event)
 	require.True(t, ok, "Expected result to be an Event")
 
-	assert.Equal(t, expected.Device, actual.Device, "Expected Event to be same as passed in")
-	assert.True(t, continuePipeline, "Pipeline should'nt stop processing")
+	assert.Equal(t, expected.DeviceName, actual.DeviceName, "Expected Event to be same as passed in")
+	assert.True(t, continuePipeline, "Pipeline shouldn't stop processing")
 }
 
 func TestFilterByDeviceNameFoundExtraParameters(t *testing.T) {
-	eventIn := models.Event{
-		Device: devID1,
+	eventIn := dtos.Event{
+		DeviceName: devID1,
 	}
 
 	filter := NewFilter([]string{"id1"})
@@ -130,8 +129,8 @@ func TestFilterByDeviceNameFoundExtraParameters(t *testing.T) {
 	require.NotNil(t, result)
 	assert.True(t, continuePipeline, "Pipeline should continue processing")
 
-	if eventOut, ok := result.(*models.Event); ok {
-		assert.Equal(t, "id1", eventOut.Device, "device id does not match filter")
+	if eventOut, ok := result.(*dtos.Event); ok {
+		assert.Equal(t, "id1", eventOut.DeviceName, "DeviceName does not match filter")
 	}
 }
 
@@ -140,19 +139,19 @@ func TestFilterByValueDescriptor(t *testing.T) {
 	f12 := NewFilter([]string{descriptor1, descriptor2})
 
 	// event with a value descriptor 1
-	event1 := models.Event{
-		Device: devID1,
+	event1 := dtos.Event{
+		DeviceName: devID1,
 	}
-	event1.Readings = append(event1.Readings, models.Reading{Name: descriptor1})
+	event1.Readings = append(event1.Readings, dtos.BaseReading{ResourceName: descriptor1})
 
 	// event with a value descriptor 2
-	event2 := models.Event{}
-	event2.Readings = append(event2.Readings, models.Reading{Name: descriptor2})
+	event2 := dtos.Event{}
+	event2.Readings = append(event2.Readings, dtos.BaseReading{ResourceName: descriptor2})
 
 	// event with a value descriptor 1 and another 2
-	event12 := models.Event{}
-	event12.Readings = append(event12.Readings, models.Reading{Name: descriptor1})
-	event12.Readings = append(event12.Readings, models.Reading{Name: descriptor2})
+	event12 := dtos.Event{}
+	event12.Readings = append(event12.Readings, dtos.BaseReading{ResourceName: descriptor1})
+	event12.Readings = append(event12.Readings, dtos.BaseReading{ResourceName: descriptor2})
 
 	continuePipeline, res := f1.FilterByValueDescriptor(context)
 	assert.False(t, continuePipeline, "Pipeline should stop since no parameter was passed")
@@ -160,26 +159,26 @@ func TestFilterByValueDescriptor(t *testing.T) {
 
 	continuePipeline, res = f1.FilterByValueDescriptor(context, event1)
 	assert.True(t, continuePipeline, "Pipeline should continue")
-	assert.Len(t, res.(models.Event).Readings, 1, "Event should have one reading")
+	assert.Len(t, res.(dtos.Event).Readings, 1, "Event should have one reading")
 
 	continuePipeline, res = f1.FilterByValueDescriptor(context, event12)
 	assert.True(t, continuePipeline, "Pipeline should continue")
-	assert.Len(t, res.(models.Event).Readings, 1, "Event should have one reading")
+	assert.Len(t, res.(dtos.Event).Readings, 1, "Event should have one reading")
 
 	continuePipeline, res = f1.FilterByValueDescriptor(context, event2)
 	assert.False(t, continuePipeline, "Event should be filtered out")
 
 	continuePipeline, res = f12.FilterByValueDescriptor(context, event1)
 	assert.True(t, continuePipeline, "Pipeline should continue")
-	assert.Len(t, res.(models.Event).Readings, 1, "Event should have one reading")
+	assert.Len(t, res.(dtos.Event).Readings, 1, "Event should have one reading")
 
 	continuePipeline, res = f12.FilterByValueDescriptor(context, event12)
 	assert.True(t, continuePipeline, "Pipeline should continue")
-	assert.Len(t, res.(models.Event).Readings, 2, "Event should have one reading")
+	assert.Len(t, res.(dtos.Event).Readings, 2, "Event should have one reading")
 
 	continuePipeline, res = f12.FilterByValueDescriptor(context, event2)
 	assert.True(t, continuePipeline, "Pipeline should continue")
-	assert.Len(t, res.(models.Event).Readings, 1, "Event should have one reading")
+	assert.Len(t, res.(dtos.Event).Readings, 1, "Event should have one reading")
 }
 
 func TestFilterOutByValueDescriptor(t *testing.T) {
@@ -189,23 +188,23 @@ func TestFilterOutByValueDescriptor(t *testing.T) {
 	f12.FilterOut = true
 
 	// event with a value descriptor 1
-	event1 := models.Event{
-		Device: devID1,
+	event1 := dtos.Event{
+		DeviceName: devID1,
 	}
-	event1.Readings = append(event1.Readings, models.Reading{Name: descriptor1})
+	event1.Readings = append(event1.Readings, dtos.BaseReading{ResourceName: descriptor1})
 
 	// event with a value descriptor 2
-	event2 := models.Event{}
-	event2.Readings = append(event2.Readings, models.Reading{Name: descriptor2})
+	event2 := dtos.Event{}
+	event2.Readings = append(event2.Readings, dtos.BaseReading{ResourceName: descriptor2})
 
 	// event with a value descriptor 1 and another 2
-	event12 := models.Event{}
-	event12.Readings = append(event12.Readings, models.Reading{Name: descriptor1})
-	event12.Readings = append(event12.Readings, models.Reading{Name: descriptor2})
+	event12 := dtos.Event{}
+	event12.Readings = append(event12.Readings, dtos.BaseReading{ResourceName: descriptor1})
+	event12.Readings = append(event12.Readings, dtos.BaseReading{ResourceName: descriptor2})
 
 	// event with a value descriptor 3
-	event3 := models.Event{}
-	event3.Readings = append(event3.Readings, models.Reading{Name: descriptor3})
+	event3 := dtos.Event{}
+	event3.Readings = append(event3.Readings, dtos.BaseReading{ResourceName: descriptor3})
 
 	continuePipeline, res := f1.FilterByValueDescriptor(context)
 	assert.False(t, continuePipeline, "Pipeline should stop since no parameter was passed")
@@ -213,63 +212,63 @@ func TestFilterOutByValueDescriptor(t *testing.T) {
 
 	continuePipeline, res = f1.FilterByValueDescriptor(context, event1)
 	assert.False(t, continuePipeline, "Pipeline should NOT continue")
-	assert.Len(t, res.(models.Event).Readings, 0, "Event should have no readings")
+	assert.Len(t, res.(dtos.Event).Readings, 0, "Event should have no readings")
 
 	continuePipeline, res = f1.FilterByValueDescriptor(context, event2)
 	assert.True(t, continuePipeline, "Pipeline should continue")
-	assert.Len(t, res.(models.Event).Readings, 1, "Event should have one reading")
+	assert.Len(t, res.(dtos.Event).Readings, 1, "Event should have one reading")
 
 	continuePipeline, res = f1.FilterByValueDescriptor(context, event12)
 	assert.True(t, continuePipeline, "Event should be filtered out")
-	assert.Len(t, res.(models.Event).Readings, 1, "Event should have one reading")
+	assert.Len(t, res.(dtos.Event).Readings, 1, "Event should have one reading")
 
 	continuePipeline, res = f12.FilterByValueDescriptor(context, event1)
 	assert.False(t, continuePipeline, "Pipeline should NOT continue")
-	assert.Len(t, res.(models.Event).Readings, 0, "Event should have one reading")
+	assert.Len(t, res.(dtos.Event).Readings, 0, "Event should have one reading")
 
 	continuePipeline, res = f12.FilterByValueDescriptor(context, event2)
 	assert.False(t, continuePipeline, "Pipeline should NOT continue")
-	assert.Len(t, res.(models.Event).Readings, 0, "Event should have no reading")
+	assert.Len(t, res.(dtos.Event).Readings, 0, "Event should have no reading")
 
 	continuePipeline, res = f12.FilterByValueDescriptor(context, event12)
 	assert.False(t, continuePipeline, "Pipeline should NOT continue")
-	assert.Len(t, res.(models.Event).Readings, 0, "Event should have no reading")
+	assert.Len(t, res.(dtos.Event).Readings, 0, "Event should have no reading")
 
 	continuePipeline, res = f12.FilterByValueDescriptor(context, event3)
 	assert.True(t, continuePipeline, "Event should be filtered out")
-	assert.Len(t, res.(models.Event).Readings, 1, "Event should have one reading")
+	assert.Len(t, res.(dtos.Event).Readings, 1, "Event should have one reading")
 }
 
 func TestFilterByValueDescriptorNoFilterValues(t *testing.T) {
-	expected := models.Event{
-		Device: devID1,
+	expected := dtos.Event{
+		DeviceName: devID1,
 	}
 
-	expected.Readings = append(expected.Readings, models.Reading{Name: descriptor1})
+	expected.Readings = append(expected.Readings, dtos.BaseReading{ResourceName: descriptor1})
 
 	filter := NewFilter(nil)
 
 	continuePipeline, result := filter.FilterByValueDescriptor(context, expected)
 	require.NotNil(t, result, "Expected event to be passed thru")
 
-	actual, ok := result.(models.Event)
+	actual, ok := result.(dtos.Event)
 	require.True(t, ok, "Expected result to be an Event")
 	require.NotNil(t, actual.Readings, "Expected Reading passed thru")
-	assert.Equal(t, expected.Device, actual.Device, "Expected Event to be same as passed in")
-	assert.Equal(t, expected.Readings[0].Name, actual.Readings[0].Name, "Expected Reading to be same as passed in")
-	assert.True(t, continuePipeline, "Pipeline should'nt stop processing")
+	assert.Equal(t, expected.DeviceName, actual.DeviceName, "Expected Event to be same as passed in")
+	assert.Equal(t, expected.Readings[0].ResourceName, actual.Readings[0].ResourceName, "Expected Reading to be same as passed in")
+	assert.True(t, continuePipeline, "Pipeline shouldn't stop processing")
 }
 
 func TestFilterByValueDescriptorExtraParameters(t *testing.T) {
 	f1 := NewFilter([]string{descriptor1})
 
 	// event with a value descriptor 1
-	event1 := models.Event{
-		Device: devID1,
+	event1 := dtos.Event{
+		DeviceName: devID1,
 	}
-	event1.Readings = append(event1.Readings, models.Reading{Name: descriptor1})
+	event1.Readings = append(event1.Readings, dtos.BaseReading{ResourceName: descriptor1})
 
 	continuePipeline, res := f1.FilterByValueDescriptor(context, event1, "application/event")
 	assert.True(t, continuePipeline, "Pipeline should continue")
-	assert.Len(t, res.(models.Event).Readings, 1, "Event should have one reading")
+	assert.Len(t, res.(dtos.Event).Readings, 1, "Event should have one reading")
 }

--- a/pkg/transforms/outputdata_test.go
+++ b/pkg/transforms/outputdata_test.go
@@ -20,11 +20,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSetOutputDataString(t *testing.T) {
@@ -56,8 +55,8 @@ func TestSetOutputDataBytes(t *testing.T) {
 func TestSetOutputDataEvent(t *testing.T) {
 	target := NewOutputData()
 
-	eventIn := models.Event{
-		Device: devID1,
+	eventIn := dtos.Event{
+		DeviceName: devID1,
 	}
 
 	expected, _ := json.Marshal(eventIn)

--- a/pkg/transforms/tags.go
+++ b/pkg/transforms/tags.go
@@ -20,9 +20,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
-
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/appcontext"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
 )
 
 // Tags contains the list of Tag key/values
@@ -45,7 +45,7 @@ func (t *Tags) AddTags(edgexcontext *appcontext.Context, params ...interface{}) 
 		return false, errors.New("no Event Received")
 	}
 
-	event, ok := params[0].(models.Event)
+	event, ok := params[0].(dtos.Event)
 	if !ok {
 		return false, errors.New("type received is not an Event")
 	}

--- a/pkg/transforms/tags_test.go
+++ b/pkg/transforms/tags_test.go
@@ -19,13 +19,13 @@ package transforms
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/edgexfoundry/app-functions-sdk-go/v2/appcontext"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
 
-	"github.com/edgexfoundry/app-functions-sdk-go/v2/appcontext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var tagsToAdd = map[string]string{
@@ -34,7 +34,7 @@ var tagsToAdd = map[string]string{
 	"Longitude": "-95.377603",
 }
 
-var eventWithExistingTags = models.Event{
+var eventWithExistingTags = dtos.Event{
 	Tags: map[string]string{
 		"Tag1": "Value1",
 		"Tag2": "Value2",
@@ -62,7 +62,7 @@ func TestTags_AddTags(t *testing.T) {
 		ErrorExpected bool
 		ErrorContains string
 	}{
-		{"Happy path - no existing Event tags", models.Event{}, tagsToAdd, tagsToAdd, false, ""},
+		{"Happy path - no existing Event tags", dtos.Event{}, tagsToAdd, tagsToAdd, false, ""},
 		{"Happy path - Event has existing tags", eventWithExistingTags, tagsToAdd, allTagsAdded, false, ""},
 		{"Happy path - No tags added", eventWithExistingTags, map[string]string{}, eventWithExistingTags.Tags, false, ""},
 		{"Error - No data", nil, nil, nil, true, "no Event Received"},
@@ -91,7 +91,7 @@ func TestTags_AddTags(t *testing.T) {
 			}
 
 			assert.True(t, continuePipeline)
-			actual, ok := result.(models.Event)
+			actual, ok := result.(dtos.Event)
 			require.True(t, ok, "Result not an Event")
 			assert.Equal(t, testCase.Expected, actual.Tags)
 		})

--- a/pkg/util/helpers_test.go
+++ b/pkg/util/helpers_test.go
@@ -21,14 +21,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
-
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSplitComma(t *testing.T) {
-	commaDelimmited := "Hel lo,, ,Test,Hi, "
-	results := strings.FieldsFunc(commaDelimmited, SplitComma)
+	commaDelimited := "Hel lo,, ,Test,Hi, "
+	results := strings.FieldsFunc(commaDelimited, SplitComma)
 	// Should have 4 elements (space counts as an element)
 	assert.Equal(t, 5, len(results))
 	assert.Equal(t, "Hel lo", results[0])
@@ -38,8 +37,8 @@ func TestSplitComma(t *testing.T) {
 	assert.Equal(t, " ", results[4])
 }
 func TestSplitCommaEmpty(t *testing.T) {
-	commaDelimmited := ""
-	results := strings.FieldsFunc(commaDelimmited, SplitComma)
+	commaDelimited := ""
+	results := strings.FieldsFunc(commaDelimited, SplitComma)
 	// Should have 4 elements (space counts as an element)
 	assert.Equal(t, 0, len(results))
 }
@@ -68,9 +67,9 @@ func TestCoerceTypeByteArrayToByteArray(t *testing.T) {
 	assert.NoError(t, err)
 	assert.IsType(t, reflect.TypeOf(expectedType), reflect.TypeOf(result))
 }
-func TestCoerceTypeJSONMarshalerToByteArray(t *testing.T) {
-	myData := models.Event{
-		Device: "deviceId",
+func TestCoerceTypeJSONMarshallerToByteArray(t *testing.T) {
+	myData := dtos.Event{
+		DeviceName: "deviceId",
 	}
 	var expectedType []byte
 	result, err := CoerceType(myData)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Triggers and some pipeline function expect a V1 Event model

Issue Number: #595


## What is the new behavior?

Triggers and appropriate pipeline functions now expect a V2 Event DTO.

V1 Event model temporarily supported by converting V1 Event to a V2 Event DTO.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

## Are there any new imports or modules? If so, what are they used for and why?

no
## Are there any specific instructions or things that should be known prior to reviewing?

## Other information