### PR TITLE
refactor: Use Core Metadata Version API for version check

### DIFF
--- a/internal/bootstrap/handlers/version_test.go
+++ b/internal/bootstrap/handlers/version_test.go
@@ -42,7 +42,7 @@ func TestValidateVersionMatch(t *testing.T) {
 	startupTimer := startup.NewStartUpTimer("unit-test")
 
 	clientConfigs := make(map[string]config.ClientInfo)
-	clientConfigs[common.CoreDataServiceKey] = config.ClientInfo{
+	clientConfigs[common.CoreMetaDataServiceKey] = config.ClientInfo{
 		Protocol: "http",
 		Host:     "localhost",
 		Port:     0, // Will be replaced by local test webserver's port
@@ -116,9 +116,9 @@ func TestValidateVersionMatch(t *testing.T) {
 
 			testServerUrl, _ := url.Parse(testServer.URL)
 			port, _ := strconv.Atoi(testServerUrl.Port())
-			coreService := configuration.Clients[common.CoreDataServiceKey]
+			coreService := configuration.Clients[common.CoreMetaDataServiceKey]
 			coreService.Port = port
-			configuration.Clients[common.CoreDataServiceKey] = coreService
+			configuration.Clients[common.CoreMetaDataServiceKey] = coreService
 
 			validator := NewVersionValidator(test.skipVersionCheck, test.SdkVersion)
 			result := validator.BootstrapHandler(context.Background(), &sync.WaitGroup{}, startupTimer, dic)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Core Data is now optional, so need to use service that will always be present.

Issue Number: #902


## What is the new behavior?
Core Data is used for version check, but is now optional service is device services are using MessageBus and no persistence is needed/enabled.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information