### PR TITLE
fix: Set logger in MqttFactory to avoid panic when AuthMode is empty

### DIFF
--- a/pkg/secure/mqttfactory.go
+++ b/pkg/secure/mqttfactory.go
@@ -48,6 +48,7 @@ type MqttFactory struct {
 func NewMqttFactory(appContext interfaces.AppFunctionContext, mode string, path string, skipVerify bool) MqttFactory {
 	return MqttFactory{
 		appContext:     appContext,
+		logger:         appContext.LoggingClient(),
 		authMode:       mode,
 		secretPath:     path,
 		skipCertVerify: skipVerify,

--- a/pkg/secure/mqttfactory_test.go
+++ b/pkg/secure/mqttfactory_test.go
@@ -51,6 +51,20 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func TestNewMqttFactory(t *testing.T) {
+	expectedMode := "none"
+	expectedPath := "myPath"
+	expectedSkipVerify := true
+	target := NewMqttFactory(context, expectedMode, expectedPath, expectedSkipVerify)
+
+	assert.NotNil(t, target.logger)
+	assert.Equal(t, expectedMode, target.authMode)
+	assert.Equal(t, expectedPath, target.secretPath)
+	assert.Equal(t, expectedSkipVerify, target.skipCertVerify)
+	assert.Nil(t, target.opts)
+
+}
+
 func TestConfigureMQTTClientForAuth(t *testing.T) {
 	target := NewMqttFactory(context, "", "", false)
 	target.opts = mqtt.NewClientOptions()


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->


## What is the current behavior?
MqttFactory will panic when attempt to log warning about `authMode` empty du to logger not set in the factory method.

Issue Number: #920


## What is the new behavior?
Logger set set in the factory method avoiding panic and logging wanring.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information