### PR TITLE
fix: Use latest 1.8.8 of redigo and ignore bad v2.0.0 tag

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "github.com/gomodule/redigo"
+        # For github.com/gomodule/redigo, ignore version v2.0.0
+        versions: ["v2.0.0"]

--- a/app-service-template/go.mod
+++ b/app-service-template/go.mod
@@ -6,7 +6,7 @@ go 1.17
 
 require (
 	github.com/edgexfoundry/app-functions-sdk-go/v2 v2.1.0
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.9
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.11
 	github.com/google/uuid v1.3.0
 	github.com/stretchr/testify v1.7.0
 )
@@ -20,7 +20,7 @@ require (
 	github.com/eclipse/paho.mqtt.golang v1.3.5 // indirect
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.1-dev.28 // indirect
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.1.0 // indirect
-	github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.7 // indirect
+	github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.8 // indirect
 	github.com/edgexfoundry/go-mod-registry/v2 v2.1.0 // indirect
 	github.com/edgexfoundry/go-mod-secrets/v2 v2.1.0 // indirect
 	github.com/fatih/color v1.9.0 // indirect

--- a/app-service-template/go.sum
+++ b/app-service-template/go.sum
@@ -57,10 +57,10 @@ github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.1-dev.28/go.mod h1:12Szn7YDPPoQ
 github.com/edgexfoundry/go-mod-configuration/v2 v2.1.0 h1:wiLtHYo1QxImARJZt7TYj88cUhq1ANh8se4TBvFsYvw=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.1.0/go.mod h1:MvHit0MxBXN4bC8LL0NZRsw72ByRE1XwtVLQP9C+2vg=
 github.com/edgexfoundry/go-mod-core-contracts/v2 v2.1.0/go.mod h1:I6UhBPCREubcU0ouIGBdZlNG5Xx4NijUVN5rvEtD03k=
-github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.9 h1:EeXfSNWIHpG6sugmW7DjRcA/faeMS8QirRBU01B1smA=
-github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.9/go.mod h1:FYFqOHl4OxULCnWecVcBatvk9f/BnRPwivLmARi+YCM=
-github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.7 h1:O7C5NBlN03NMSPS7a6vG8ZTO1qyoiiN62HRyDw9dUNk=
-github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.7/go.mod h1:+X6C0h8ZTJe+lLU2AGJfiAzCJK3zL+yM6cej9VC+79E=
+github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.11 h1:qcfLweqTSyYhDPNn5ByzTuV799dFHW4BjhwJ4mAynVc=
+github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.11/go.mod h1:FYFqOHl4OxULCnWecVcBatvk9f/BnRPwivLmARi+YCM=
+github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.8 h1:JQ7/Ky2BBhapLhZ+mwy6FW9/W/Zp4UVDkH3VsNSdNEs=
+github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.8/go.mod h1:+X6C0h8ZTJe+lLU2AGJfiAzCJK3zL+yM6cej9VC+79E=
 github.com/edgexfoundry/go-mod-registry/v2 v2.1.0 h1:ks0ejtLLUYKuoKrUBbWxygCU7q2mBFJlHE/+dEzV2Gw=
 github.com/edgexfoundry/go-mod-registry/v2 v2.1.0/go.mod h1:+MNlQm8Ks9ZmxqrMK4O3KdBA6E7nRK9M+qBtv/1lPcA=
 github.com/edgexfoundry/go-mod-secrets/v2 v2.1.0 h1:ASVZCZUv6cwM2GVoMJNb7rk5R7cw70S1gsut1yX8OXk=
@@ -127,6 +127,7 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/gomodule/redigo v1.8.8/go.mod h1:7ArFNvsTjH8GMMzB4uy1snslv2BwmginuMs06a1uzZE=
 github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c h1:964Od4U6p2jUkFxvCydnIczKteheJEzHRToSGK3Bnlw=

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.8
 	github.com/edgexfoundry/go-mod-registry/v2 v2.1.0
 	github.com/fxamacker/cbor/v2 v2.4.0
-	github.com/gomodule/redigo v2.0.0+incompatible
+	github.com/gomodule/redigo v1.8.8
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
-github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/gomodule/redigo v1.8.8 h1:f6cXq6RRfiyrOJEV7p3JhLDlmawGBVBBP1MggY8Mo4E=
+github.com/gomodule/redigo v1.8.8/go.mod h1:7ArFNvsTjH8GMMzB4uy1snslv2BwmginuMs06a1uzZE=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c h1:964Od4U6p2jUkFxvCydnIczKteheJEzHRToSGK3Bnlw=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=


### PR DESCRIPTION
closes #1048

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) *N/A for dep version change, existing tests pass**
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) *N/A unit tests are sufficient**
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A-  non needed**

## Testing Instructions

## New Dependency Instructions (If applicable)
