### PR TITLE
fix(triggers): Write HTTP Response Data

### DIFF
--- a/internal/trigger/http/rest.go
+++ b/internal/trigger/http/rest.go
@@ -118,6 +118,21 @@ func (trigger *Trigger) requestHandler(writer http.ResponseWriter, r *http.Reque
 	if messageError != nil {
 		writer.WriteHeader(messageError.ErrorCode)
 		_, _ = writer.Write([]byte(messageError.Err.Error()))
+		return
+	}
+
+	if len(appContext.ResponseContentType()) > 0 {
+		writer.Header().Set(common.ContentType, appContext.ResponseContentType())
+	}
+
+	_, err = writer.Write(appContext.ResponseData())
+	if err != nil {
+		lc.Errorf("unable to write ResponseData as HTTP response: %s", err.Error())
+		return
+	}
+
+	if appContext.ResponseData() != nil {
+		lc.Trace("Sent http response message", common.CorrelationHeader, correlationID)
 	}
 }
 

--- a/internal/trigger/http/rest_test.go
+++ b/internal/trigger/http/rest_test.go
@@ -160,6 +160,7 @@ func TestTriggerRequestHandler(t *testing.T) {
 		assert.Equal(t, afc, ctx)
 		assert.Equal(t, data, env.Payload)
 		assert.Equal(t, contentType, env.ContentType)
+		ctx.SetResponseData(data)
 		return nil
 	})
 
@@ -169,6 +170,8 @@ func TestTriggerRequestHandler(t *testing.T) {
 	}
 
 	writer := &mocks.TriggerResponseWriter{}
+
+	writer.On("Write", data).Return(0, nil)
 
 	req, err := http.NewRequest("", "", bytes.NewBuffer(data))
 	req.Header = http.Header{}


### PR DESCRIPTION
After refactoring response data was not written to response

fixes #1028

Signed-off-by: Alex Ullrich <alex.ullrich@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
     unit tests sufficient
- [ ] I have opened a PR for the related docs change (if not, why?)
     no docs change

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->