### PR TITLE
fix(runtime): ignore charset for Content-Type comparison (#951)

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -320,7 +320,9 @@ func (gr *GolangRuntime) processEventPayload(envelope types.MessageEnvelope, lc 
 func (gr *GolangRuntime) unmarshalPayload(envelope types.MessageEnvelope, target interface{}) error {
 	var err error
 
-	switch envelope.ContentType {
+	contentType := strings.Split(envelope.ContentType, ";")[0]
+
+	switch contentType {
 	case common.ContentTypeJSON:
 		err = json.Unmarshal(envelope.Payload, target)
 


### PR DESCRIPTION
Fixes #951 

Signed-off-by: Jeff Titus <jeff.rtitus@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) 
- None affected. All tests pass with same coverage.
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) 
- No docs change required.
      <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Tested scenario using local build

```go
require github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0
replace github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0 => ../app-functions-sdk-go
```

```bash
# With charset
$ http :59770/api/v2/trigger Content-Type:"application/json; charset=utf-8" action=set deviceName=SomeDevice commandName=SomeCommand resourceName=SomeResource value=45
HTTP/1.1 200 OK
Content-Length: 36
Content-Type: application/json
Date: Fri, 17 Sep 2021 18:21:19 GMT

{
    "apiVersion": "v2",
    "statusCode": 200
}

# Without charset
$ http :59770/api/v2/trigger Content-Type:"application/json" action=set deviceName=SomeDevice commandName=SomeCommand resourceName=SomeResource value=45
HTTP/1.1 200 OK
Content-Length: 36
Content-Type: application/json
Date: Fri, 17 Sep 2021 18:21:19 GMT

{
    "apiVersion": "v2",
    "statusCode": 200
}
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->