### PR TITLE
feat(sdk): Use v2 Command Client

### DIFF
--- a/app-service-template/go.mod
+++ b/app-service-template/go.mod
@@ -6,7 +6,7 @@ go 1.15
 
 require (
 	github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0-dev.52
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.91
 	github.com/google/uuid v1.2.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9
 	github.com/eclipse/paho.mqtt.golang v1.3.4
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.54
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.91
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.13
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.7
 	github.com/fxamacker/cbor/v2 v2.2.0

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -29,11 +29,11 @@ import (
 	"syscall"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/command"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/notifications"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+	clientInterfaces "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
 	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/v2/registry"
 
@@ -480,7 +480,7 @@ func (svc *Service) EventClient() coredata.EventClient {
 }
 
 // CommandClient returns the Command client, which may be nil, from the dependency injection container
-func (svc *Service) CommandClient() command.CommandClient {
+func (svc *Service) CommandClient() clientInterfaces.CommandClient {
 	return container.CommandClientFrom(svc.dic.Get)
 }
 

--- a/internal/appfunction/context.go
+++ b/internal/appfunction/context.go
@@ -23,10 +23,10 @@ import (
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/command"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/notifications"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/internal/bootstrap/container"
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/pkg/util"
@@ -205,7 +205,7 @@ func (appContext *Context) EventClient() coredata.EventClient {
 }
 
 // CommandClient returns the Command client, which may be nil, from the dependency injection container
-func (appContext *Context) CommandClient() command.CommandClient {
+func (appContext *Context) CommandClient() interfaces.CommandClient {
 	return container.CommandClientFrom(appContext.dic.Get)
 }
 

--- a/internal/appfunction/context_test.go
+++ b/internal/appfunction/context_test.go
@@ -27,12 +27,12 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces/mocks"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/command"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/notifications"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/urlclient/local"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	v2clients "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/http"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 
@@ -55,11 +55,10 @@ func TestMain(m *testing.M) {
 			return notifications.NewNotificationsClient(local.New(clients.ApiNotificationRoute))
 		},
 		container.CommandClientName: func(get di.Get) interface{} {
-			return command.NewCommandClient(local.New(clients.ApiCommandRoute))
+			return v2clients.NewCommandClient(clients.ApiCommandRoute)
 		},
 		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
 			return logger.NewMockClient()
-
 		},
 	})
 	target = NewContext("", dic, "")

--- a/internal/bootstrap/container/clients.go
+++ b/internal/bootstrap/container/clients.go
@@ -17,10 +17,9 @@ package container
 
 import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/command"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/notifications"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/coredata"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/notifications"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
 )
 
 // ValueDescriptorClientName contains the name of the ValueDescriptorClient's implementation in the DIC.
@@ -60,13 +59,13 @@ func NotificationsClientFrom(get di.Get) notifications.NotificationsClient {
 }
 
 // CommandClientName contains the name of the CommandClientInfo's implementation in the DIC.
-var CommandClientName = di.TypeInstanceToName((*command.CommandClient)(nil))
+var CommandClientName = di.TypeInstanceToName((*interfaces.CommandClient)(nil))
 
 // NotificationsClientFrom helper function queries the DIC and returns the NotificationsClientInfo's implementation.
-func CommandClientFrom(get di.Get) command.CommandClient {
+func CommandClientFrom(get di.Get) interfaces.CommandClient {
 	if get(CommandClientName) == nil {
 		return nil
 	}
 
-	return get(CommandClientName).(command.CommandClient)
+	return get(CommandClientName).(interfaces.CommandClient)
 }

--- a/internal/bootstrap/handlers/clients.go
+++ b/internal/bootstrap/handlers/clients.go
@@ -22,10 +22,11 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/command"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/notifications"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/urlclient/local"
+	v2clients "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/http"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/internal/bootstrap/container"
 )
@@ -50,7 +51,7 @@ func (_ *Clients) BootstrapHandler(
 
 	var eventClient coredata.EventClient
 	var valueDescriptorClient coredata.ValueDescriptorClient
-	var commandClient command.CommandClient
+	var commandClient interfaces.CommandClient
 	var notificationsClient notifications.NotificationsClient
 
 	// Use of these client interfaces is optional, so they are not required to be configured. For instance if not
@@ -64,8 +65,7 @@ func (_ *Clients) BootstrapHandler(
 	}
 
 	if _, ok := config.Clients[clients.CoreCommandServiceKey]; ok {
-		commandClient = command.NewCommandClient(
-			local.New(config.Clients[clients.CoreCommandServiceKey].Url() + clients.ApiDeviceRoute))
+		commandClient = v2clients.NewCommandClient(config.Clients[clients.CoreCommandServiceKey].Url())
 	}
 
 	if _, ok := config.Clients[clients.SupportNotificationsServiceKey]; ok {

--- a/pkg/interfaces/context.go
+++ b/pkg/interfaces/context.go
@@ -18,7 +18,8 @@ package interfaces
 import (
 	"time"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/command"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/notifications"
@@ -68,7 +69,7 @@ type AppFunctionContext interface {
 	EventClient() coredata.EventClient
 	// CommandClient returns the Command client. Note if Support Command is not specified in the Clients configuration,
 	// this will return nil.
-	CommandClient() command.CommandClient
+	CommandClient() interfaces.CommandClient
 	// NotificationsClient returns the Notifications client. Note if Support Notifications is not specified in the
 	// Clients configuration, this will return nil.
 	NotificationsClient() notifications.NotificationsClient

--- a/pkg/interfaces/mocks/ApplicationService.go
+++ b/pkg/interfaces/mocks/ApplicationService.go
@@ -3,8 +3,8 @@
 package mocks
 
 import (
-	command "github.com/edgexfoundry/go-mod-core-contracts/v2/clients/command"
 	coredata "github.com/edgexfoundry/go-mod-core-contracts/v2/clients/coredata"
+	interfaces2 "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
 
 	http "net/http"
 
@@ -78,15 +78,15 @@ func (_m *ApplicationService) ApplicationSettings() map[string]string {
 }
 
 // CommandClient provides a mock function with given fields:
-func (_m *ApplicationService) CommandClient() command.CommandClient {
+func (_m *ApplicationService) CommandClient() interfaces2.CommandClient {
 	ret := _m.Called()
 
-	var r0 command.CommandClient
-	if rf, ok := ret.Get(0).(func() command.CommandClient); ok {
+	var r0 interfaces2.CommandClient
+	if rf, ok := ret.Get(0).(func() interfaces2.CommandClient); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(command.CommandClient)
+			r0 = ret.Get(0).(interfaces2.CommandClient)
 		}
 	}
 

--- a/pkg/interfaces/service.go
+++ b/pkg/interfaces/service.go
@@ -18,7 +18,8 @@ package interfaces
 import (
 	"net/http"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/command"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/notifications"
@@ -103,7 +104,7 @@ type ApplicationService interface {
 	EventClient() coredata.EventClient
 	// CommandClient returns the Command client. Note if Support Command is not specified in the Clients configuration,
 	// this will return nil.
-	CommandClient() command.CommandClient
+	CommandClient() interfaces.CommandClient
 	// NotificationsClient returns the Notifications client. Note if Support Notifications is not specified in the
 	// Clients configuration, this will return nil.
 	NotificationsClient() notifications.NotificationsClient


### PR DESCRIPTION
Register v2 client in dic and change interface used throughout.

Signed-off-by: Alex Ullrich <alexullrich@technotects.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features
<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
v1 client is still exposed to custom services by the SDK, does not work with commands routed to v2 device services.

Issue Number: #844


## What is the new behavior?
v2 client is registered with dic and interface used in references throughout.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Yes this will break any usages of the client retrieved through context.CommandClient() by returning a new interface.

- [x] Yes
- [ ] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

I updated the mocks by hand since I didn't want to worry about mockery version or usage differences messing something up.

## Other information