### PR TITLE
fix: Fix webserver to use ServerBindAddr only if not blank as rest of EdgeX

### DIFF
--- a/app-service-template/res/configuration.toml
+++ b/app-service-template/res/configuration.toml
@@ -21,6 +21,7 @@ BootTimeout = '30s'
 ClientMonitor = '15s'
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = '' # Leave blank so default to Host value unless different value is needed.
 Port = 49600  # TODO: set this port appropriately
 Protocol = 'http'
 ReadMaxLimit = 100

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9
 	github.com/eclipse/paho.mqtt.golang v1.3.2
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.27
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.28
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.62
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.7
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.4

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -105,10 +105,14 @@ func (webserver *WebServer) StartWebServer(errChannel chan error) {
 
 // Helper function to handle HTTPs or HTTP connection based on the configured protocol
 func listenAndServe(webserver *WebServer, serviceTimeout time.Duration, errChannel chan error) {
-
-	// this allows env overrides to explicitly set the value used
-	// for ListenAndServe, as needed for different deployments
-	addr := fmt.Sprintf("%v:%d", webserver.config.Service.ServerBindAddr, webserver.config.Service.Port)
+	// The Host value is the default bind address value if the ServerBindAddr value is not specified
+	// this allows env overrides to explicitly set the value used for ListenAndServe,
+	// as needed for different deployments
+	bindAddress := webserver.config.Service.Host
+	if len(webserver.config.Service.ServerBindAddr) != 0 {
+		bindAddress = webserver.config.Service.ServerBindAddr
+	}
+	addr := fmt.Sprintf("%s:%d", bindAddress, webserver.config.Service.Port)
 
 	if webserver.config.Service.Protocol == "https" {
 		webserver.lc.Infof("Starting HTTPS Web Server on address %v", addr)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
If `If `ServerBindAddr ` is blank, webserver listens to any interface rather than locked down to value of Host as with all other EdgeX services.
` is blank, webserver listens to any interface rather than locked down to value of Host as with all other EdgeX services.

Issue Number: #775


## What is the new behavior?
If `ServerBindAddr ` is blank, webserver listens to value of Host as with all other EdgeX services.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Webserver will be locked down to listen just to `Host` value when If `ServerBindAddr ` is blank

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information