### PR TITLE
test(sdk): Use -race Flag when testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ ARCH=$(shell uname -m)
 
 GO=CGO_ENABLED=1 GO111MODULE=on go
 
+GOTESTFLAGS?=-race
+
 build:
 	make -C ./app-service-template build
 
@@ -34,7 +36,7 @@ test-template:
 	make -C ./app-service-template test
 
 test-sdk:
-	$(GO) test ./... -coverprofile=coverage.out ./...
+	$(GO) test $(GOTESTFLAGS) -coverprofile=coverage.out ./...
 
 vet:
 	$(GO) vet ./...

--- a/app-service-template/Makefile
+++ b/app-service-template/Makefile
@@ -18,6 +18,8 @@
 
 GO=CGO_ENABLED=1 go
 
+GOTESTFLAGS?=-race
+
 # VERSION file is not needed for local development, In the CI/CD pipeline, a temporary VERSION file is written
 # if you need a specific version, just override below
 # TODO: If your service is not being upstreamed to Edgex Foundry, you need to determine the best approach for
@@ -59,7 +61,7 @@ docker:
 # The test-attribution-txt.sh scripts are required for upstreaming to EdgeX Foundry.
 # TODO: Remove bin folder and reference to script below if NOT upstreaming to EdgeX Foundry.
 test:
-	$(GO) test -coverprofile=coverage.out ./...
+	$(GO) test $(GOTESTFLAGS) -coverprofile=coverage.out ./...
 	$(GO) vet ./...
 	gofmt -l $$(find . -type f -name '*.go'| grep -v "/vendor/")
 	[ "`gofmt -l $$(find . -type f -name '*.go'| grep -v "/vendor/")`" = "" ]


### PR DESCRIPTION
Includes naive fix for one race detected.

Fixes #209

Signed-off-by: Alex Ullrich <alex.ullrich@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
    - unit tests sufficient
- [ ] I have opened a PR for the related docs change (if not, why?)
      no docs change

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->