### PR TITLE
feat: Add ability to chain HTTP exports for multiple destinations

### DIFF
--- a/internal/app/configurable.go
+++ b/internal/app/configurable.go
@@ -42,6 +42,8 @@ const (
 	ExportMethodPut     = "put"
 	MimeType            = "mimetype"
 	PersistOnError      = "persistonerror"
+	ContinueOnSendError = "continueonsenderror"
+	ReturnInputData     = "returninputdata"
 	SkipVerify          = "skipverify"
 	Qos                 = "qos"
 	Retain              = "retain"
@@ -76,13 +78,15 @@ const (
 )
 
 type postPutParameters struct {
-	method         string
-	url            string
-	mimeType       string
-	persistOnError bool
-	headerName     string
-	secretPath     string
-	secretName     string
+	method              string
+	url                 string
+	mimeType            string
+	persistOnError      bool
+	continueOnSendError bool
+	returnInputData     bool
+	headerName          string
+	secretPath          string
+	secretName          string
 }
 
 // Configurable contains the helper functions that return the function pointers for building the configurable function pipeline.
@@ -638,6 +642,36 @@ func (app *Configurable) processHttpExportParameters(
 				fmt.Errorf("HTTPExport Could not parse '%s' to a bool for '%s' parameter: %s",
 					value,
 					PersistOnError,
+					err.Error())
+		}
+	}
+
+	// ContinueOnSendError is optional and is false by default.
+	result.continueOnSendError = false
+	value, ok = parameters[ContinueOnSendError]
+	if ok {
+		var err error
+		result.continueOnSendError, err = strconv.ParseBool(value)
+		if err != nil {
+			return nil,
+				fmt.Errorf("HTTPExport Could not parse '%s' to a bool for '%s' parameter: %s",
+					value,
+					ContinueOnSendError,
+					err.Error())
+		}
+	}
+
+	// ReturnInputData is optional and is false by default.
+	result.returnInputData = false
+	value, ok = parameters[ReturnInputData]
+	if ok {
+		var err error
+		result.returnInputData, err = strconv.ParseBool(value)
+		if err != nil {
+			return nil,
+				fmt.Errorf("HTTPExport Could not parse '%s' to a bool for '%s' parameter: %s",
+					value,
+					ReturnInputData,
 					err.Error())
 		}
 	}

