### PR TITLE
fix: Change logging of CorrelationID to use proper function call

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -190,7 +190,7 @@ func (gr *GolangRuntime) ExecutePipeline(
 				if err, ok := result.(error); ok {
 					appContext.LoggingClient().Error(
 						fmt.Sprintf("Pipeline function #%d resulted in error", functionIndex),
-						"error", err.Error(), common.CorrelationHeader, appContext.CorrelationID)
+						"error", err.Error(), common.CorrelationHeader, appContext.CorrelationID())
 					if appContext.RetryData() != nil && !isRetry {
 						gr.storeForward.storeForLaterRetry(appContext.RetryData(), appContext, functionIndex)
 					}

--- a/internal/runtime/storeforward.go
+++ b/internal/runtime/storeforward.go
@@ -115,7 +115,7 @@ func (sf *storeForwardInfo) storeForLaterRetry(
 	item.CorrelationID = appContext.CorrelationID()
 
 	appContext.LoggingClient().Trace("Storing data for later retry",
-		common.CorrelationHeader, appContext.CorrelationID)
+		common.CorrelationHeader, appContext.CorrelationID())
 
 	config := container.ConfigurationFrom(sf.dic.Get)
 	if !config.Writable.StoreAndForward.Enabled {
@@ -235,7 +235,7 @@ func (sf *storeForwardInfo) retryExportFunction(item contracts.StoredObject) boo
 		appContext.AddValue(strings.ToLower(k), v)
 	}
 
-	appContext.LoggingClient().Trace("Retrying stored data", common.CorrelationHeader, appContext.CorrelationID)
+	appContext.LoggingClient().Trace("Retrying stored data", common.CorrelationHeader, appContext.CorrelationID())
 
 	return sf.runtime.ExecutePipeline(
 		item.Payload,

--- a/pkg/transforms/http.go
+++ b/pkg/transforms/http.go
@@ -210,7 +210,7 @@ func (sender HTTPSender) httpSend(ctx interfaces.AppFunctionContext, data interf
 	}
 
 	ctx.LoggingClient().Debugf("Sent %s bytes of data. Response status is %s", len(exportData), response.Status)
-	ctx.LoggingClient().Trace("Data exported", "Transport", "HTTP", common.CorrelationHeader, ctx.CorrelationID)
+	ctx.LoggingClient().Trace("Data exported", "Transport", "HTTP", common.CorrelationHeader, ctx.CorrelationID())
 
 	// This allows multiple HTTP Exports to be chained in the pipeline to send the same data to different destinations
 	// Don't need to read the response data since not going to return it so just return now.

--- a/pkg/transforms/mqttsecret.go
+++ b/pkg/transforms/mqttsecret.go
@@ -202,7 +202,7 @@ func (sender *MQTTSecretSender) MQTTSend(ctx interfaces.AppFunctionContext, data
 	}
 
 	ctx.LoggingClient().Debug("Sent data to MQTT Broker")
-	ctx.LoggingClient().Trace("Data exported", "Transport", "MQTT", common.CorrelationHeader, ctx.CorrelationID)
+	ctx.LoggingClient().Trace("Data exported", "Transport", "MQTT", common.CorrelationHeader, ctx.CorrelationID())
 
 	return true, nil
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Call CorrelationID API in log messages missing `()`

Issue Number:  #923



## What is the new behavior?
All calls CorrelationID API now proper function calls.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information