### PR TITLE
fix(sdk): External MQTT Trigger Publish

### DIFF
--- a/internal/trigger/mqtt/mqtt.go
+++ b/internal/trigger/mqtt/mqtt.go
@@ -181,7 +181,7 @@ func (trigger *Trigger) messageHandler(client pahoMqtt.Client, message pahoMqtt.
 	}
 
 	if len(appContext.ResponseData()) > 0 && len(topic) > 0 {
-		if token := client.Publish(topic, brokerConfig.QoS, brokerConfig.Retain, appContext.ResponseData); token.Wait() && token.Error() != nil {
+		if token := client.Publish(topic, brokerConfig.QoS, brokerConfig.Retain, appContext.ResponseData()); token.Wait() && token.Error() != nil {
 			lc.Errorf("could not publish to topic '%s' for MQTT trigger: %s", topic, token.Error().Error())
 		} else {
 			lc.Trace("Sent MQTT Trigger response message", clients.CorrelationHeader, correlationID)


### PR DESCRIPTION
Pass context.ResponseData function result instead of reference to paho
client

Signed-off-by: Alex Ullrich <alexullrich@technotects.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
passes reference to the ResponseData function to paho client instead of response data itself.

Issue Number: #848 


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information