### PR TITLE
refactor: Replace file based with use of Secret Provider to get Access Tokens

### DIFF
--- a/app-service-template/go.mod
+++ b/app-service-template/go.mod
@@ -6,7 +6,7 @@ go 1.15
 
 require (
 	github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.14
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.62
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.64
 	github.com/google/uuid v1.2.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/app-service-template/res/configuration.toml
+++ b/app-service-template/res/configuration.toml
@@ -27,13 +27,11 @@ Protocol = 'http'
 ReadMaxLimit = 100
 StartupMsg = 'new-app-service Application Service has started'
 Timeout = '30s'
-ConfigAccessTokenFile = '/tmp/edgex/secrets/new-app-service/consul-token' # ignored in non-secure mode
 
 [Registry]
 Host = 'localhost'
 Port = 8500
 Type = 'consul'
-AccessTokenFile = '/tmp/edgex/secrets/new-app-service/consul-token' # ignored in non-secure mode
 
 [Database]
 Type = "redisdb"
@@ -47,13 +45,14 @@ Timeout = "30s"
 #       service in secure mode.
 #       For more deatils about SecretStore: https://docs.edgexfoundry.org/1.3/microservices/security/Ch-SecretStore/
 [SecretStore]
+Type = 'vault'
 Host = 'localhost'
 Port = 8200
 Path = '/v1/secret/edgex/appservice/'
 Protocol = 'http'
 RootCaCertPath = ''
 ServerName = ''
-TokenFile = '/vault/config/assets/resp-init.json'
+TokenFile = '/tmp/edgex/secrets/new-app-service/secrets-token.json'
 AdditionalRetryAttempts = 10
 RetryWaitPeriod = "1s"
   [SecretStore.Authentication]

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9
 	github.com/eclipse/paho.mqtt.golang v1.3.3
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.31
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.32
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.64
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.8
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.4

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9
 	github.com/eclipse/paho.mqtt.golang v1.3.3
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.29
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.62
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.31
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.64
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.8
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.4
 	github.com/fxamacker/cbor/v2 v2.2.0

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -51,7 +51,6 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/config"
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/flags"
-	bootstrapHandlers "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/handlers"
 	bootstrapInterfaces "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/secret"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
@@ -402,8 +401,8 @@ func (svc *Service) Initialize() error {
 		configUpdated,
 		startupTimer,
 		svc.dic,
+		true,
 		[]bootstrapInterfaces.BootstrapHandler{
-			bootstrapHandlers.SecureProviderBootstrapHandler,
 			handlers.NewDatabase().BootstrapHandler,
 			handlers.NewClients().BootstrapHandler,
 			handlers.NewTelemetry().BootstrapHandler,
@@ -430,7 +429,7 @@ func (svc *Service) Initialize() error {
 		secretProvider := bootstrapContainer.SecretProviderFrom(svc.dic.Get)
 		credentials, err := secretProvider.GetSecrets(svc.config.Database.Type)
 		if err != nil {
-			return fmt.Errorf("unable to set RedisStreams password from DB credentials")
+			return fmt.Errorf("unable to set RedisStreams password from DB credentials: %s", err.Error())
 		}
 		svc.config.Trigger.EdgexMessageBus.Optional[optionalPasswordKey] = credentials[secret.PasswordKey]
 	}
@@ -452,7 +451,7 @@ func (svc *Service) Initialize() error {
 // as the standard configuration.
 func (svc *Service) LoadCustomConfig(customConfig interfaces.UpdatableConfig, sectionName string) error {
 	if svc.configProcessor == nil {
-		svc.configProcessor = config.NewProcessorForCustomConfig(svc.lc, svc.flags, svc.ctx.appCtx, svc.ctx.appWg, svc.dic)
+		svc.configProcessor = config.NewProcessorForCustomConfig(svc.flags, svc.ctx.appCtx, svc.ctx.appWg, svc.dic)
 	}
 	return svc.configProcessor.LoadCustomConfigSection(customConfig, sectionName)
 }

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -429,7 +429,7 @@ func (svc *Service) Initialize() error {
 		secretProvider := bootstrapContainer.SecretProviderFrom(svc.dic.Get)
 		credentials, err := secretProvider.GetSecrets(svc.config.Database.Type)
 		if err != nil {
-			return fmt.Errorf("unable to set RedisStreams password from DB credentials: %s", err.Error())
+			return fmt.Errorf("unable to set RedisStreams password from DB credentials: %w", err)
 		}
 		svc.config.Trigger.EdgexMessageBus.Optional[optionalPasswordKey] = credentials[secret.PasswordKey]
 	}

--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -61,18 +61,17 @@ type ConfigurationStruct struct {
 
 // ServiceInfo is used to hold and configure various settings related to the hosting of this service
 type ServiceInfo struct {
-	BootTimeout           string
-	CheckInterval         string
-	Host                  string
-	HTTPSCert             string
-	HTTPSKey              string
-	ServerBindAddr        string
-	Port                  int
-	Protocol              string
-	StartupMsg            string
-	ReadMaxLimit          int
-	Timeout               string
-	ConfigAccessTokenFile string
+	BootTimeout    string
+	CheckInterval  string
+	Host           string
+	HTTPSCert      string
+	HTTPSKey       string
+	ServerBindAddr string
+	Port           int
+	Protocol       string
+	StartupMsg     string
+	ReadMaxLimit   int
+	Timeout        string
 }
 
 // TriggerInfo contains Metadata associated with each Trigger
@@ -197,15 +196,14 @@ func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecre
 // transformToBootstrapServiceInfo transforms the SDK's ServiceInfo to the bootstrap's version of ServiceInfo
 func (c *ConfigurationStruct) transformToBootstrapServiceInfo() bootstrapConfig.ServiceInfo {
 	return bootstrapConfig.ServiceInfo{
-		BootTimeout:           durationToMill(c.Service.BootTimeout),
-		CheckInterval:         c.Service.CheckInterval,
-		Host:                  c.Service.Host,
-		Port:                  c.Service.Port,
-		Protocol:              c.Service.Protocol,
-		StartupMsg:            c.Service.StartupMsg,
-		MaxResultCount:        c.Service.ReadMaxLimit,
-		Timeout:               durationToMill(c.Service.Timeout),
-		ConfigAccessTokenFile: c.Service.ConfigAccessTokenFile,
+		BootTimeout:    durationToMill(c.Service.BootTimeout),
+		CheckInterval:  c.Service.CheckInterval,
+		Host:           c.Service.Host,
+		Port:           c.Service.Port,
+		Protocol:       c.Service.Protocol,
+		StartupMsg:     c.Service.StartupMsg,
+		MaxResultCount: c.Service.ReadMaxLimit,
+		Timeout:        durationToMill(c.Service.Timeout),
 	}
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently expecting the Registry/Config Access tokens to be retrieved for files using the file location config settings.

Issue Number: #769


## What is the new behavior?
Now uses SecretProvider to retrieve the access tokens.
File location config settings have been removed

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: All App Services running with the secure Edgex Stack now need to have the SecretStore configured, a Vault token created and run with EDGEX_SECURITY_SECRET_STORE=true.

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information