### PR TITLE
fix: Errors in dynamic pipeline updates allow previous pipeline to run, hiding the errors

### DIFF
--- a/appsdk/configupdates.go
+++ b/appsdk/configupdates.go
@@ -149,8 +149,12 @@ func (processor *ConfigUpdateProcessor) processConfigChangedPipeline() {
 		transforms, err := sdk.LoadConfigurablePipeline()
 		if err != nil {
 			sdk.LoggingClient.Error("unable to reload Configurable Pipeline from new configuration: " + err.Error())
+			// Reset the transforms so error occurs when attempting to execute the pipeline.
+			sdk.transforms = nil
+			sdk.runtime.SetTransforms(nil)
 			return
 		}
+
 		err = sdk.SetFunctionsPipeline(transforms...)
 		if err != nil {
 			sdk.LoggingClient.Error("unable to set Configurable Pipeline functions from new configuration: " + err.Error())

--- a/appsdk/sdk.go
+++ b/appsdk/sdk.go
@@ -301,6 +301,11 @@ func (sdk *AppFunctionsSDK) LoadConfigurablePipeline() ([]appcontext.AppFunction
 		if !ok {
 			return nil, fmt.Errorf("failed to cast function %s as AppFunction type", functionName)
 		}
+
+		if function == nil {
+			return nil, fmt.Errorf("%s from configuration failed", functionName)
+		}
+
 		pipeline = append(pipeline, function)
 		configurable.Sdk.LoggingClient.Debug(fmt.Sprintf("%s function added to configurable pipeline", functionName))
 	}

--- a/appsdk/sdk_test.go
+++ b/appsdk/sdk_test.go
@@ -269,7 +269,7 @@ func TestLoadConfigurablePipelineNotABuiltInSdkFunction(t *testing.T) {
 func TestLoadConfigurablePipelineNumFunctions(t *testing.T) {
 	functions := make(map[string]common.PipelineFunction)
 	functions["FilterByDeviceName"] = common.PipelineFunction{
-		Parameters: map[string]string{"FilterValues": "Random-Float-Device, Random-Integer-Device"},
+		Parameters: map[string]string{"DeviceNames": "Random-Float-Device, Random-Integer-Device"},
 	}
 	functions["TransformToXML"] = common.PipelineFunction{}
 	functions["SetOutputData"] = common.PipelineFunction{}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -19,13 +19,14 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
 	"sync"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	edgexErrors "github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/google/uuid"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
@@ -81,7 +82,7 @@ func (gr *GolangRuntime) ProcessMessage(edgexcontext *appcontext.Context, envelo
 	lc := edgexcontext.LoggingClient
 
 	if len(gr.transforms) == 0 {
-		err := fmt.Errorf("No transforms configured. Please check log for errors loading pipeline")
+		err := errors.New("No transforms configured. Please check log for errors loading pipeline")
 		logError(lc, err, envelope.CorrelationID)
 		return &MessageError{Err: err, ErrorCode: http.StatusInternalServerError}
 	}
@@ -96,7 +97,7 @@ func (gr *GolangRuntime) ProcessMessage(edgexcontext *appcontext.Context, envelo
 	}
 
 	if reflect.TypeOf(gr.TargetType).Kind() != reflect.Ptr {
-		err := fmt.Errorf("TargetType must be a pointer, not a value of the target type")
+		err := errors.New("TargetType must be a pointer, not a value of the target type")
 		logError(lc, err, envelope.CorrelationID)
 		return &MessageError{Err: err, ErrorCode: http.StatusInternalServerError}
 	}
@@ -116,7 +117,7 @@ func (gr *GolangRuntime) ProcessMessage(edgexcontext *appcontext.Context, envelo
 		event, err := gr.processEventPayload(envelope, lc)
 		if err != nil {
 			errorCode := http.StatusInternalServerError
-			if errors.Kind(err) == errors.KindContractInvalid {
+			if edgexErrors.Kind(err) == edgexErrors.KindContractInvalid {
 				errorCode = http.StatusBadRequest
 			}
 
@@ -233,7 +234,7 @@ func (gr *GolangRuntime) processEventPayload(envelope types.MessageEnvelope, lc 
 	}
 
 	// Check for validation error
-	if errors.Kind(requestDtoErr) != errors.KindContractInvalid {
+	if edgexErrors.Kind(requestDtoErr) != edgexErrors.KindContractInvalid {
 		return nil, requestDtoErr
 	}
 
@@ -251,7 +252,7 @@ func (gr *GolangRuntime) processEventPayload(envelope types.MessageEnvelope, lc 
 	}
 
 	// Check for validation error
-	if errors.Kind(err) != errors.KindContractInvalid {
+	if edgexErrors.Kind(err) != edgexErrors.KindContractInvalid {
 		return nil, err
 	}
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -96,15 +96,21 @@ func TestProcessMessageBasRequest(t *testing.T) {
 		LoggingClient: lc,
 	}
 
+	dummyTransform := func(edgexcontext *appcontext.Context, params ...interface{}) (bool, interface{}) {
+		return true, "Hello"
+	}
+
 	runtime := GolangRuntime{}
 	runtime.Initialize(nil, nil)
-
+	runtime.SetTransforms([]appcontext.AppFunction{dummyTransform})
 	result := runtime.ProcessMessage(context, envelope)
 	require.NotNil(t, result)
 	assert.Equal(t, expected, result.ErrorCode)
 }
 
 func TestProcessMessageNoTransforms(t *testing.T) {
+	expected := http.StatusInternalServerError
+
 	payload, err := json.Marshal(testAddEventRequest)
 	require.NoError(t, err)
 	envelope := types.MessageEnvelope{
@@ -120,7 +126,8 @@ func TestProcessMessageNoTransforms(t *testing.T) {
 	runtime.Initialize(nil, nil)
 
 	result := runtime.ProcessMessage(context, envelope)
-	require.Nil(t, result, "result should be nil since no transforms have been passed")
+	require.NotNil(t, result)
+	assert.Equal(t, expected, result.ErrorCode)
 }
 
 func TestProcessMessageOneCustomTransform(t *testing.T) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Error building from configuration leaves previous pipeline in tact and allows it to execute which hides the error that occurred.

Issue Number: #707

## What is the new behavior?
Pipeline now is reset to empty when error building from configuration so that an error is generated each time it is executed.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information