### PR TITLE
fix: Clean up retry properties and update secret path

### DIFF
--- a/app-service-template/res/configuration.toml
+++ b/app-service-template/res/configuration.toml
@@ -62,13 +62,11 @@ Timeout = "30s"
 Type = 'vault'
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secret/edgex/appservice/'
+Path = 'appservice/'
 Protocol = 'http'
 RootCaCertPath = ''
 ServerName = ''
 TokenFile = '/tmp/edgex/secrets/new-app-service/secrets-token.json'
-AdditionalRetryAttempts = 10
-RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9
 	github.com/eclipse/paho.mqtt.golang v1.3.4
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.59
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.61
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.91
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.13
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.7


### PR DESCRIPTION
`SecretStore` config no longer support Retry related properties and secret path now only needs service specific path, `/v1/secret/edgex/` automatically prefix in front of it.

Fixes: #864
Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Retry related properties in toml file and secret path is still full path.

Issue Number: #864 


## What is the new behavior?
Retry related properties are removed and secret path now only contains the service specific path.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information