### PR TITLE
fix(sdk): Normalize Trigger Factory Returns

### DIFF
--- a/appsdk/triggerfactory.go
+++ b/appsdk/triggerfactory.go
@@ -108,7 +108,7 @@ func (sdk *AppFunctionsSDK) setupTrigger(configuration *common.ConfigurationStru
 			t, err = factory(sdk)
 			if err != nil {
 				sdk.LoggingClient.Error(fmt.Sprintf("failed to initialize custom trigger [%s]: %s", triggerType, err.Error()))
-				panic(err)
+				return nil
 			}
 		} else {
 			sdk.LoggingClient.Error(fmt.Sprintf("Invalid Trigger type of '%s' specified", configuration.Binding.Type))


### PR DESCRIPTION
Was panicing on errors encountered in custom trigger creation, makes
more sense to force returning and let sdk handle it.

Signed-off-by: Alex Ullrich <alexullrich@technotects.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:
#698 

## What is the new behavior?
Consistently return nil trigger to the SDK.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information