### PR TITLE
refactor: Update for new service key names and overrides for hyphen to underscore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ test-template:
 	make -C ./app-service-template test
 
 test-sdk:
+	go mod tidy
 	$(GO) test ./... -coverprofile=coverage.out ./...
 	$(GO) vet ./...
 	gofmt -l .

--- a/app-service-template/go.mod
+++ b/app-service-template/go.mod
@@ -6,7 +6,7 @@ go 1.15
 
 require (
 	github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.52
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.83
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
 	github.com/google/uuid v1.2.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/app-service-template/res/configuration.toml
+++ b/app-service-template/res/configuration.toml
@@ -58,7 +58,7 @@ RetryWaitPeriod = "1s"
   AuthType = 'X-Vault-Token'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
   Protocol = 'http'
   Host = 'localhost'
   Port = 48080

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9
 	github.com/eclipse/paho.mqtt.golang v1.3.4
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.52
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.83
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.54
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.13
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.7
 	github.com/fxamacker/cbor/v2 v2.2.0


### PR DESCRIPTION
**Dependent on edgexfoundry/go-mod-core-contracts#613
Dependent on edgexfoundry/go-mod-bootstrap#216**

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## What is the current behavior?
Service key constants have the edgex- prefix

Issue Number: #801 & #837

## What is the new behavior?
Service key constants no longer have the edgex- prefix
Hyphen in Overrides are converted to underscore

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Service key names used in configuration have changed.


## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information