### PR TITLE
feat(sdk): Use Default Topic Formatting for Triggers

### DIFF
--- a/internal/app/backgroundmessage.go
+++ b/internal/app/backgroundmessage.go
@@ -1,6 +1,5 @@
 //
-// Copyright (c) 2020 Technotects
-// Copyright (c) 2021 Intel Corporation
+// Copyright (c) 2021 Technotects
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,11 +14,21 @@
 // limitations under the License.
 //
 
-package interfaces
+package app
 
-// BackgroundPublisher provides an interface to send messages from background processes
-// through the service's configured MessageBus output
-type BackgroundPublisher interface {
-	// Publish provided message through the configured MessageBus output
-	Publish(payload []byte, context AppFunctionContext) error
+import (
+	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
+)
+
+type BackgroundMessage struct {
+	PublishTopic string
+	Payload      types.MessageEnvelope
+}
+
+func (bg BackgroundMessage) Topic() string {
+	return bg.PublishTopic
+}
+
+func (bg BackgroundMessage) Message() types.MessageEnvelope {
+	return bg.Payload
 }

--- a/internal/app/backgroundpublisher_test.go
+++ b/internal/app/backgroundpublisher_test.go
@@ -18,33 +18,91 @@
 package app
 
 import (
+	"fmt"
+	"github.com/edgexfoundry/app-functions-sdk-go/v2/internal/appfunction"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewBackgroundPublisherAndPublish(t *testing.T) {
-	background, pub := newBackgroundPublisher(1)
+func TestPublish_Plain_Topic(t *testing.T) {
+	topic := uuid.NewString()
+
+	background, pub := newBackgroundPublisher(topic, 1)
 
 	payload := []byte("something")
 	correlationId := "id"
 	contentType := "type"
 
-	pub.Publish(payload, correlationId, contentType)
+	pub.Publish(payload, appfunction.NewContext(correlationId, nil, contentType))
 
 	waiting := true
 
 	for waiting {
 		select {
 		case msgs := <-background:
-			assert.Equal(t, correlationId, msgs.CorrelationID)
-			assert.Equal(t, contentType, msgs.ContentType)
-			assert.Equal(t, payload, msgs.Payload)
+			msg := msgs.Message()
+			assert.Equal(t, correlationId, msg.CorrelationID)
+			assert.Equal(t, contentType, msg.ContentType)
+			assert.Equal(t, payload, msg.Payload)
+			assert.Equal(t, topic, msgs.Topic())
 			waiting = false
 		case <-time.After(1 * time.Second):
 			assert.Fail(t, "message timed out, background channel likely not configured correctly")
 			waiting = false
 		}
 	}
+}
+
+func TestPublish_Formatted_Topic(t *testing.T) {
+	topic := "{context-key}/topic"
+
+	background, pub := newBackgroundPublisher(topic, 1)
+
+	payload := []byte("something")
+	correlationId := "id"
+	contentType := "type"
+
+	appCtx := appfunction.NewContext(correlationId, nil, contentType)
+
+	appCtx.AddValue("context-key", "replaced")
+	err := pub.Publish(payload, appCtx)
+
+	require.NoError(t, err)
+
+	waiting := true
+
+	for waiting {
+		select {
+		case msgs := <-background:
+			msg := msgs.Message()
+			assert.Equal(t, correlationId, msg.CorrelationID)
+			assert.Equal(t, contentType, msg.ContentType)
+			assert.Equal(t, payload, msg.Payload)
+			assert.Equal(t, "replaced/topic", msgs.Topic())
+			waiting = false
+		case <-time.After(1 * time.Second):
+			assert.Fail(t, "message timed out, background channel likely not configured correctly")
+			waiting = false
+		}
+	}
+}
+
+func TestPublish_Topic_Formatting_Error(t *testing.T) {
+	topic := "{context-key}/topic"
+
+	_, pub := newBackgroundPublisher(topic, 1)
+
+	payload := []byte("something")
+	correlationId := "id"
+	contentType := "type"
+
+	err := pub.Publish(payload, appfunction.NewContext(correlationId, nil, contentType))
+
+	require.Error(t, err)
+
+	require.Equal(t, fmt.Sprintf("Failed to prepare topic for publishing: failed to replace all context placeholders in input ('%s' after replacements)", topic), err.Error())
 }

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -48,7 +48,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	commonConstants "github.com/edgexfoundry/go-mod-core-contracts/v2/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
-	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/v2/registry"
 
 	"github.com/gorilla/mux"
@@ -83,7 +82,7 @@ type Service struct {
 	webserver                 *webserver.WebServer
 	ctx                       contextGroup
 	deferredFunctions         []bootstrap.Deferred
-	backgroundPublishChannel  <-chan types.MessageEnvelope
+	backgroundPublishChannel  <-chan interfaces.BackgroundMessage
 	customTriggerFactories    map[string]func(sdk *Service) (interfaces.Trigger, error)
 	profileSuffixPlaceholder  string
 	commandLine               commandLineFlags
@@ -119,10 +118,28 @@ func (svc *Service) AddRoute(route string, handler func(nethttp.ResponseWriter, 
 
 // AddBackgroundPublisher will create a channel of provided capacity to be
 // consumed by the MessageBus output and return a publisher that writes to it
-func (svc *Service) AddBackgroundPublisher(capacity int) interfaces.BackgroundPublisher {
-	bgchan, pub := newBackgroundPublisher(capacity)
+func (svc *Service) AddBackgroundPublisher(capacity int) (interfaces.BackgroundPublisher, error) {
+	topic := svc.config.Trigger.EdgexMessageBus.PublishHost.PublishTopic
+
+	if topic == "" {
+		return nil, errors.New("no publish topic configured for messagebus, background publishing unavailable")
+	}
+	return svc.AddBackgroundPublisherWithTopic(capacity, topic)
+}
+
+// AddBackgroundPublisherWithTopic will create a channel of provided capacity to be
+// consumed by the MessageBus output and return a publisher that writes to it on a different
+// topic than configured for messagebus output.
+func (svc *Service) AddBackgroundPublisherWithTopic(capacity int, topic string) (interfaces.BackgroundPublisher, error) {
+	// for custom triggers we don't know if background publishing available or not
+	// but probably makes sense to trust the caller.
+	if svc.config.Trigger.Type == TriggerTypeHTTP || svc.config.Trigger.Type == TriggerTypeMQTT {
+		return nil, fmt.Errorf("Background publishing not supported for %s trigger.", svc.config.Trigger.Type)
+	}
+
+	bgchan, pub := newBackgroundPublisher(topic, capacity)
 	svc.backgroundPublishChannel = bgchan
-	return pub
+	return pub, nil
 }
 
 // MakeItStop will force the service loop to exit in the same fashion as SIGINT/SIGTERM received from the OS

--- a/internal/app/triggerfactory_test.go
+++ b/internal/app/triggerfactory_test.go
@@ -35,8 +35,6 @@ import (
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
-	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -153,7 +151,7 @@ func TestSetupTrigger_MQTT(t *testing.T) {
 type mockCustomTrigger struct {
 }
 
-func (*mockCustomTrigger) Initialize(_ *sync.WaitGroup, _ context.Context, _ <-chan types.MessageEnvelope) (bootstrap.Deferred, error) {
+func (*mockCustomTrigger) Initialize(_ *sync.WaitGroup, _ context.Context, _ <-chan interfaces.BackgroundMessage) (bootstrap.Deferred, error) {
 	return nil, nil
 }
 

--- a/internal/trigger/http/rest.go
+++ b/internal/trigger/http/rest.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/edgexfoundry/app-functions-sdk-go/v2/pkg/interfaces"
 	"io"
 	"net/http"
 	"sync"
@@ -53,7 +54,7 @@ func NewTrigger(dic *di.Container, runtime *runtime.GolangRuntime, webserver *we
 }
 
 // Initialize initializes the Trigger for logging and REST route
-func (trigger *Trigger) Initialize(_ *sync.WaitGroup, _ context.Context, background <-chan types.MessageEnvelope) (bootstrap.Deferred, error) {
+func (trigger *Trigger) Initialize(_ *sync.WaitGroup, _ context.Context, background <-chan interfaces.BackgroundMessage) (bootstrap.Deferred, error) {
 	lc := bootstrapContainer.LoggingClientFrom(trigger.dic.Get)
 
 	if background != nil {

--- a/internal/trigger/http/rest_test.go
+++ b/internal/trigger/http/rest_test.go
@@ -18,18 +18,17 @@
 package http
 
 import (
+	"github.com/edgexfoundry/app-functions-sdk-go/v2/pkg/interfaces"
 	"testing"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
-	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTriggerInitializeWitBackgroundChannel(t *testing.T) {
-	background := make(chan types.MessageEnvelope)
+	background := make(chan interfaces.BackgroundMessage)
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
 			return logger.NewMockClient()

--- a/internal/trigger/mqtt/mqtt.go
+++ b/internal/trigger/mqtt/mqtt.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/edgexfoundry/app-functions-sdk-go/v2/pkg/interfaces"
 	"net/url"
 	"strings"
 	"sync"
@@ -59,7 +60,7 @@ func NewTrigger(dic *di.Container, runtime *runtime.GolangRuntime) *Trigger {
 }
 
 // Initialize initializes the Trigger for an external MQTT broker
-func (trigger *Trigger) Initialize(_ *sync.WaitGroup, _ context.Context, background <-chan types.MessageEnvelope) (bootstrap.Deferred, error) {
+func (trigger *Trigger) Initialize(_ *sync.WaitGroup, _ context.Context, background <-chan interfaces.BackgroundMessage) (bootstrap.Deferred, error) {
 	// Convenience short cuts
 	lc := trigger.lc
 	config := container.ConfigurationFrom(trigger.dic.Get)
@@ -181,7 +182,13 @@ func (trigger *Trigger) messageHandler(client pahoMqtt.Client, message pahoMqtt.
 	}
 
 	if len(appContext.ResponseData()) > 0 && len(topic) > 0 {
-		if token := client.Publish(topic, brokerConfig.QoS, brokerConfig.Retain, appContext.ResponseData()); token.Wait() && token.Error() != nil {
+		formattedTopic, err := appContext.ApplyValues(topic)
+
+		if err != nil {
+			lc.Errorf("could not format topic '%s' for MQTT trigger output: %s", topic, err.Error())
+		}
+
+		if token := client.Publish(formattedTopic, brokerConfig.QoS, brokerConfig.Retain, appContext.ResponseData()); token.Wait() && token.Error() != nil {
 			lc.Errorf("could not publish to topic '%s' for MQTT trigger: %s", topic, token.Error().Error())
 		} else {
 			lc.Trace("Sent MQTT Trigger response message", common.CorrelationHeader, correlationID)

--- a/pkg/interfaces/backgroundmessage.go
+++ b/pkg/interfaces/backgroundmessage.go
@@ -1,6 +1,5 @@
 //
-// Copyright (c) 2020 Technotects
-// Copyright (c) 2021 Intel Corporation
+// Copyright (c) 2021 Technotects
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,9 +16,11 @@
 
 package interfaces
 
-// BackgroundPublisher provides an interface to send messages from background processes
-// through the service's configured MessageBus output
-type BackgroundPublisher interface {
-	// Publish provided message through the configured MessageBus output
-	Publish(payload []byte, context AppFunctionContext) error
+import (
+	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
+)
+
+type BackgroundMessage interface {
+	Message() types.MessageEnvelope
+	Topic() string
 }

--- a/pkg/interfaces/mocks/ApplicationService.go
+++ b/pkg/interfaces/mocks/ApplicationService.go
@@ -22,7 +22,7 @@ type ApplicationService struct {
 }
 
 // AddBackgroundPublisher provides a mock function with given fields: capacity
-func (_m *ApplicationService) AddBackgroundPublisher(capacity int) interfaces.BackgroundPublisher {
+func (_m *ApplicationService) AddBackgroundPublisher(capacity int) (interfaces.BackgroundPublisher, error) {
 	ret := _m.Called(capacity)
 
 	var r0 interfaces.BackgroundPublisher
@@ -34,7 +34,41 @@ func (_m *ApplicationService) AddBackgroundPublisher(capacity int) interfaces.Ba
 		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(int) error); ok {
+		r1 = rf(1)
+	} else {
+		if ret.Get(0) != nil {
+			r1 = ret.Get(1).(error)
+		}
+	}
+
+	return r0, r1
+}
+
+// AddBackgroundPublisher provides a mock function with given fields: capacity, topic
+func (_m *ApplicationService) AddBackgroundPublisherWithTopic(capacity int, topic string) (interfaces.BackgroundPublisher, error) {
+	ret := _m.Called(capacity)
+
+	var r0 interfaces.BackgroundPublisher
+	if rf, ok := ret.Get(0).(func(int, string) interfaces.BackgroundPublisher); ok {
+		r0 = rf(capacity, topic)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(interfaces.BackgroundPublisher)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(int) error); ok {
+		r1 = rf(1)
+	} else {
+		if ret.Get(0) != nil {
+			r1 = ret.Get(1).(error)
+		}
+	}
+
+	return r0, r1
 }
 
 // AddRoute provides a mock function with given fields: route, handler, methods

--- a/pkg/interfaces/service.go
+++ b/pkg/interfaces/service.go
@@ -80,9 +80,14 @@ type ApplicationService interface {
 	MakeItStop()
 	// RegisterCustomTriggerFactory registers a trigger factory for a custom trigger to be used.
 	RegisterCustomTriggerFactory(name string, factory func(TriggerConfig) (Trigger, error)) error
-	// Adds and returns a BackgroundPublisher which is used to publish asynchronously to the Edgex MessageBus.
+	// AddBackgroundPublisher Adds and returns a BackgroundPublisher which is used to publish
+	// asynchronously to the Edgex MessageBus.
 	// Not valid for use with the HTTP or External MQTT triggers
-	AddBackgroundPublisher(capacity int) BackgroundPublisher
+	AddBackgroundPublisher(capacity int) (BackgroundPublisher, error)
+	// AddBackgroundPublisherWithTopic Adds and returns a BackgroundPublisher which is used to publish
+	// asynchronously to the Edgex MessageBus on the specified topic.
+	// Not valid for use with the HTTP or External MQTT triggers
+	AddBackgroundPublisherWithTopic(capacity int, topic string) (BackgroundPublisher, error)
 	// GetSecret returns the secret data from the secret store (secure or insecure) for the specified path.
 	// An error is returned if the path is not found or any of the keys (if specified) are not found.
 	// Omit keys if all secret data for the specified path is required.

--- a/pkg/interfaces/trigger.go
+++ b/pkg/interfaces/trigger.go
@@ -36,7 +36,7 @@ type TriggerConfig struct {
 // Trigger provides an abstract means to pass messages to the function pipeline
 type Trigger interface {
 	// Initialize performs post creation initializations
-	Initialize(wg *sync.WaitGroup, ctx context.Context, background <-chan types.MessageEnvelope) (bootstrap.Deferred, error)
+	Initialize(wg *sync.WaitGroup, ctx context.Context, background <-chan BackgroundMessage) (bootstrap.Deferred, error)
 }
 
 // TriggerMessageProcessor provides an interface that can be used by custom triggers to invoke the runtime


### PR DESCRIPTION
Enable publish topic formatting for MQTT and Messagebus triggers.  Make
BackgroundPublisher API context-aware so that topics can be formatted
and delivered along with the MessageEnvelope for publication.

Signed-off-by: Alex Ullrich <alexullrich@technotects.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: #803 


## What is the new behavior?
"Default" context-based topic formatting is applied when publishing to trigger outputs (including background publishing for MessageBus)

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BackgroundPublisher.Publish now takes an interfaces.Context instead of correlation ID and content type.

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information