### PR TITLE
feat: Switch to Redis as the default MessageBus for template service

### DIFF
--- a/app-service-template/go.mod
+++ b/app-service-template/go.mod
@@ -6,7 +6,7 @@ go 1.15
 
 require (
 	github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.14
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.64
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.78
 	github.com/google/uuid v1.2.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/app-service-template/res/configuration.toml
+++ b/app-service-template/res/configuration.toml
@@ -66,18 +66,18 @@ RetryWaitPeriod = "1s"
 
 [Trigger]
 Type="edgex-messagebus"
-SubscribeTopics="events, edgex/events"
+SubscribeTopics="edgex/events/#"
 PublishTopic="event-xml"  #TODO: remove if service is NOT publishing back to the message bus
     [Trigger.EdgexMessageBus]
-    Type = 'zero'
+    Type = 'redisstreams'
         [Trigger.EdgexMessageBus.SubscribeHost]
         Host = 'localhost'
-        Port = 5563
-        Protocol = 'tcp'
+        Port = 6379
+        Protocol = 'redis'
         [Trigger.EdgexMessageBus.PublishHost]   # TODO: Remove if service is NOT publishing back to the message bus
-        Host = '*'
-        Port = 5564
-        Protocol = 'tcp'
+        Host = 'localhost'
+        Port = 6379
+        Protocol = 'redis'
 
 # TODO: If using mqtt messagebus, Uncomment this section and remove above [Trigger] section,
 #       Otherwise remove this commented out block


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
ZMQ is the default MessageBus

## Issue Number: #810 


## What is the new behavior?
Redis is now the default MessageBus

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [X] Yes
- [ ] No

BREAKING CHANGE: All service sending Events must now be configured to use Redis as the MessageBus

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information