### PR TITLE
refactor(transforms): MQTTSecretSender Topic Replacements

### DIFF
--- a/pkg/transforms/mqttsecret_test.go
+++ b/pkg/transforms/mqttsecret_test.go
@@ -58,8 +58,8 @@ func TestMQTTSecretSender_formatTopic_Default(t *testing.T) {
 
 	formattedTopic, err := sender.formatTopic(ctx, nil)
 
-	require.Equal(t, configuredTopic, formattedTopic)
 	require.NoError(t, err)
+	require.Equal(t, configuredTopic, formattedTopic)
 }
 
 func TestMQTTSecretSender_formatTopic_Default_ContextKeyUsed(t *testing.T) {
@@ -79,8 +79,8 @@ func TestMQTTSecretSender_formatTopic_Default_ContextKeyUsed(t *testing.T) {
 		expectedTopic = strings.Replace(expectedTopic, fmt.Sprintf("{%s}", k), v, -1)
 	}
 
-	require.Equal(t, expectedTopic, formattedTopic)
 	require.NoError(t, err)
+	require.Equal(t, expectedTopic, formattedTopic)
 }
 
 func TestMQTTSecretSender_formatTopic_Default_MissingContextKeyUsed(t *testing.T) {
@@ -92,9 +92,9 @@ func TestMQTTSecretSender_formatTopic_Default_MissingContextKeyUsed(t *testing.T
 
 	formattedTopic, err := sender.formatTopic(ctx, nil)
 
-	require.Equal(t, "", formattedTopic)
 	require.Error(t, err)
 	require.Equal(t, fmt.Sprintf("failed to replace all context placeholders in configured topic ('%s' after replacements)", configuredTopic), err.Error())
+	require.Equal(t, "", formattedTopic)
 }
 
 func TestMQTTSecretSender_WithTopicFormatter_formatTopic(t *testing.T) {
@@ -109,8 +109,8 @@ func TestMQTTSecretSender_WithTopicFormatter_formatTopic(t *testing.T) {
 
 	formattedTopic, err := sender.formatTopic(ctx, nil)
 
-	require.Equal(t, configuredTopic+"/"+subtopic, formattedTopic)
 	require.NoError(t, err)
+	require.Equal(t, configuredTopic+"/"+subtopic, formattedTopic)
 }
 
 func TestMQTTSecretSender_WithTopicFormatter_formatTopic_Error(t *testing.T) {
@@ -124,8 +124,8 @@ func TestMQTTSecretSender_WithTopicFormatter_formatTopic_Error(t *testing.T) {
 
 	formattedTopic, err := sender.formatTopic(ctx, nil)
 
-	require.Equal(t, "", formattedTopic)
 	require.Error(t, err)
+	require.Equal(t, "", formattedTopic)
 }
 
 func TestMQTTSecretSender_MQTTSendNodata(t *testing.T) {


### PR DESCRIPTION
Instead of attempting a replacement for all values in context, find
all placeholders with regexp and use matches to drive replacement
attempts.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Topic replacement is performed for all entries in context dictionary 

Issue Number: #871 


## What is the new behavior?
Since replacement activity is validated using a regexp, used same regexp to find placeholders actually used in topic and only attempt replacement from context for those.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information