### PR TITLE
feat: Add GetAppSetting() convenience API

### DIFF
--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -323,6 +323,20 @@ func (svc *Service) ApplicationSettings() map[string]string {
 	return svc.config.ApplicationSettings
 }
 
+// GetAppSettingStrings returns the string for the specified App Setting.
+func (svc *Service) GetAppSetting(setting string) (string, error) {
+	if svc.config.ApplicationSettings == nil {
+		return "", fmt.Errorf("%s setting not found: ApplicationSettings section is missing", setting)
+	}
+
+	settingValue, ok := svc.config.ApplicationSettings[setting]
+	if !ok {
+		return "", fmt.Errorf("%s setting not found in ApplicationSettings section", setting)
+	}
+
+	return settingValue, nil
+}
+
 // GetAppSettingStrings returns the strings slice for the specified App Setting.
 func (svc *Service) GetAppSettingStrings(setting string) ([]string, error) {
 	if svc.config.ApplicationSettings == nil {
@@ -331,7 +345,7 @@ func (svc *Service) GetAppSettingStrings(setting string) ([]string, error) {
 
 	settingValue, ok := svc.config.ApplicationSettings[setting]
 	if !ok {
-		return nil, fmt.Errorf("%s setting not found in ApplicationSettings", setting)
+		return nil, fmt.Errorf("%s setting not found in ApplicationSettings section", setting)
 	}
 
 	valueStrings := util.DeleteEmptyAndTrim(strings.FieldsFunc(settingValue, util.SplitComma))

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -195,6 +195,33 @@ func TestApplicationSettingsNil(t *testing.T) {
 	require.Nil(t, appSettings, "returned application settings expected to be nil")
 }
 
+func TestGetAppSetting(t *testing.T) {
+	goodSettingName := "ExportUrl"
+	expectedGoodValue := "http:/somewhere.com"
+	badSettingName := "DeviceName"
+
+	svc := Service{
+		config: &common.ConfigurationStruct{
+			ApplicationSettings: map[string]string{
+				goodSettingName: expectedGoodValue,
+			},
+		},
+	}
+
+	actual, err := svc.GetAppSetting(goodSettingName)
+	require.NoError(t, err)
+	assert.EqualValues(t, expectedGoodValue, actual, "actual application setting values not as expected")
+
+	_, err = svc.GetAppSetting(badSettingName)
+	require.Error(t, err)
+	assert.EqualError(t, err, fmt.Sprintf("%s setting not found in ApplicationSettings section", badSettingName))
+
+	svc.config.ApplicationSettings = nil
+	_, err = svc.GetAppSetting(goodSettingName)
+	require.Error(t, err)
+	assert.EqualError(t, err, fmt.Sprintf("%s setting not found: ApplicationSettings section is missing", goodSettingName))
+}
+
 func TestGetAppSettingStrings(t *testing.T) {
 	setting := "DeviceNames"
 	expected := []string{"dev1", "dev2"}

--- a/pkg/interfaces/mocks/AppFunctionContext.go
+++ b/pkg/interfaces/mocks/AppFunctionContext.go
@@ -181,6 +181,22 @@ func (_m *AppFunctionContext) ResponseContentType() string {
 	return r0
 }
 
+// ResponseData provides a mock function with given fields:
+func (_m *AppFunctionContext) ResponseData() []byte {
+	ret := _m.Called()
+
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func() []byte); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	return r0
+}
+
 // SecretsLastUpdated provides a mock function with given fields:
 func (_m *AppFunctionContext) SecretsLastUpdated() time.Time {
 	ret := _m.Called()

--- a/pkg/interfaces/mocks/ApplicationService.go
+++ b/pkg/interfaces/mocks/ApplicationService.go
@@ -109,6 +109,27 @@ func (_m *ApplicationService) EventClient() coredata.EventClient {
 	return r0
 }
 
+// GetAppSetting provides a mock function with given fields: setting
+func (_m *ApplicationService) GetAppSetting(setting string) (string, error) {
+	ret := _m.Called(setting)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(setting)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(setting)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetAppSettingStrings provides a mock function with given fields: setting
 func (_m *ApplicationService) GetAppSettingStrings(setting string) ([]string, error) {
 	ret := _m.Called(setting)

--- a/pkg/interfaces/service.go
+++ b/pkg/interfaces/service.go
@@ -60,9 +60,13 @@ type ApplicationService interface {
 	AddRoute(route string, handler func(http.ResponseWriter, *http.Request), methods ...string) error
 	// ApplicationSettings returns the key/value map of custom settings
 	ApplicationSettings() map[string]string
+	// GetAppSetting is a convenience function return a setting from the ApplicationSetting
+	// section of the service configuration.
+	// An error is returned if the specified setting is not found.
+	GetAppSetting(setting string) (string, error)
 	// GetAppSettingStrings is a convenience function that parses the value for the specified custom
 	// application setting as a comma separated list. It returns the list of strings.
-	// An error is returned if the specified setting is no found.
+	// An error is returned if the specified setting is not found.
 	GetAppSettingStrings(setting string) ([]string, error)
 	// SetFunctionsPipeline set the functions pipeline with the specified list of Application Functions.
 	// Note that the functions are executed in the order provided in the list.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
GetAppSetting() convenience API doesn't exist so devs have to deal with ApplicationSetting string map directly

Issue Number: #760


## What is the new behavior?
GetAppSetting() convenience API exists making it much easier for devs to pull a setting value out of the ApplicationSetting config section

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information