### PR TITLE
fix: Rebuild Default and PerTopicPipelines properly after configuration changes

### DIFF
--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -374,10 +374,7 @@ func (svc *Service) SetDefaultFunctionsPipeline(transforms ...interfaces.AppFunc
 	}
 
 	svc.runtime.TargetType = svc.targetType
-	err := svc.runtime.SetDefaultFunctionsPipeline(transforms)
-	if err != nil {
-		return err
-	}
+	svc.runtime.SetDefaultFunctionsPipeline(transforms)
 
 	svc.lc.Debugf("Default pipeline added with %d transform(s)", len(transforms))
 

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -242,8 +242,7 @@ func TestSetupHTTPTrigger(t *testing.T) {
 	}
 
 	testRuntime := runtime.NewGolangRuntime("", nil, dic)
-	err := testRuntime.SetDefaultFunctionsPipeline(nil)
-	require.NoError(t, err)
+	testRuntime.SetDefaultFunctionsPipeline(nil)
 	trigger := sdk.setupTrigger(sdk.config, testRuntime)
 	result := IsInstanceOf(trigger, (*triggerHttp.Trigger)(nil))
 	assert.True(t, result, "Expected Instance of HTTP Trigger")
@@ -259,8 +258,7 @@ func TestSetupMessageBusTrigger(t *testing.T) {
 		},
 	}
 	testRuntime := runtime.NewGolangRuntime("", nil, dic)
-	err := testRuntime.SetDefaultFunctionsPipeline(nil)
-	require.NoError(t, err)
+	testRuntime.SetDefaultFunctionsPipeline(nil)
 	trigger := sdk.setupTrigger(sdk.config, testRuntime)
 	result := IsInstanceOf(trigger, (*messagebus.Trigger)(nil))
 	assert.True(t, result, "Expected Instance of Message Bus Trigger")
