### PR TITLE
feat: Add KeepAlive and ConnectionTimeout to MQTT Export settings

### DIFF
--- a/internal/app/configurable.go
+++ b/internal/app/configurable.go
@@ -46,6 +46,7 @@ const (
 	Qos                 = "qos"
 	Retain              = "retain"
 	AutoReconnect       = "autoreconnect"
+	ConnectTimeout      = "connecttimeout"
 	DeviceName          = "devicename"
 	ReadingName         = "readingname"
 	Rule                = "rule"
@@ -56,6 +57,7 @@ const (
 	SecretName          = "secretname"
 	BrokerAddress       = "brokeraddress"
 	ClientID            = "clientid"
+	KeepAlive           = "keepalive"
 	Topic               = "topic"
 	TransformType       = "type"
 	TransformXml        = "xml"
@@ -403,10 +405,17 @@ func (app *Configurable) MQTTExport(parameters map[string]string) interfaces.App
 			return nil
 		}
 	}
+
+	// These are optional and blank values result in MQTT defaults being used.
+	keepAlive := parameters[KeepAlive]
+	connectTimeout := parameters[ConnectTimeout]
+
 	mqttConfig := transforms.MQTTSecretConfig{
 		Retain:         retain,
 		SkipCertVerify: skipCertVerify,
 		AutoReconnect:  autoReconnect,
+		ConnectTimeout: connectTimeout,
+		KeepAlive:      keepAlive,
 		QoS:            byte(qos),
 		BrokerAddress:  brokerAddress,
 		ClientId:       clientID,

--- a/internal/app/configurable_test.go
+++ b/internal/app/configurable_test.go
@@ -311,6 +311,8 @@ func TestMQTTExport(t *testing.T) {
 	params[SkipVerify] = "true"
 	params[PersistOnError] = "false"
 	params[AuthMode] = "none"
+	params[ConnectTimeout] = "5s"
+	params[KeepAlive] = "6s"
 
 	trx := configurable.MQTTExport(params)
 	assert.NotNil(t, trx, "return result from MQTTSecretSend should not be nil")

--- a/pkg/transforms/mqttsecret.go
+++ b/pkg/transforms/mqttsecret.go
@@ -51,6 +51,10 @@ type MQTTSecretConfig struct {
 	SecretPath string
 	// AutoReconnect indicated whether or not to retry connection if disconnected
 	AutoReconnect bool
+	// KeepAlive is the interval duration between client sending keepalive ping to broker
+	KeepAlive string
+	// ConnectTimeout is the duration for timing out on connecting to the broker
+	ConnectTimeout string
 	// Topic that you wish to publish to
 	Topic string
 	// QoS for MQTT Connection
@@ -71,6 +75,7 @@ func NewMQTTSecretSender(mqttConfig MQTTSecretConfig, persistOnError bool) *MQTT
 	opts.AddBroker(mqttConfig.BrokerAddress)
 	opts.SetClientID(mqttConfig.ClientId)
 	opts.SetAutoReconnect(mqttConfig.AutoReconnect)
+
 	//avoid casing issues
 	mqttConfig.AuthMode = strings.ToLower(mqttConfig.AuthMode)
 	sender := &MQTTSecretSender{
@@ -95,6 +100,28 @@ func (sender *MQTTSecretSender) initializeMQTTClient(ctx interfaces.AppFunctionC
 
 	config := sender.mqttConfig
 	mqttFactory := secure.NewMqttFactory(ctx, config.AuthMode, config.SecretPath, config.SkipCertVerify)
+
+	if len(sender.mqttConfig.KeepAlive) > 0 {
+		keepAlive, err := time.ParseDuration(sender.mqttConfig.KeepAlive)
+		if err != nil {
+			return fmt.Errorf("Unable to parse KeepAlive value of '%s': %w", sender.mqttConfig.KeepAlive, err)
+		}
+
+		sender.opts.SetKeepAlive(keepAlive)
+
+		fmt.Printf("KeepAlive set to '%d'", sender.opts.KeepAlive)
+	}
+
+	if len(sender.mqttConfig.ConnectTimeout) > 0 {
+		timeout, err := time.ParseDuration(sender.mqttConfig.ConnectTimeout)
+		if err != nil {
+			return fmt.Errorf("Unable to parse ConnectTimeout value of '%s': %w", sender.mqttConfig.ConnectTimeout, err)
+		}
+
+		sender.opts.SetConnectTimeout(timeout)
+
+		fmt.Printf("ConnectTimeout set to '%d'", sender.opts.ConnectTimeout)
+	}
 
 	client, err := mqttFactory.Create(sender.opts)
 	if err != nil {

--- a/pkg/transforms/mqttsecret.go
+++ b/pkg/transforms/mqttsecret.go
@@ -108,8 +108,6 @@ func (sender *MQTTSecretSender) initializeMQTTClient(ctx interfaces.AppFunctionC
 		}
 
 		sender.opts.SetKeepAlive(keepAlive)
-
-		fmt.Printf("KeepAlive set to '%d'", sender.opts.KeepAlive)
 	}
 
 	if len(sender.mqttConfig.ConnectTimeout) > 0 {
@@ -119,8 +117,6 @@ func (sender *MQTTSecretSender) initializeMQTTClient(ctx interfaces.AppFunctionC
 		}
 
 		sender.opts.SetConnectTimeout(timeout)
-
-		fmt.Printf("ConnectTimeout set to '%d'", sender.opts.ConnectTimeout)
 	}
 
 	client, err := mqttFactory.Create(sender.opts)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## What is the current behavior?
KeepAlive and ConnectTimeout MQQ setting for MQTT Export not available

Issue Number: #858


## What is the new behavior?
KeepAlive and ConnectTimeout MQQ setting no part of MQTT Export

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information