### PR TITLE
feat(sdk): Support Multi-Topic Pipeline Configuration

### DIFF
--- a/app-service-template/go.sum
+++ b/app-service-template/go.sum
@@ -81,8 +81,9 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-msgpack v0.5.3 h1:zKjpN5BK/P5lMYrLmBHdBULWbJ0XpYR+7NGzqkZzoD4=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=

--- a/app-service-template/main.go
+++ b/app-service-template/main.go
@@ -100,9 +100,9 @@ func (app *myApp) CreateAndRunAppService(serviceKey string, newServiceFactory fu
 	sample := functions.NewSample()
 
 	// TODO: Replace below functions with built in and/or your custom functions for your use case
-	//       or remove is using Pipeline By Topic below.
+	//       or remove if using Pipeline By Topics below.
 	//       See https://docs.edgexfoundry.org/2.0/microservices/application/BuiltIn/ for list of built-in functions
-	err = app.service.SetFunctionsPipeline(
+	err = app.service.SetDefaultFunctionsPipeline(
 		transforms.NewFilterFor(deviceNames).FilterByDeviceName,
 		sample.LogEventDetails,
 		sample.ConvertEventToXML,
@@ -120,8 +120,8 @@ func (app *myApp) CreateAndRunAppService(serviceKey string, newServiceFactory fu
 	//       Core Data publishes to the 'edgex/events/core/<profile-name>/<device-name>/<source-name>' topic
 	// Note: This example with default above causes Events from Random-Float-Device device to be processed twice
 	//       resulting in the XML to be published back to the MessageBus twice.
-	// See <Pipeline By Topic documentation url TBD> for more details.
-	err = app.service.AddFunctionsPipelineForTopic("Floats", "edgex/events/#/#/Random-Float-Device/#",
+	// See https://docs.edgexfoundry.org/2.0/microservices/application/AdvancedTopics/#pipeline-per-topics for more details.
+	err = app.service.AddFunctionsPipelineForTopics("Floats", []string{"edgex/events/#/#/Random-Float-Device/#"},
 		transforms.NewFilterFor(deviceNames).FilterByDeviceName,
 		sample.LogEventDetails,
 		sample.ConvertEventToXML,
@@ -132,7 +132,7 @@ func (app *myApp) CreateAndRunAppService(serviceKey string, newServiceFactory fu
 	}
 	// Note: This example with default above causes Events from Int32 source to be processed twice
 	//       resulting in the XML to be published back to the MessageBus twice.
-	err = app.service.AddFunctionsPipelineForTopic("Int32s", "edgex/events/#/#/#/Int32",
+	err = app.service.AddFunctionsPipelineForTopics("Int32s", []string{"edgex/events/#/#/#/Int32"},
 		transforms.NewFilterFor(deviceNames).FilterByDeviceName,
 		sample.LogEventDetails,
 		sample.ConvertEventToXML,

--- a/app-service-template/main_test.go
+++ b/app-service-template/main_test.go
@@ -42,9 +42,9 @@ func TestCreateAndRunService_Success(t *testing.T) {
 		mockAppService.On("LoggingClient").Return(logger.NewMockClient())
 		mockAppService.On("GetAppSettingStrings", "DeviceNames").
 			Return([]string{"Random-Boolean-Device, Random-Integer-Device"}, nil)
-		mockAppService.On("SetFunctionsPipeline", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mockAppService.On("SetDefaultFunctionsPipeline", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(nil)
-		mockAppService.On("AddFunctionsPipelineForTopic", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mockAppService.On("AddFunctionsPipelineForTopics", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(nil)
 		mockAppService.On("LoadCustomConfig", mock.Anything, mock.Anything, mock.Anything).
 			Return(nil).Run(func(args mock.Arguments) {
@@ -115,7 +115,7 @@ func TestCreateAndRunService_SetFunctionsPipeline_Failed(t *testing.T) {
 		})
 		mockAppService.On("ListenForCustomConfigChanges", mock.Anything, mock.Anything, mock.Anything).
 			Return(nil)
-		mockAppService.On("SetFunctionsPipeline", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mockAppService.On("SetDefaultFunctionsPipeline", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(fmt.Errorf("Failed")).Run(func(args mock.Arguments) {
 			setFunctionsPipelineCalled = true
 		})
@@ -148,9 +148,9 @@ func TestCreateAndRunService_MakeItRun_Failed(t *testing.T) {
 		})
 		mockAppService.On("ListenForCustomConfigChanges", mock.Anything, mock.Anything, mock.Anything).
 			Return(nil)
-		mockAppService.On("SetFunctionsPipeline", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mockAppService.On("SetDefaultFunctionsPipeline", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(nil)
-		mockAppService.On("AddFunctionsPipelineForTopic", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mockAppService.On("AddFunctionsPipelineForTopics", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(nil)
 		mockAppService.On("MakeItRun").Return(fmt.Errorf("Failed")).Run(func(args mock.Arguments) {
 			makeItRunCalled = true

--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -162,12 +162,12 @@ type PipelineInfo struct {
 	Functions map[string]PipelineFunction
 }
 
-// TopicPipeline define the data to a Pre Topic functions pipeline
+// TopicPipeline define the data to a Per Topics functions pipeline
 type TopicPipeline struct {
 	// Id is the unique ID of the pipeline instance
 	Id string
-	// Topic is the topic which must match the incoming topic inorder for the pipeline to execute
-	Topic string
+	// Topics is the set of comma separated topics matched against the incoming to determine if pipeline should execute
+	Topics string
 	// ExecutionOrder is a list of functions, in execution order, for the pipeline instance
 	ExecutionOrder string
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2021 Intel Corporation
+// Copyright (c) 2021 One Track Consulting
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -531,42 +532,46 @@ func TestTopicMatches(t *testing.T) {
 	incomingTopic := "edgex/events/P/D/S"
 
 	tests := []struct {
-		name          string
-		incomingTopic string
-		pipelineTopic string
-		expected      bool
+		name           string
+		incomingTopic  string
+		pipelineTopics []string
+		expected       bool
 	}{
-		{"Match - Default all", incomingTopic, TopicWildCard, true},
-		{"Match - Exact", incomingTopic, incomingTopic, true},
-		{"Match - Any Profile for Device and Source", incomingTopic, "edgex/events/#/D/S", true},
-		{"Match - Any Device for Profile and Source", incomingTopic, "edgex/events/P/#/S", true},
-		{"Match - Any Source for Profile and Device", incomingTopic, "edgex/events/P/D/#", true},
-		{"Match - All Events ", incomingTopic, "edgex/events/#", true},
-		{"Match - All Devices and Sources for Profile ", incomingTopic, "edgex/events/P/#", true},
-		{"Match - All Sources for Profile and Device ", incomingTopic, "edgex/events/P/D/#", true},
-		{"Match - All Sources for a Device for any Profile ", incomingTopic, "edgex/events/#/D/#", true},
-		{"Match - Source for any Profile and any Device ", incomingTopic, "edgex/events/#/#/S", true},
-		{"NoMatch - SourceX for any Profile and any Device ", incomingTopic, "edgex/events/#/#/Sx", false},
-		{"NoMatch - All Sources for DeviceX and any Profile ", incomingTopic, "edgex/events/#/Dx/#", false},
-		{"NoMatch - All Sources for ProfileX and Device ", incomingTopic, "edgex/events/Px/D/#", false},
-		{"NoMatch - All Sources for Profile and DeviceX ", incomingTopic, "edgex/events/P/Dx/#", false},
-		{"NoMatch - All Sources for ProfileX and DeviceX ", incomingTopic, "edgex/events/Px/Dx/#", false},
-		{"NoMatch - All Devices and Sources for ProfileX ", incomingTopic, "edgex/events/Px/#", false},
-		{"NoMatch - Any Profile for DeviceX and Source", incomingTopic, "edgex/events/#/Dx/S", false},
-		{"NoMatch - Any Profile for DeviceX and Source", incomingTopic, "edgex/events/#/Dx/S", false},
-		{"NoMatch - Any Profile for Device and SourceX", incomingTopic, "edgex/events/#/D/Sx", false},
-		{"NoMatch - Any Profile for DeviceX and SourceX", incomingTopic, "edgex/events/#/Dx/Sx", false},
-		{"NoMatch - Any Device for Profile and SourceX", incomingTopic, "edgex/events/P/#/Sx", false},
-		{"NoMatch - Any Device for ProfileX and Source", incomingTopic, "edgex/events/Px/#/S", false},
-		{"NoMatch - Any Device for ProfileX and SourceX", incomingTopic, "edgex/events/Px/#/Sx", false},
-		{"NoMatch - Any Source for ProfileX and Device", incomingTopic, "edgex/events/Px/D/#", false},
-		{"NoMatch - Any Source for Profile and DeviceX", incomingTopic, "edgex/events/P/Dx/#", false},
-		{"NoMatch - Any Source for ProfileX and DeviceX", incomingTopic, "edgex/events/Px/Dx/#", false},
+		{"Match - Default all", incomingTopic, []string{TopicWildCard}, true},
+		{"Match - Not First Topic", incomingTopic, []string{"not-edgex/#", TopicWildCard}, true},
+		{"Match - Exact", incomingTopic, []string{incomingTopic}, true},
+		{"Match - Any Profile for Device and Source", incomingTopic, []string{"edgex/events/#/D/S"}, true},
+		{"Match - Any Profile for Device and Source", incomingTopic, []string{"edgex/events/#/D/S"}, true},
+		{"Match - Any Device for Profile and Source", incomingTopic, []string{"edgex/events/P/#/S"}, true},
+		{"Match - Any Source for Profile and Device", incomingTopic, []string{"edgex/events/P/D/#"}, true},
+		{"Match - All Events ", incomingTopic, []string{"edgex/events/#"}, true},
+		{"Match - First Topic Deeper ", incomingTopic, []string{"edgex/events/P/D/S/Z", "edgex/events/#"}, true},
+		{"Match - All Devices and Sources for Profile ", incomingTopic, []string{"edgex/events/P/#"}, true},
+		{"Match - All Sources for Profile and Device ", incomingTopic, []string{"edgex/events/P/D/#"}, true},
+		{"Match - All Sources for a Device for any Profile ", incomingTopic, []string{"edgex/events/#/D/#"}, true},
+		{"Match - Source for any Profile and any Device ", incomingTopic, []string{"edgex/events/#/#/S"}, true},
+		{"NoMatch - SourceX for any Profile and any Device ", incomingTopic, []string{"edgex/events/#/#/Sx"}, false},
+		{"NoMatch - All Sources for DeviceX and any Profile ", incomingTopic, []string{"edgex/events/#/Dx/#"}, false},
+		{"NoMatch - All Sources for ProfileX and Device ", incomingTopic, []string{"edgex/events/Px/D/#"}, false},
+		{"NoMatch - All Sources for Profile and DeviceX ", incomingTopic, []string{"edgex/events/P/Dx/#"}, false},
+		{"NoMatch - All Sources for ProfileX and DeviceX ", incomingTopic, []string{"edgex/events/Px/Dx/#"}, false},
+		{"NoMatch - All Devices and Sources for ProfileX ", incomingTopic, []string{"edgex/events/Px/#"}, false},
+		{"NoMatch - Any Profile for DeviceX and Source", incomingTopic, []string{"edgex/events/#/Dx/S"}, false},
+		{"NoMatch - Any Profile for DeviceX and Source", incomingTopic, []string{"edgex/events/#/Dx/S"}, false},
+		{"NoMatch - Any Profile for Device and SourceX", incomingTopic, []string{"edgex/events/#/D/Sx"}, false},
+		{"NoMatch - Any Profile for DeviceX and SourceX", incomingTopic, []string{"edgex/events/#/Dx/Sx"}, false},
+		{"NoMatch - Any Device for Profile and SourceX", incomingTopic, []string{"edgex/events/P/#/Sx"}, false},
+		{"NoMatch - Any Device for ProfileX and Source", incomingTopic, []string{"edgex/events/Px/#/S"}, false},
+		{"NoMatch - Any Device for ProfileX and SourceX", incomingTopic, []string{"edgex/events/Px/#/Sx"}, false},
+		{"NoMatch - Any Source for ProfileX and Device", incomingTopic, []string{"edgex/events/Px/D/#"}, false},
+		{"NoMatch - Any Source for Profile and DeviceX", incomingTopic, []string{"edgex/events/P/Dx/#"}, false},
+		{"NoMatch - Any Source for ProfileX and DeviceX", incomingTopic, []string{"edgex/events/Px/Dx/#"}, false},
+		{"NoMatch - Pipeline Topic Deeper", incomingTopic, []string{"edgex/events/P/D/S/Z"}, false},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := topicMatches(test.incomingTopic, test.pipelineTopic)
+			actual := topicMatches(test.incomingTopic, test.pipelineTopics)
 			assert.Equal(t, test.expected, actual)
 		})
 	}
@@ -576,7 +581,7 @@ func TestGetPipelineById(t *testing.T) {
 	target := NewGolangRuntime(serviceKey, nil, nil)
 
 	expectedId := "my-pipeline"
-	expectedTopic := "edgex/events/#"
+	expectedTopics := []string{"edgex/events/#"}
 	expectedTransforms := []interfaces.AppFunction{
 		transforms.NewResponseData().SetResponseData,
 	}
@@ -585,20 +590,20 @@ func TestGetPipelineById(t *testing.T) {
 	err := target.SetDefaultFunctionsPipeline(expectedTransforms)
 	require.NoError(t, err)
 
-	err = target.AddFunctionsPipeline(expectedId, expectedTopic, expectedTransforms)
+	err = target.AddFunctionsPipeline(expectedId, expectedTopics, expectedTransforms)
 	require.NoError(t, err)
 
 	actual := target.GetPipelineById(interfaces.DefaultPipelineId)
 	require.NotNil(t, actual)
 	assert.Equal(t, interfaces.DefaultPipelineId, actual.Id)
-	assert.Equal(t, TopicWildCard, actual.Topic)
+	assert.Equal(t, []string{TopicWildCard}, actual.Topics)
 	assert.Equal(t, expectedTransforms, actual.Transforms)
 	assert.NotEmpty(t, actual.Hash)
 
 	actual = target.GetPipelineById(expectedId)
 	require.NotNil(t, actual)
 	assert.Equal(t, expectedId, actual.Id)
-	assert.Equal(t, expectedTopic, actual.Topic)
+	assert.Equal(t, expectedTopics, actual.Topics)
 	assert.Equal(t, expectedTransforms, actual.Transforms)
 	assert.NotEmpty(t, actual.Hash)
 
@@ -613,11 +618,11 @@ func TestGetMatchingPipelines(t *testing.T) {
 		transforms.NewResponseData().SetResponseData,
 	}
 
-	err := target.AddFunctionsPipeline("one", "edgex/events/#/D1/#", expectedTransforms)
+	err := target.AddFunctionsPipeline("one", []string{"edgex/events/#/D1/#"}, expectedTransforms)
 	require.NoError(t, err)
-	err = target.AddFunctionsPipeline("two", "edgex/events/P1/#", expectedTransforms)
+	err = target.AddFunctionsPipeline("two", []string{"edgex/events/P1/#"}, expectedTransforms)
 	require.NoError(t, err)
-	err = target.AddFunctionsPipeline("three", "edgex/events/P1/D1/S1", expectedTransforms)
+	err = target.AddFunctionsPipeline("three", []string{"edgex/events/P1/D1/S1"}, expectedTransforms)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -650,7 +655,7 @@ func TestGolangRuntime_GetDefaultPipeline(t *testing.T) {
 	actual := target.GetDefaultPipeline()
 	require.NotNil(t, actual)
 	assert.Equal(t, interfaces.DefaultPipelineId, actual.Id)
-	assert.Empty(t, actual.Topic)
+	assert.Empty(t, actual.Topics)
 	assert.Nil(t, actual.Transforms)
 	assert.Empty(t, actual.Hash)
 
@@ -660,7 +665,7 @@ func TestGolangRuntime_GetDefaultPipeline(t *testing.T) {
 	actual = target.GetDefaultPipeline()
 	require.NotNil(t, actual)
 	assert.Equal(t, interfaces.DefaultPipelineId, actual.Id)
-	assert.Equal(t, TopicWildCard, actual.Topic)
+	assert.Equal(t, []string{TopicWildCard}, actual.Topics)
 	assert.Equal(t, expectedTransforms, actual.Transforms)
 	assert.NotEmpty(t, actual.Hash)
 }

--- a/internal/runtime/storeforward_test.go
+++ b/internal/runtime/storeforward_test.go
@@ -103,10 +103,10 @@ func TestProcessRetryItems(t *testing.T) {
 		{"RetryCount Increased - Default", failureTransform, true, expectedPayload, 4, 5, 0, false, contextData, false},
 		{"Max Retries - Default", failureTransform, true, expectedPayload, 9, 9, 1, false, contextData, false},
 		{"Bad Version - Default", successTransform, false, expectedPayload, 0, 0, 1, true, contextData, false},
-		{"Happy Path - Per Topic", successTransform, true, expectedPayload, 0, 0, 1, false, contextData, true},
-		{"RetryCount Increased - Per Topic", failureTransform, true, expectedPayload, 4, 5, 0, false, contextData, true},
-		{"Max Retries - Per Topic", failureTransform, true, expectedPayload, 9, 9, 1, false, contextData, true},
-		{"Bad Version - Per Topic", successTransform, false, expectedPayload, 0, 0, 1, true, contextData, true},
+		{"Happy Path - Per Topics", successTransform, true, expectedPayload, 0, 0, 1, false, contextData, true},
+		{"RetryCount Increased - Per Topics", failureTransform, true, expectedPayload, 4, 5, 0, false, contextData, true},
+		{"Max Retries - Per Topics", failureTransform, true, expectedPayload, 9, 9, 1, false, contextData, true},
+		{"Bad Version - Per Topics", successTransform, false, expectedPayload, 0, 0, 1, true, contextData, true},
 	}
 
 	for _, test := range tests {
@@ -117,7 +117,7 @@ func TestProcessRetryItems(t *testing.T) {
 			var pipeline *interfaces.FunctionPipeline
 
 			if test.UsePerTopic {
-				err := runtime.AddFunctionsPipeline("per-topic", "#", []interfaces.AppFunction{transformPassthru, transformPassthru, test.TargetTransform})
+				err := runtime.AddFunctionsPipeline("per-topic", []string{"#"}, []interfaces.AppFunction{transformPassthru, transformPassthru, test.TargetTransform})
 				require.NoError(t, err)
 				pipeline = runtime.GetPipelineById("per-topic")
 				require.NotNil(t, pipeline)
@@ -169,9 +169,9 @@ func TestDoStoreAndForwardRetry(t *testing.T) {
 		{"RetryCount Increased - Default", httpPost, 1, 2, 1, false},
 		{"Max Retries - Default", httpPost, 9, 0, 0, false},
 		{"Retry Success - Default", successTransform, 1, 0, 0, false},
-		{"RetryCount Increased - Per Topic", httpPost, 1, 2, 1, true},
-		{"Max Retries - Per Topic", httpPost, 9, 0, 0, true},
-		{"Retry Success - Per Topic", successTransform, 1, 0, 0, true},
+		{"RetryCount Increased - Per Topics", httpPost, 1, 2, 1, true},
+		{"Max Retries - Per Topics", httpPost, 9, 0, 0, true},
+		{"Retry Success - Per Topics", successTransform, 1, 0, 0, true},
 	}
 
 	for _, test := range tests {
@@ -181,7 +181,7 @@ func TestDoStoreAndForwardRetry(t *testing.T) {
 			var pipeline *interfaces.FunctionPipeline
 
 			if test.UsePerTopic {
-				err := runtime.AddFunctionsPipeline("per-topic", "#", []interfaces.AppFunction{transformPassthru, test.TargetTransform})
+				err := runtime.AddFunctionsPipeline("per-topic", []string{"#"}, []interfaces.AppFunction{transformPassthru, test.TargetTransform})
 				require.NoError(t, err)
 				pipeline = runtime.GetPipelineById("per-topic")
 				require.NotNil(t, pipeline)

--- a/internal/trigger/messagebus/messaging_test.go
+++ b/internal/trigger/messagebus/messaging_test.go
@@ -263,9 +263,9 @@ func TestPipelinePerTopic(t *testing.T) {
 
 	goRuntime := runtime.NewGolangRuntime("", nil, dic)
 
-	err = goRuntime.AddFunctionsPipeline("P1", "edgex/events/device/P1/#", []interfaces.AppFunction{transform1})
+	err = goRuntime.AddFunctionsPipeline("P1", []string{"edgex/events/device/P1/#"}, []interfaces.AppFunction{transform1})
 	require.NoError(t, err)
-	err = goRuntime.AddFunctionsPipeline("P2", "edgex/events/device/P2/#", []interfaces.AppFunction{transform2})
+	err = goRuntime.AddFunctionsPipeline("P2", []string{"edgex/events/device/P2/#"}, []interfaces.AppFunction{transform2})
 	require.NoError(t, err)
 
 	trigger := NewTrigger(dic, goRuntime)

--- a/pkg/interfaces/mocks/ApplicationService.go
+++ b/pkg/interfaces/mocks/ApplicationService.go
@@ -67,20 +67,20 @@ func (_m *ApplicationService) AddBackgroundPublisherWithTopic(capacity int, topi
 	return r0, r1
 }
 
-// AddFunctionsPipelineForTopic provides a mock function with given fields: id, topic, transforms
-func (_m *ApplicationService) AddFunctionsPipelineForTopic(id string, topic string, transforms ...func(interfaces.AppFunctionContext, interface{}) (bool, interface{})) error {
+// AddFunctionsPipelineForTopics provides a mock function with given fields: id, topic, transforms
+func (_m *ApplicationService) AddFunctionsPipelineForTopics(id string, topics []string, transforms ...func(interfaces.AppFunctionContext, interface{}) (bool, interface{})) error {
 	_va := make([]interface{}, len(transforms))
 	for _i := range transforms {
 		_va[_i] = transforms[_i]
 	}
 	var _ca []interface{}
-	_ca = append(_ca, id, topic)
+	_ca = append(_ca, id, topics)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, ...func(interfaces.AppFunctionContext, interface{}) (bool, interface{})) error); ok {
-		r0 = rf(id, topic, transforms...)
+	if rf, ok := ret.Get(0).(func(string, []string, ...func(interfaces.AppFunctionContext, interface{}) (bool, interface{})) error); ok {
+		r0 = rf(id, topics, transforms...)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/interfaces/service.go
+++ b/pkg/interfaces/service.go
@@ -48,8 +48,8 @@ type FunctionPipeline struct {
 	Id string
 	// Collection of App Functions to execute
 	Transforms []AppFunction
-	// Topic to match against the incoming topic to determine if the pipeline will execute on the incoming message
-	Topic string
+	// Topics to match against the incoming topic to determine if the pipeline will execute on the incoming message
+	Topics []string
 	// Hash of the list of transforms set and used internally for Store and Forward
 	Hash string
 }
@@ -88,11 +88,11 @@ type ApplicationService interface {
 	// Note that the functions are executed in the order provided in the list.
 	// An error is returned if the list is empty.
 	SetDefaultFunctionsPipeline(transforms ...AppFunction) error
-	// AddFunctionsPipelineForTopic adds a functions pipeline with the specified unique id and list of Application Functions
-	// to be executed when the incoming topic matches the specified topic. The specified topic may contain the '#' wildcard
+	// AddFunctionsPipelineForTopics adds a functions pipeline with the specified unique id and list of Application Functions
+	// to be executed when the incoming topic matches any of the specified topics. The specified topic may contain the '#' wildcard
 	// so that it matches multiple incoming topics. If just "#" is used for the specified topic it will match all incoming
 	// topics and the specified functions pipeline will execute on every message received.
-	AddFunctionsPipelineForTopic(id string, topic string, transforms ...AppFunction) error
+	AddFunctionsPipelineForTopics(id string, topic []string, transforms ...AppFunction) error
 	// MakeItRun starts the configured trigger to allow the functions pipeline to execute when the trigger
 	// receives data and starts the internal webserver. This is a long running function which does not return until
 	// the service is stopped or MakeItStop() is called.


### PR DESCRIPTION
Match incoming topic against an array of topics when determining whether
or not to execute a given pipeline.  Allow Topics configuration as comma
separated list similar to messaging triggers.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Related Docs PR now required (if applicable) 
Related Docs PR:

https://github.com/edgexfoundry/edgex-docs/pull/551

If n/a for Docs PR, state why it is not applicable:

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Pipelines can only be configured to run for a single topic.

Issue Number: #945 

## What is the new behavior?
<!-- Please describe the new behavior. -->
Pipelines can be configured with a comma-separated list of topics similar to messaging triggers.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, if so please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

- [ ] Yes
- [x] No

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information