@@ -301,7 +299,8 @@ func TestSetDefaultFunctionsPipelineOneTransform(t *testing.T) {
 func TestService_AddFunctionsPipelineForTopics(t *testing.T) {
 	service := Service{
 		lc:      lc,
-		runtime: runtime.NewGolangRuntime("", nil, nil),
+		dic:     dic,
+		runtime: runtime.NewGolangRuntime("", nil, dic),
 		config: &common.ConfigurationStruct{
 			Trigger: common.TriggerInfo{
 				Type: TriggerTypeMessageBus,

--- a/internal/runtime/storeforward_test.go
+++ b/internal/runtime/storeforward_test.go
@@ -122,8 +122,7 @@ func TestProcessRetryItems(t *testing.T) {
 				pipeline = runtime.GetPipelineById("per-topic")
 				require.NotNil(t, pipeline)
 			} else {
-				err := runtime.SetDefaultFunctionsPipeline([]interfaces.AppFunction{transformPassthru, transformPassthru, test.TargetTransform})
-				require.NoError(t, err)
+				runtime.SetDefaultFunctionsPipeline([]interfaces.AppFunction{transformPassthru, transformPassthru, test.TargetTransform})
 				pipeline = runtime.GetDefaultPipeline()
 				require.NotNil(t, pipeline)
 			}
@@ -186,8 +185,7 @@ func TestDoStoreAndForwardRetry(t *testing.T) {
 				pipeline = runtime.GetPipelineById("per-topic")
 				require.NotNil(t, pipeline)
 			} else {
-				err := runtime.SetDefaultFunctionsPipeline([]interfaces.AppFunction{transformPassthru, test.TargetTransform})
-				require.NoError(t, err)
+				runtime.SetDefaultFunctionsPipeline([]interfaces.AppFunction{transformPassthru, test.TargetTransform})
 				pipeline = runtime.GetDefaultPipeline()
 				require.NotNil(t, pipeline)
 			}

--- a/internal/trigger/messagebus/messaging_test.go
+++ b/internal/trigger/messagebus/messaging_test.go
@@ -349,11 +349,10 @@ func TestInitializeAndProcessEventWithNoOutput(t *testing.T) {
 	}
 
 	goRuntime := runtime.NewGolangRuntime("", nil, dic)
+	goRuntime.SetDefaultFunctionsPipeline([]interfaces.AppFunction{transform1})
 
-	err := goRuntime.SetDefaultFunctionsPipeline([]interfaces.AppFunction{transform1})
-	require.NoError(t, err)
 	trigger := NewTrigger(dic, goRuntime)
-	_, err = trigger.Initialize(&sync.WaitGroup{}, context.Background(), nil)
+	_, err := trigger.Initialize(&sync.WaitGroup{}, context.Background(), nil)
 	require.NoError(t, err)
 
 	payload, err := json.Marshal(addEventRequest)
@@ -433,9 +432,8 @@ func TestInitializeAndProcessEventWithOutput(t *testing.T) {
 	}
 
 	goRuntime := runtime.NewGolangRuntime("", nil, dic)
+	goRuntime.SetDefaultFunctionsPipeline([]interfaces.AppFunction{transform1})
 
-	err := goRuntime.SetDefaultFunctionsPipeline([]interfaces.AppFunction{transform1})
-	require.NoError(t, err)
 	trigger := NewTrigger(dic, goRuntime)
 
 	testClientConfig := types.MessageBusConfig{
@@ -537,9 +535,7 @@ func TestInitializeAndProcessEventWithOutput_InferJSON(t *testing.T) {
 	}
 
 	goRuntime := runtime.NewGolangRuntime("", nil, dic)
-
-	err := goRuntime.SetDefaultFunctionsPipeline([]interfaces.AppFunction{transform1})
-	require.NoError(t, err)
+	goRuntime.SetDefaultFunctionsPipeline([]interfaces.AppFunction{transform1})
 
 	trigger := NewTrigger(dic, goRuntime)
 
@@ -642,9 +638,7 @@ func TestInitializeAndProcessEventWithOutput_AssumeCBOR(t *testing.T) {
 	}
 
 	goRuntime := runtime.NewGolangRuntime("", nil, dic)
-
-	err := goRuntime.SetDefaultFunctionsPipeline([]interfaces.AppFunction{transform1})
-	require.NoError(t, err)
+	goRuntime.SetDefaultFunctionsPipeline([]interfaces.AppFunction{transform1})
 
 	trigger := NewTrigger(dic, goRuntime)
 	testClientConfig := types.MessageBusConfig{
@@ -831,12 +825,10 @@ func TestInitializeAndProcessEventMultipleTopics(t *testing.T) {
 	}
 
 	goRuntime := runtime.NewGolangRuntime("", nil, dic)
-
-	err := goRuntime.SetDefaultFunctionsPipeline([]interfaces.AppFunction{transform1})
-	require.NoError(t, err)
+	goRuntime.SetDefaultFunctionsPipeline([]interfaces.AppFunction{transform1})
 
 	trigger := NewTrigger(dic, goRuntime)
-	_, err = trigger.Initialize(&sync.WaitGroup{}, context.Background(), nil)
+	_, err := trigger.Initialize(&sync.WaitGroup{}, context.Background(), nil)
 	require.NoError(t, err)
 
 	payload, _ := json.Marshal(addEventRequest)


### PR DESCRIPTION
This applies only to Configurable Pipelines
Default is properly rebuilt after error that occurred in previous configuration change are corrected.
PerTopicPipelines are properly rebuilt after any pipeline configuration changes.

fixes #998 & #999

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A for internal code**

## Testing Instructions
- Run non-secure EdgeX stack with Device Virtual running
- Use this branch in ASC go.mod
- Build and run ASC with `-p=sample -cp` options
- From Consul change 
```
http://localhost:8500/ui/dc1/kv/edgex/appservices/2.0/app-sample/Writable/Pipeline/Functions/TransformXml/Parameters/Type` 
```
value to `junk`
- Verify logs contain and errors start occurring as data is received
```
level=INFO ts=2021-11-09T22:54:18.1218977Z app=app-sample source=configupdates.go:67 msg="Processing App Service configuration updates"
level=ERROR ts=2021-11-09T22:54:18.1221052Z app=app-sample source=configurable.go:185 msg="Invalid transform type 'junk'. Must be 'xml' or 'json'"
level=ERROR ts=2021-11-09T22:54:18.1222071Z app=app-sample source=configupdates.go:149 msg="unable to reload Configurable Pipeline(s) from new configuration: TransformXml from configuration failed for pipeline 'default-pipeline': all pipelines have been disabled"
level=ERROR ts=2021-11-09T22:54:24.6613081Z app=app-sample source=runtime.go:470 msg="no transforms configured for pipleline Id='float-pipeline'. Please check log for earlier errors loading pipeline.
```
- From Consul change 
```
http://localhost:8500/ui/dc1/kv/edgex/appservices/2.0/app-sample/Writable/Pipeline/Functions/TransformXml/Parameters/Type` 
```
value back to `xml`
- Verify logs contain the following and error have ceased 
```
level=INFO ts=2021-11-09T22:57:13.7386204Z app=app-sample source=config.go:479 msg="Writeable configuration has been updated from the Configuration Provider"
level=INFO ts=2021-11-09T22:57:13.7387778Z app=app-sample source=configupdates.go:67 msg="Processing App Service configuration updates"
level=INFO ts=2021-11-09T22:57:13.7390568Z app=app-sample source=runtime.go:111 msg="Transforms set for `default-pipeline` pipeline"
level=INFO ts=2021-11-09T22:57:13.739122Z app=app-sample source=runtime.go:111 msg="Transforms set for `float-pipeline` pipeline"
level=INFO ts=2021-11-09T22:57:13.7391817Z app=app-sample source=runtime.go:111 msg="Transforms set for `int8-16-pipeline` pipeline"
level=INFO ts=2021-11-09T22:57:13.7392276Z app=app-sample source=configupdates.go:160 msg="Configurable Pipeline successfully reloaded from new configuration"
```

## New Dependency Instructions (If applicable)
N/A