### PR TITLE
feat(sdk): Custom Trigger Multi-Pipeline Support

### DIFF
--- a/app-service-template/Attribution.txt
+++ b/app-service-template/Attribution.txt
@@ -51,11 +51,17 @@ https://github.com/gorilla/mux/blob/master/LICENSE
 hashicorp/consul/api (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
 https://github.com/hashicorp/consul/blob/master/LICENSE
 
+hashicorp/errwrap (Mozilla Public License 2.0) https://github.com/hashicorp/errwrap
+https://github.com/hashicorp/errwrap/blob/master/LICENSE
+
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
 
 hashicorp/go-immutable-radix (Mozilla Public License 2.0) https://github.com/hashicorp/go-immutable-radix
 https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
+
+hashicorp/go-multierror (Mozilla Public License 2.0) https://github.com/hashicorp/go-multierror
+https://github.com/hashicorp/go-multierror/blob/master/LICENSE
 
 hashicorp/go-rootcerts (Mozilla Public License 2.0) https://github.com/hashicorp/go-rootcerts
 https://github.com/hashicorp/go-rootcerts/blob/master/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,6 @@ require (
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
+	github.com/hashicorp/go-multierror v1.1.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/pkg/interfaces/trigger.go
+++ b/pkg/interfaces/trigger.go
@@ -27,10 +27,18 @@ import (
 
 // TriggerConfig provides a container to pass context needed for user defined triggers
 type TriggerConfig struct {
-	Logger           logger.LoggingClient
-	ContextBuilder   TriggerContextBuilder
+	// Logger exposes the logging client passed from the service
+	Logger logger.LoggingClient
+	// ContextBuilder contructs a context the trigger can specify for processing the received message
+	// Deprecated: only needed when using MessageProcessor
+	ContextBuilder TriggerContextBuilder
+	// MessageProcessor processes a message on the services default pipeline
+	// Deprecated: use ProcessMessage so that custom triggers can feed data to services configured with multiple pipelines
 	MessageProcessor TriggerMessageProcessor
-	ConfigLoader     TriggerConfigLoader
+	// ProcessMessage is a function of type MessageProcessor that is used to deliver messages to the runtime.
+	ProcessMessage MessageProcessor
+	// ConfigLoader is a function of type TriggerConfigLoader that can be used to load custom configuration sections for the trigger.s
+	ConfigLoader TriggerConfigLoader
 }
 
 // Trigger provides an abstract means to pass messages to the function pipeline
@@ -40,9 +48,15 @@ type Trigger interface {
 }
 
 // TriggerMessageProcessor provides an interface that can be used by custom triggers to invoke the runtime
+// Deprecated: use MessageProcessor instead
 type TriggerMessageProcessor func(ctx AppFunctionContext, envelope types.MessageEnvelope) error
 
 // TriggerContextBuilder provides an interface to construct an AppFunctionContext for message
+// Deprecated: only used with legacy TriggerMessageProcessor
 type TriggerContextBuilder func(env types.MessageEnvelope) AppFunctionContext
 
+// MessageProcessor provides an interface that can be used by custom triggers to invoke the runtime
+type MessageProcessor func(envelope types.MessageEnvelope) error
+
+// TriggerConfigLoader provides an interface that can be used by custom triggers to load custom configuration elements
 type TriggerConfigLoader func(config UpdatableConfig, sectionName string) error


### PR DESCRIPTION
Add service.processMessageOnRuntime to use default pipeline if configured or attempt to use topic matching logic.  Deprecate TriggerMessageProcessor and TriggerContextBuilder and inline the existing functions on TriggerConfig as the approach used there will not work with multiple pipelines. Replace with MessageProcessor that only takes the message envelope and builds context(s) as needed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Related Docs PR now required (if applicable) 
Related Docs PR:

If n/a for Docs PR, state why it is not applicable:

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:
#940 

## What is the new behavior?
<!-- Please describe the new behavior. -->
Custom triggers will be able to use the default topic -> pipeline(s) matching logic.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, if so please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

Only affects custom triggers, the message processor function no longer takes the app context as a parameter.   The trigger will no longer be responsible for establishing context just preparing the message envelope.

## Are there any new imports or modules? If so, what are they used for and why?

- [x] Yes
- [ ] No

go-multierror from hashicorp is used to group pipeline errors for return to the trigger.

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information