### PR TITLE
fix: Remove initvector from require parameters for Encrypt with aes256

### DIFF
--- a/internal/app/configurable.go
+++ b/internal/app/configurable.go
@@ -312,14 +312,14 @@ func (app *Configurable) Encrypt(parameters map[string]string) interfaces.AppFun
 		return nil
 	}
 
-	initVector, ok := parameters[InitVector]
-	if !ok {
-		app.lc.Error("Could not find " + InitVector)
-		return nil
-	}
-
 	switch strings.ToLower(algorithm) {
 	case EncryptAES:
+		initVector, ok := parameters[InitVector]
+		if !ok {
+			app.lc.Error("Could not find " + InitVector)
+			return nil
+		}
+
 		//nolint: staticcheck
 		transform := transforms.Encryption{
 			EncryptionKey:        encryptionKey,

--- a/internal/app/configurable_test.go
+++ b/internal/app/configurable_test.go
@@ -16,9 +16,10 @@
 package app
 
 import (
-	"github.com/google/uuid"
 	"net/http"
 	"testing"
+
+	"github.com/google/uuid"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
 
@@ -394,8 +395,8 @@ func TestEncrypt(t *testing.T) {
 		{"Bad - No Key or secrets ", EncryptAES, "", vector, "", "", true},
 		{"Bad - Missing secretPath", EncryptAES, "", vector, "", secretName, true},
 		{"Bad - Missing secretName", EncryptAES, "", vector, secretsPath, "", true},
-		{"AES256 - Bad - No secrets ", EncryptAES256, "", vector, "", "", true},
-		{"AES256 - good - secrets", EncryptAES256, "", vector, uuid.NewString(), uuid.NewString(), false},
+		{"AES256 - Bad - No secrets ", EncryptAES256, "", "", "", "", true},
+		{"AES256 - good - secrets", EncryptAES256, "", "", uuid.NewString(), uuid.NewString(), false},
 	}
 
 	for _, testCase := range tests {


### PR DESCRIPTION
fixes #994

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?) 
      Existing PR for new AES256: https://github.com/edgexfoundry/edgex-docs/pull/614

## Testing Instructions
1. Build and Run ASC with this branch (i.e. update go.mod file to replace SDK)
2. Set ExecutionOder in config of sample profile to just `Encrypt`
3. Verify the error in logs is NOT the `initvector required` error
   - Note there will be another error due to invalid key for aes256 which is fix in TBD PR for ASC
   - 
## New Dependency Instructions (If applicable)
N/A