### PR TITLE
refactor: Rework secrets for HTTP Export so value in InsecureSecrets can be overridden

### DIFF
--- a/appsdk/configurable.go
+++ b/appsdk/configurable.go
@@ -36,7 +36,6 @@ const (
 	Url                 = "url"
 	MimeType            = "mimetype"
 	PersistOnError      = "persistonerror"
-	Cert                = "cert"
 	SkipVerify          = "skipverify"
 	Qos                 = "qos"
 	Retain              = "retain"
@@ -46,7 +45,7 @@ const (
 	Rule                = "rule"
 	BatchThreshold      = "batchthreshold"
 	TimeInterval        = "timeinterval"
-	SecretHeaderName    = "secretheadername"
+	HeaderName          = "headername"
 	SecretPath          = "secretpath"
 	SecretName          = "secretname"
 	BrokerAddress       = "brokeraddress"
@@ -173,7 +172,7 @@ func (dynamic AppFunctionsSDKConfigurable) FilterByResourceName(parameters map[s
 
 // TransformToXML transforms an EdgeX event to XML.
 // It will return an error and stop the pipeline if a non-edgex
-// event is received or if no data is recieved.
+// event is received or if no data is received.
 // This function is a configuration function and returns a function pointer.
 func (dynamic AppFunctionsSDKConfigurable) TransformToXML() appcontext.AppFunction {
 	transform := transforms.Conversion{}
@@ -182,7 +181,7 @@ func (dynamic AppFunctionsSDKConfigurable) TransformToXML() appcontext.AppFuncti
 
 // TransformToJSON transforms an EdgeX event to JSON.
 // It will return an error and stop the pipeline if a non-edgex
-// event is received or if no data is recieved.
+// event is received or if no data is received.
 // This function is a configuration function and returns a function pointer.
 func (dynamic AppFunctionsSDKConfigurable) TransformToJSON() appcontext.AppFunction {
 	transform := transforms.Conversion{}
@@ -213,14 +212,14 @@ func (dynamic AppFunctionsSDKConfigurable) PushToCore(parameters map[string]stri
 	return transform.PushToCoreData
 }
 
-// CompressWithGZIP compresses data received as either a string,[]byte, or json.Marshaler using gzip algorithm and returns a base64 encoded string as a []byte.
+// CompressWithGZIP compresses data received as either a string,[]byte, or json.Marshaller using gzip algorithm and returns a base64 encoded string as a []byte.
 // This function is a configuration function and returns a function pointer.
 func (dynamic AppFunctionsSDKConfigurable) CompressWithGZIP() appcontext.AppFunction {
 	transform := transforms.Compression{}
 	return transform.CompressWithGZIP
 }
 
-// CompressWithZLIB compresses data received as either a string,[]byte, or json.Marshaler using zlib algorithm and returns a base64 encoded string as a []byte.
+// CompressWithZLIB compresses data received as either a string,[]byte, or json.Marshaller using zlib algorithm and returns a base64 encoded string as a []byte.
 // This function is a configuration function and returns a function pointer.
 func (dynamic AppFunctionsSDKConfigurable) CompressWithZLIB() appcontext.AppFunction {
 	transform := transforms.Compression{}
@@ -256,14 +255,14 @@ func (dynamic AppFunctionsSDKConfigurable) EncryptWithAES(parameters map[string]
 		return nil
 	}
 
-	transforms := transforms.Encryption{
+	transform := transforms.Encryption{
 		EncryptionKey:        encryptionKey,
 		InitializationVector: initVector,
 		SecretPath:           secretPath,
 		SecretName:           secretName,
 	}
 
-	return transforms.EncryptWithAES
+	return transform.EncryptWithAES
 }
 
 // HTTPPost will send data from the previous function to the specified Endpoint via http POST. If no previous function exists,
@@ -271,42 +270,20 @@ func (dynamic AppFunctionsSDKConfigurable) EncryptWithAES(parameters map[string]
 // method will default to application/json.
 // This function is a configuration function and returns a function pointer.
 func (dynamic AppFunctionsSDKConfigurable) HTTPPost(parameters map[string]string) appcontext.AppFunction {
-	var err error
-
-	url, ok := parameters[Url]
-	if !ok {
-		dynamic.Sdk.LoggingClient.Error("HTTPPost Could not find " + Url)
-		return nil
-	}
-	mimeType, ok := parameters[MimeType]
-	if !ok {
-		dynamic.Sdk.LoggingClient.Error("HTTPPost Could not find " + MimeType)
+	url, mimeType, persistOnError, headerName, secretPath, secretName, err := dynamic.processPostPutParameters(parameters)
+	if err != nil {
+		dynamic.Sdk.LoggingClient.Error(err.Error())
 		return nil
 	}
 
-	// PersistOnError is optional and is false by default.
-	persistOnError := false
-	value, ok := parameters[PersistOnError]
-	if ok {
-		persistOnError, err = strconv.ParseBool(value)
-		if err != nil {
-			dynamic.Sdk.LoggingClient.Error(fmt.Sprintf("HTTPPost Could not parse '%s' to a bool for '%s' parameter", value, PersistOnError), "error", err)
-			return nil
-		}
-	}
-
-	url = strings.TrimSpace(url)
-	mimeType = strings.TrimSpace(mimeType)
-
-	secretHeaderName := parameters[SecretHeaderName]
-	secretPath := parameters[SecretPath]
 	var transform transforms.HTTPSender
-	if secretHeaderName != "" && secretPath != "" {
-		transform = transforms.NewHTTPSenderWithSecretHeader(url, mimeType, persistOnError, secretHeaderName, secretPath)
+	if len(secretPath) != 0 {
+		transform = transforms.NewHTTPSenderWithSecretHeader(url, mimeType, persistOnError, headerName, secretPath, secretName)
 	} else {
 		transform = transforms.NewHTTPSender(url, mimeType, persistOnError)
 	}
-	dynamic.Sdk.LoggingClient.Debug("HTTPPost Parameters", Url, transform.URL, MimeType, transform.MimeType)
+
+	dynamic.Sdk.LoggingClient.Debugf("HTTPPost Parameters: %v", parameters)
 	return transform.HTTPPost
 }
 
@@ -331,41 +308,19 @@ func (dynamic AppFunctionsSDKConfigurable) HTTPPostXML(parameters map[string]str
 // method will default to application/json.
 // This function is a configuration function and returns a function pointer.
 func (dynamic AppFunctionsSDKConfigurable) HTTPPut(parameters map[string]string) appcontext.AppFunction {
-	var err error
-
-	url, ok := parameters[Url]
-	if !ok {
-		dynamic.Sdk.LoggingClient.Error("HTTPPut Could not find " + Url)
-		return nil
-	}
-	mimeType, ok := parameters[MimeType]
-	if !ok {
-		dynamic.Sdk.LoggingClient.Error("HTTPPut Could not find " + MimeType)
+	url, mimeType, persistOnError, headerName, secretPath, secretName, err := dynamic.processPostPutParameters(parameters)
+	if err != nil {
+		dynamic.Sdk.LoggingClient.Error(err.Error())
 		return nil
 	}
 
-	// PersistOnError is optional and is false by default.
-	persistOnError := false
-	value, ok := parameters[PersistOnError]
-	if ok {
-		persistOnError, err = strconv.ParseBool(value)
-		if err != nil {
-			dynamic.Sdk.LoggingClient.Error(fmt.Sprintf("HTTPPut Could not parse '%s' to a bool for '%s' parameter", value, PersistOnError), "error", err)
-			return nil
-		}
-	}
-
-	url = strings.TrimSpace(url)
-	mimeType = strings.TrimSpace(mimeType)
-
-	secretHeaderName := parameters[SecretHeaderName]
-	secretPath := parameters[SecretPath]
 	var transform transforms.HTTPSender
-	if secretHeaderName != "" && secretPath != "" {
-		transform = transforms.NewHTTPSenderWithSecretHeader(url, mimeType, persistOnError, secretHeaderName, secretPath)
+	if len(secretPath) != 0 {
+		transform = transforms.NewHTTPSenderWithSecretHeader(url, mimeType, persistOnError, headerName, secretPath, secretName)
 	} else {
 		transform = transforms.NewHTTPSender(url, mimeType, persistOnError)
 	}
+
 	dynamic.Sdk.LoggingClient.Debug("HTTPPut Parameters", Url, transform.URL, MimeType, transform.MimeType)
 	return transform.HTTPPut
 }
@@ -387,7 +342,7 @@ func (dynamic AppFunctionsSDKConfigurable) HTTPPutXML(parameters map[string]stri
 }
 
 // SetOutputData sets the output data to that passed in from the previous function.
-// It will return an error and stop the pipeline if data passed in is not of type []byte, string or json.Mashaler
+// It will return an error and stop the pipeline if data passed in is not of type []byte, string or json.Marshaller
 // This function is a configuration function and returns a function pointer.
 func (dynamic AppFunctionsSDKConfigurable) SetOutputData(parameters map[string]string) appcontext.AppFunction {
 	transform := transforms.OutputData{}
@@ -597,4 +552,52 @@ func (dynamic AppFunctionsSDKConfigurable) AddTags(parameters map[string]string)
 	dynamic.Sdk.LoggingClient.Debug("Add Tags", Tags, fmt.Sprintf("%v", tags))
 
 	return transform.AddTags
+}
+
+func (dynamic AppFunctionsSDKConfigurable) processPostPutParameters(
+	parameters map[string]string) (string, string, bool, string, string, string, error) {
+	url, ok := parameters[Url]
+	if !ok {
+		return "", "", false, "", "", "", fmt.Errorf("HTTPPut Could not find %s", Url)
+	}
+	mimeType, ok := parameters[MimeType]
+	if !ok {
+		return "", "", false, "", "", "", fmt.Errorf("HTTPPut Could not find %s", MimeType)
+	}
+
+	// PersistOnError is optional and is false by default.
+	persistOnError := false
+	value, ok := parameters[PersistOnError]
+	if ok {
+		var err error
+		persistOnError, err = strconv.ParseBool(value)
+		if err != nil {
+			return "", "", false, "", "", "",
+				fmt.Errorf("HTTPPut Could not parse '%s' to a bool for '%s' parameter: %s",
+					value,
+					PersistOnError,
+					err.Error())
+		}
+	}
+
+	url = strings.TrimSpace(url)
+	mimeType = strings.TrimSpace(mimeType)
+	headerName := strings.TrimSpace(parameters[HeaderName])
+	secretPath := strings.TrimSpace(parameters[SecretPath])
+	secretName := strings.TrimSpace(parameters[SecretName])
+
+	if len(headerName) == 0 && len(secretPath) != 0 && len(secretName) != 0 {
+		return "", "", false, "", "", "",
+			fmt.Errorf("HTTPPost missing %s since %s & %s are specified", HeaderName, SecretPath, SecretName)
+	}
+	if len(secretPath) == 0 && len(headerName) != 0 && len(secretName) != 0 {
+		return "", "", false, "", "", "",
+			fmt.Errorf("HTTPPost missing %s since %s & %s are specified", SecretPath, HeaderName, SecretName)
+	}
+	if len(secretName) == 0 && len(secretPath) != 0 && len(headerName) != 0 {
+		return "", "", false, "", "", "",
+			fmt.Errorf("HTTPPost missing %s since %s & %s are specified", SecretName, SecretPath, HeaderName)
+	}
+
+	return url, mimeType, persistOnError, headerName, secretPath, secretName, nil
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
SecretHeaderName used as key for InsecureSecrets is dynamic so can not be overridden in the 'http-export' profile which just has a place holder.

Issue Number: #521

## What is the new behavior?
Now the key in InsecureSecrets can be fixed in the 'http-export' profile since is is not also used as the HTTP Header Name.
This allows for the header value stored in InsecureSecrets to be overridden with environment variable.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Parameters have changed for HTTP Post/Put with SecretHeader

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information