--- a/internal/app/configurable_test.go
+++ b/internal/app/configurable_test.go
@@ -157,41 +157,50 @@ func TestHTTPExport(t *testing.T) {
 	testMimeType := clients.ContentTypeJSON
 	testPersistOnError := "false"
 	testBadPersistOnError := "bogus"
+	testContinueOnSendError := "true"
+	testBadContinueOnSendError := "bogus"
+	testReturnInputData := "true"
+	testBadReturnInputData := "bogus"
+
 	testHeaderName := "My-Header"
 	testSecretPath := "/path"
 	testSecretName := "header"
 
 	tests := []struct {
-		Name           string
-		Method         string
-		Url            *string
-		MimeType       *string
-		PersistOnError *string
-		HeaderName     *string
-		SecretPath     *string
-		SecretName     *string
-		ExpectValid    bool
+		Name                string
+		Method              string
+		Url                 *string
+		MimeType            *string
+		PersistOnError      *string
+		ContinueOnSendError *string
+		ReturnInputData     *string
+		HeaderName          *string
+		SecretPath          *string
+		SecretName          *string
+		ExpectValid         bool
 	}{
-		{"Valid Post - ony required params", ExportMethodPost, &testUrl, &testMimeType, nil, nil, nil, nil, true},
-		{"Valid Post - w/o secrets", http.MethodPost, &testUrl, &testMimeType, &testPersistOnError, nil, nil, nil, true},
-		{"Valid Post - with secrets", ExportMethodPost, &testUrl, &testMimeType, nil, &testHeaderName, &testSecretPath, &testSecretName, true},
-		{"Valid Post - with all params", ExportMethodPost, &testUrl, &testMimeType, &testPersistOnError, &testHeaderName, &testSecretPath, &testSecretName, true},
-		{"Invalid Post - no url", ExportMethodPost, nil, &testMimeType, nil, nil, nil, nil, false},
-		{"Invalid Post - no mimeType", ExportMethodPost, &testUrl, nil, nil, nil, nil, nil, false},
-		{"Invalid Post - bad persistOnError", ExportMethodPost, &testUrl, &testMimeType, &testBadPersistOnError, nil, nil, nil, false},
-		{"Invalid Post - missing headerName", ExportMethodPost, &testUrl, &testMimeType, &testPersistOnError, nil, &testSecretPath, &testSecretName, false},
-		{"Invalid Post - missing secretPath", ExportMethodPost, &testUrl, &testMimeType, &testPersistOnError, &testHeaderName, nil, &testSecretName, false},
-		{"Invalid Post - missing secretName", ExportMethodPost, &testUrl, &testMimeType, &testPersistOnError, &testHeaderName, &testSecretPath, nil, false},
-		{"Valid Put - ony required params", ExportMethodPut, &testUrl, &testMimeType, nil, nil, nil, nil, true},
-		{"Valid Put - w/o secrets", ExportMethodPut, &testUrl, &testMimeType, &testPersistOnError, nil, nil, nil, true},
-		{"Valid Put - with secrets", http.MethodPut, &testUrl, &testMimeType, nil, &testHeaderName, &testSecretPath, &testSecretName, true},
-		{"Valid Put - with all params", ExportMethodPut, &testUrl, &testMimeType, &testPersistOnError, &testHeaderName, &testSecretPath, &testSecretName, true},
-		{"Invalid Put - no url", ExportMethodPut, nil, &testMimeType, nil, nil, nil, nil, false},
-		{"Invalid Put - no mimeType", ExportMethodPut, &testUrl, nil, nil, nil, nil, nil, false},
-		{"Invalid Put - bad persistOnError", ExportMethodPut, &testUrl, &testMimeType, &testBadPersistOnError, nil, nil, nil, false},
-		{"Invalid Put - missing headerName", ExportMethodPut, &testUrl, &testMimeType, &testPersistOnError, nil, &testSecretPath, &testSecretName, false},
-		{"Invalid Put - missing secretPath", ExportMethodPut, &testUrl, &testMimeType, &testPersistOnError, &testHeaderName, nil, &testSecretName, false},
-		{"Invalid Put - missing secretName", ExportMethodPut, &testUrl, &testMimeType, &testPersistOnError, &testHeaderName, &testSecretPath, nil, false},
+		{"Valid Post - ony required params", ExportMethodPost, &testUrl, &testMimeType, nil, nil, nil, nil, nil, nil, true},
+		{"Valid Post - w/o secrets", http.MethodPost, &testUrl, &testMimeType, &testPersistOnError, nil, nil, nil, nil, nil, true},
+		{"Valid Post - with secrets", ExportMethodPost, &testUrl, &testMimeType, nil, nil, nil, &testHeaderName, &testSecretPath, &testSecretName, true},
+		{"Valid Post - with all params", ExportMethodPost, &testUrl, &testMimeType, &testPersistOnError, &testContinueOnSendError, &testReturnInputData, &testHeaderName, &testSecretPath, &testSecretName, true},
+		{"Invalid Post - no url", ExportMethodPost, nil, &testMimeType, nil, nil, nil, nil, nil, nil, false},
+		{"Invalid Post - no mimeType", ExportMethodPost, &testUrl, nil, nil, nil, nil, nil, nil, nil, false},
+		{"Invalid Post - bad persistOnError", ExportMethodPost, &testUrl, &testMimeType, &testBadPersistOnError, nil, nil, nil, nil, nil, false},
+		{"Invalid Post - missing headerName", ExportMethodPost, &testUrl, &testMimeType, &testPersistOnError, nil, nil, nil, &testSecretPath, &testSecretName, false},
+		{"Invalid Post - missing secretPath", ExportMethodPost, &testUrl, &testMimeType, &testPersistOnError, nil, nil, &testHeaderName, nil, &testSecretName, false},
+		{"Invalid Post - missing secretName", ExportMethodPost, &testUrl, &testMimeType, &testPersistOnError, nil, nil, &testHeaderName, &testSecretPath, nil, false},
+		{"Valid Put - ony required params", ExportMethodPut, &testUrl, &testMimeType, nil, nil, nil, nil, nil, nil, true},
+		{"Valid Put - w/o secrets", ExportMethodPut, &testUrl, &testMimeType, &testPersistOnError, nil, nil, nil, nil, nil, true},
+		{"Valid Put - with secrets", http.MethodPut, &testUrl, &testMimeType, nil, nil, nil, &testHeaderName, &testSecretPath, &testSecretName, true},
+		{"Valid Put - with all params", ExportMethodPut, &testUrl, &testMimeType, &testPersistOnError, nil, nil, &testHeaderName, &testSecretPath, &testSecretName, true},
+		{"Invalid Put - no url", ExportMethodPut, nil, &testMimeType, nil, nil, nil, nil, nil, nil, false},
+		{"Invalid Put - no mimeType", ExportMethodPut, &testUrl, nil, nil, nil, nil, nil, nil, nil, false},
+		{"Invalid Put - bad persistOnError", ExportMethodPut, &testUrl, &testMimeType, &testBadPersistOnError, nil, nil, nil, nil, nil, false},
+		{"Invalid Put - bad continueOnSendError", ExportMethodPut, &testUrl, &testMimeType, nil, &testBadContinueOnSendError, nil, nil, nil, nil, false},
+		{"Invalid Put - bad returnInputData", ExportMethodPut, &testUrl, &testMimeType, nil, nil, &testBadReturnInputData, nil, nil, nil, false},
+		{"Invalid Put - missing headerName", ExportMethodPut, &testUrl, &testMimeType, &testPersistOnError, nil, nil, nil, &testSecretPath, &testSecretName, false},
+		{"Invalid Put - missing secretPath", ExportMethodPut, &testUrl, &testMimeType, &testPersistOnError, nil, nil, &testHeaderName, nil, &testSecretName, false},
+		{"Invalid Put - missing secretName", ExportMethodPut, &testUrl, &testMimeType, &testPersistOnError, nil, nil, &testHeaderName, &testSecretPath, nil, false},
 	}
 
 	for _, test := range tests {
@@ -209,6 +218,14 @@ func TestHTTPExport(t *testing.T) {
 
 			if test.PersistOnError != nil {
 				params[PersistOnError] = *test.PersistOnError
+			}
+
+			if test.ContinueOnSendError != nil {
+				params[ContinueOnSendError] = *test.ContinueOnSendError
+			}
+
+			if test.ReturnInputData != nil {
+				params[ReturnInputData] = *test.ReturnInputData
 			}
 
 			if test.HeaderName != nil {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## What is the current behavior?
HTTP export returns HTTP response and stops pipeline on send errors. This block the ability to chain multiple HTTP exports in the pipeline to send the same data to multiple destinations.
Configurable pipeline only allows once instance of each function to be configured. Configuration names must match actual function names exactly. i.e. `HttpExport` matches `HttpExport`, but `HttpExport2` does not match `HttpExport`
Issue Number: #256


## What is the new behavior?
HTTP export now has option to return the input data and optionally continue pipeline on send errors. This enables the ability to chain multiple HTTP exports in the pipeline to send the same data to multiple destinations.
Configurable pipeline now supports multiple instance functions to be configured. Configuration names that start with the actual function name now match.  i.e. `HttpExport` matches `HttpExport` and `HttpExport2` also matches `HttpExport`. 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information