### PR TITLE
refactor: Change to using service keys for names in Clients configuration

### DIFF
--- a/internal/appfunction/context.go
+++ b/internal/appfunction/context.go
@@ -29,7 +29,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/notifications"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/internal/bootstrap/container"
-	"github.com/edgexfoundry/app-functions-sdk-go/v2/internal/bootstrap/handlers"
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/pkg/util"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
@@ -124,7 +123,7 @@ func (appContext *Context) PushToCoreData(deviceName string, readingName string,
 	lc.Debug("Pushing to CoreData")
 
 	if appContext.EventClient() == nil {
-		return nil, fmt.Errorf("unable to Push To CoreData: '%s' is missing from Clients configuration", handlers.CoreDataClientName)
+		return nil, fmt.Errorf("unable to Push To CoreData: '%s' is missing from Clients configuration", clients.CoreDataServiceKey)
 	}
 
 	now := time.Now().UnixNano()

--- a/internal/bootstrap/handlers/clients.go
+++ b/internal/bootstrap/handlers/clients.go
@@ -30,12 +30,6 @@ import (
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/internal/bootstrap/container"
 )
 
-const (
-	CoreCommandClientName   = "Command"
-	CoreDataClientName      = "CoreData"
-	NotificationsClientName = "Notifications"
-)
-
 // Clients contains references to dependencies required by the Clients bootstrap implementation.
 type Clients struct {
 }
@@ -61,22 +55,22 @@ func (_ *Clients) BootstrapHandler(
 
 	// Use of these client interfaces is optional, so they are not required to be configured. For instance if not
 	// sending commands, then don't need to have the Command client in the configuration.
-	if _, ok := config.Clients[CoreDataClientName]; ok {
+	if _, ok := config.Clients[clients.CoreDataServiceKey]; ok {
 		eventClient = coredata.NewEventClient(
-			local.New(config.Clients[CoreDataClientName].Url() + clients.ApiEventRoute))
+			local.New(config.Clients[clients.CoreDataServiceKey].Url() + clients.ApiEventRoute))
 
 		valueDescriptorClient = coredata.NewValueDescriptorClient(
-			local.New(config.Clients[CoreDataClientName].Url() + clients.ApiValueDescriptorRoute))
+			local.New(config.Clients[clients.CoreDataServiceKey].Url() + clients.ApiValueDescriptorRoute))
 	}
 
-	if _, ok := config.Clients[CoreCommandClientName]; ok {
+	if _, ok := config.Clients[clients.CoreCommandServiceKey]; ok {
 		commandClient = command.NewCommandClient(
-			local.New(config.Clients[CoreCommandClientName].Url() + clients.ApiDeviceRoute))
+			local.New(config.Clients[clients.CoreCommandServiceKey].Url() + clients.ApiDeviceRoute))
 	}
 
-	if _, ok := config.Clients[NotificationsClientName]; ok {
+	if _, ok := config.Clients[clients.SupportNotificationsServiceKey]; ok {
 		notificationsClient = notifications.NewNotificationsClient(
-			local.New(config.Clients[NotificationsClientName].Url() + clients.ApiNotificationRoute))
+			local.New(config.Clients[clients.SupportNotificationsServiceKey].Url() + clients.ApiNotificationRoute))
 	}
 
 	// Note that all the clients are optional so some or all these clients may be nil

--- a/internal/bootstrap/handlers/clients_test.go
+++ b/internal/bootstrap/handlers/clients_test.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-registry/v2/registry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -102,15 +103,15 @@ func TestClientsBootstrapHandler(t *testing.T) {
 			configuration.Clients = make(map[string]config.ClientInfo)
 
 			if test.CoreDataClientInfo != nil {
-				configuration.Clients[CoreDataClientName] = coreDataClientInfo
+				configuration.Clients[clients.CoreDataServiceKey] = coreDataClientInfo
 			}
 
 			if test.CommandClientInfo != nil {
-				configuration.Clients[CoreCommandClientName] = commandClientInfo
+				configuration.Clients[clients.CoreCommandServiceKey] = commandClientInfo
 			}
 
 			if test.NotificationsClientInfo != nil {
-				configuration.Clients[NotificationsClientName] = notificationsClientInfo
+				configuration.Clients[clients.SupportNotificationsServiceKey] = notificationsClientInfo
 			}
 
 			dic.Update(di.ServiceConstructorMap{

--- a/internal/bootstrap/handlers/version.go
+++ b/internal/bootstrap/handlers/version.go
@@ -84,7 +84,7 @@ func (vv *VersionValidator) BootstrapHandler(
 		return true
 	}
 
-	url := config.Clients[CoreDataClientName].Url() + clients.ApiVersionRoute
+	url := config.Clients[clients.CoreDataServiceKey].Url() + clients.ApiVersionRoute
 	var data []byte
 	var err error
 	for startupTimer.HasNotElapsed() {

--- a/internal/bootstrap/handlers/version_test.go
+++ b/internal/bootstrap/handlers/version_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-registry/v2/registry"
 	"github.com/stretchr/testify/assert"
@@ -40,8 +41,8 @@ import (
 func TestValidateVersionMatch(t *testing.T) {
 	startupTimer := startup.NewStartUpTimer("unit-test")
 
-	clients := make(map[string]config.ClientInfo)
-	clients[CoreDataClientName] = config.ClientInfo{
+	clientConfigs := make(map[string]config.ClientInfo)
+	clientConfigs[clients.CoreDataServiceKey] = config.ClientInfo{
 		Protocol: "http",
 		Host:     "localhost",
 		Port:     0, // Will be replaced by local test webserver's port
@@ -51,7 +52,7 @@ func TestValidateVersionMatch(t *testing.T) {
 		Writable: common.WritableInfo{
 			LogLevel: "DEBUG",
 		},
-		Clients: clients,
+		Clients: clientConfigs,
 	}
 
 	lc := logger.NewMockClient()
@@ -115,9 +116,9 @@ func TestValidateVersionMatch(t *testing.T) {
 
 			testServerUrl, _ := url.Parse(testServer.URL)
 			port, _ := strconv.Atoi(testServerUrl.Port())
-			coreService := configuration.Clients[CoreDataClientName]
+			coreService := configuration.Clients[clients.CoreDataServiceKey]
 			coreService.Port = port
-			configuration.Clients[CoreDataClientName] = coreService
+			configuration.Clients[clients.CoreDataServiceKey] = coreService
 
 			validator := NewVersionValidator(test.skipVersionCheck, test.SdkVersion)
 			result := validator.BootstrapHandler(context.Background(), &sync.WaitGroup{}, startupTimer, dic)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Clients configuration uses arbitrary names that have be standardized somewhat across edgex services.

Issue Number: #739


## What is the new behavior?
Clients configuration now uses the services service key for the names which are standard across all services.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Clients configuration has changed and must be updated to use service keys for names

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information