### PR TITLE
fix: improper use of secretAddedSignal channel

### DIFF
--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -173,6 +173,11 @@ func (svc *Service) MakeItRun() error {
 
 	svc.ctx.stop = stop
 
+	httpErrors := make(chan error)
+	defer close(httpErrors)
+
+	svc.webserver.StartWebServer(httpErrors)
+
 	// determine input type and create trigger for it
 	t := svc.setupTrigger(svc.config)
 	if t == nil {
@@ -199,11 +204,6 @@ func (svc *Service) MakeItRun() error {
 
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
-
-	httpErrors := make(chan error)
-	defer close(httpErrors)
-
-	svc.webserver.StartWebServer(httpErrors)
 
 	select {
 	case httpError := <-httpErrors:

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -52,7 +52,6 @@ import (
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/flags"
 	bootstrapInterfaces "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
-	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/secret"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 
@@ -174,11 +173,6 @@ func (svc *Service) MakeItRun() error {
 
 	svc.ctx.stop = stop
 
-	httpErrors := make(chan error)
-	defer close(httpErrors)
-
-	svc.webserver.StartWebServer(httpErrors)
-
 	// determine input type and create trigger for it
 	t := svc.setupTrigger(svc.config)
 	if t == nil {
@@ -195,15 +189,6 @@ func (svc *Service) MakeItRun() error {
 	// deferred is a function that needs to be called when services exits.
 	svc.addDeferred(deferred)
 
-	if secret.IsSecurityEnabled() {
-		// add a deferred function to close the SecretAddedSignal channel created during service initialization.
-		svc.addDeferred(func() {
-			if secretAddedSignal, ok := svc.ctx.appCtx.Value(internal.ContextKeySecretAddedSignal).(chan struct{}); ok {
-				close(secretAddedSignal)
-			}
-		})
-	}
-
 	if svc.config.Writable.StoreAndForward.Enabled {
 		svc.startStoreForward()
 	} else {
@@ -214,6 +199,11 @@ func (svc *Service) MakeItRun() error {
 
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
+	httpErrors := make(chan error)
+	defer close(httpErrors)
+
+	svc.webserver.StartWebServer(httpErrors)
 
 	select {
 	case httpError := <-httpErrors:
@@ -505,12 +495,6 @@ func (svc *Service) Initialize() error {
 	svc.ctx.appCtx, svc.ctx.appCancelCtx = context.WithCancel(context.Background())
 	svc.ctx.appWg = &sync.WaitGroup{}
 
-	var secretAddedSignal chan struct{}
-	if secret.IsSecurityEnabled() {
-		secretAddedSignal = make(chan struct{}, 1)
-		svc.ctx.appCtx = context.WithValue(svc.ctx.appCtx, internal.ContextKeySecretAddedSignal, secretAddedSignal)
-	}
-
 	var deferred bootstrap.Deferred
 	var successful bool
 	var configUpdated config.UpdatedStream = make(chan struct{})
@@ -557,7 +541,7 @@ func (svc *Service) Initialize() error {
 	// to wait to be signaled when the configuration has been updated and then process the changes
 	NewConfigUpdateProcessor(svc).WaitForConfigUpdates(configUpdated)
 
-	svc.webserver = webserver.NewWebServer(svc.dic, mux.NewRouter(), svc.serviceKey, secretAddedSignal)
+	svc.webserver = webserver.NewWebServer(svc.dic, mux.NewRouter(), svc.serviceKey)
 	svc.webserver.ConfigureStandardRoutes()
 
 	svc.lc.Info("Service started in: " + startupTimer.SinceAsString())

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -78,7 +78,7 @@ func IsInstanceOf(objectPtr, typePtr interface{}) bool {
 func TestAddRoute(t *testing.T) {
 	router := mux.NewRouter()
 
-	ws := webserver.NewWebServer(dic, router, uuid.NewString(), nil)
+	ws := webserver.NewWebServer(dic, router, uuid.NewString())
 
 	sdk := Service{
 		webserver: ws,

--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -146,6 +146,10 @@ type ExternalMqttConfig struct {
 	// AuthMode indicates what to use when connecting to the broker. Options are "none", "cacert" , "usernamepassword", "clientcert".
 	// If a CA Cert exists in the SecretPath then it will be used for all modes except "none".
 	AuthMode string
+	// RetryDuration indicates how long (in seconds) to wait timing out on the MQTT client creation
+	RetryDuration int
+	// RetryInterval indicates the time (in seconds) that will be waited between attempts to create MQTT client
+	RetryInterval int
 }
 
 // PipelineInfo defines the top level data for configurable pipelines

--- a/internal/constant.go
+++ b/internal/constant.go
@@ -20,15 +20,11 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
 )
 
-type contextKey int
-
 const (
 	ConfigRegistryStem = "edgex/appservices/"
 
 	ApiTriggerRoute   = common.ApiBase + "/trigger"
 	ApiAddSecretRoute = common.ApiBase + "/secret"
-
-	ContextKeySecretAddedSignal contextKey = iota
 )
 
 // SDKVersion indicates the version of the SDK - will be overwritten by build

--- a/internal/controller/rest/controller.go
+++ b/internal/controller/rest/controller.go
@@ -40,23 +40,21 @@ import (
 
 // Controller controller for V2 REST APIs
 type Controller struct {
-	router            *mux.Router
-	secretProvider    interfaces.SecretProvider
-	lc                logger.LoggingClient
-	config            *sdkCommon.ConfigurationStruct
-	serviceName       string
-	secretAddedSignal chan struct{}
+	router         *mux.Router
+	secretProvider interfaces.SecretProvider
+	lc             logger.LoggingClient
+	config         *sdkCommon.ConfigurationStruct
+	serviceName    string
 }
 
 // NewController creates and initializes an Controller
-func NewController(router *mux.Router, dic *di.Container, serviceName string, secretAddedSignal chan struct{}) *Controller {
+func NewController(router *mux.Router, dic *di.Container, serviceName string) *Controller {
 	return &Controller{
-		router:            router,
-		secretProvider:    bootstrapContainer.SecretProviderFrom(dic.Get),
-		lc:                bootstrapContainer.LoggingClientFrom(dic.Get),
-		config:            container.ConfigurationFrom(dic.Get),
-		serviceName:       serviceName,
-		secretAddedSignal: secretAddedSignal,
+		router:         router,
+		secretProvider: bootstrapContainer.SecretProviderFrom(dic.Get),
+		lc:             bootstrapContainer.LoggingClientFrom(dic.Get),
+		config:         container.ConfigurationFrom(dic.Get),
+		serviceName:    serviceName,
 	}
 }
 
@@ -122,10 +120,6 @@ func (c *Controller) AddSecret(writer http.ResponseWriter, request *http.Request
 
 	response := commonDtos.NewBaseResponse(secretRequest.RequestId, "", http.StatusCreated)
 	c.sendResponse(writer, request, internal.ApiAddSecretRoute, response, http.StatusCreated)
-
-	if c.secretAddedSignal != nil {
-		c.secretAddedSignal <- struct{}{}
-	}
 }
 
 func (c *Controller) sendError(

--- a/internal/controller/rest/controller_test.go
+++ b/internal/controller/rest/controller_test.go
@@ -59,7 +59,7 @@ func TestMain(m *testing.M) {
 func TestPingRequest(t *testing.T) {
 	serviceName := uuid.NewString()
 
-	target := NewController(nil, dic, serviceName, nil)
+	target := NewController(nil, dic, serviceName)
 
 	recorder := doRequest(t, http.MethodGet, common.ApiPingRoute, target.Ping, nil)
 
@@ -83,7 +83,7 @@ func TestVersionRequest(t *testing.T) {
 	internal.ApplicationVersion = expectedAppVersion
 	internal.SDKVersion = expectedSdkVersion
 
-	target := NewController(nil, dic, serviceName, nil)
+	target := NewController(nil, dic, serviceName)
 
 	recorder := doRequest(t, http.MethodGet, common.ApiVersion, target.Version, nil)
 
@@ -100,7 +100,7 @@ func TestVersionRequest(t *testing.T) {
 func TestMetricsRequest(t *testing.T) {
 	serviceName := uuid.NewString()
 
-	target := NewController(nil, dic, serviceName, nil)
+	target := NewController(nil, dic, serviceName)
 
 	recorder := doRequest(t, http.MethodGet, common.ApiMetricsRoute, target.Metrics, nil)
 
@@ -140,7 +140,7 @@ func TestConfigRequest(t *testing.T) {
 		},
 	})
 
-	target := NewController(nil, dic, serviceName, nil)
+	target := NewController(nil, dic, serviceName)
 
 	recorder := doRequest(t, http.MethodGet, common.ApiConfigRoute, target.Config, nil)
 
@@ -176,10 +176,7 @@ func TestAddSecretRequest(t *testing.T) {
 	mockProvider.On("StoreSecrets", "/mqtt", map[string]string{"password": "password", "username": "username"}).Return(nil)
 	mockProvider.On("StoreSecrets", "/no", map[string]string{"password": "password", "username": "username"}).Return(errors.New("Invalid w/o Vault"))
 
-	ch := make(chan struct{}, 1)
-	defer close(ch)
-
-	target := NewController(nil, dic, uuid.NewString(), ch)
+	target := NewController(nil, dic, uuid.NewString())
 	assert.NotNil(t, target)
 
 	validRequest := commonDtos.SecretRequest{

--- a/internal/trigger/mqtt/mqtt.go
+++ b/internal/trigger/mqtt/mqtt.go
@@ -121,7 +121,7 @@ func (trigger *Trigger) Initialize(_ *sync.WaitGroup, _ context.Context, backgro
 	timer := startup.NewTimer(brokerConfig.RetryDuration, brokerConfig.RetryInterval)
 	for timer.HasNotElapsed() {
 		if mqttClient, err = createMqttClient(sp, lc, brokerConfig, opts); err != nil {
-			lc.Errorf("%s. Attempt to create MQTT client again after %d seconds...", err.Error(), brokerConfig.RetryInterval)
+			lc.Warnf("%s. Attempt to create MQTT client again after %d seconds...", err.Error(), brokerConfig.RetryInterval)
 			timer.SleepForInterval()
 			continue
 		}
@@ -242,12 +242,7 @@ func createMqttClient(sp messaging.SecretDataProvider, lc logger.LoggingClient, 
 		return nil, fmt.Errorf("unable to create secure MQTT Client: %s", err.Error())
 	}
 
-	brokerUrl, err := url.Parse(config.Url)
-	if err != nil {
-		return nil, fmt.Errorf("invalid MQTT Broker Url '%s': %s", config.Url, err.Error())
-	}
-
-	lc.Infof("Connecting to mqtt broker for MQTT trigger at: %s", brokerUrl)
+	lc.Infof("Connecting to mqtt broker for MQTT trigger at: %s", config.Url)
 
 	if token := mqttClient.Connect(); token.Wait() && token.Error() != nil {
 		return nil, fmt.Errorf("could not connect to broker for MQTT trigger: %s", token.Error().Error())

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -52,12 +52,12 @@ type Version struct {
 }
 
 // NewWebServer returns a new instance of *WebServer
-func NewWebServer(dic *di.Container, router *mux.Router, serviceName string, secretAddedSignal chan struct{}) *WebServer {
+func NewWebServer(dic *di.Container, router *mux.Router, serviceName string) *WebServer {
 	ws := &WebServer{
 		lc:         bootstrapContainer.LoggingClientFrom(dic.Get),
 		config:     container.ConfigurationFrom(dic.Get),
 		router:     router,
-		controller: rest.NewController(router, dic, serviceName, secretAddedSignal),
+		controller: rest.NewController(router, dic, serviceName),
 	}
 
 	return ws

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -58,7 +58,7 @@ func TestAddRoute(t *testing.T) {
 	routePath := "/testRoute"
 	testHandler := func(_ http.ResponseWriter, _ *http.Request) {}
 
-	webserver := NewWebServer(dic, mux.NewRouter(), uuid.NewString(), nil)
+	webserver := NewWebServer(dic, mux.NewRouter(), uuid.NewString())
 	err := webserver.AddRoute(routePath, testHandler)
 	assert.NoError(t, err, "Not expecting an error")
 
@@ -69,7 +69,7 @@ func TestAddRoute(t *testing.T) {
 }
 
 func TestSetupTriggerRoute(t *testing.T) {
-	webserver := NewWebServer(dic, mux.NewRouter(), uuid.NewString(), nil)
+	webserver := NewWebServer(dic, mux.NewRouter(), uuid.NewString())
 
 	handlerFunctionNotCalled := true
 	handler := func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/secure/mqttfactory.go
+++ b/pkg/secure/mqttfactory.go
@@ -20,34 +20,27 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"fmt"
-
-	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/messaging"
-	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/secret"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
-
 	"github.com/eclipse/paho.mqtt.golang"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/messaging"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 )
 
 type MqttFactory struct {
-	sp                messaging.SecretDataProvider
-	logger            logger.LoggingClient
-	authMode          string
-	secretPath        string
-	opts              *mqtt.ClientOptions
-	skipCertVerify    bool
-	secretAddedSignal chan struct{}
+	sp             messaging.SecretDataProvider
+	logger         logger.LoggingClient
+	authMode       string
+	secretPath     string
+	opts           *mqtt.ClientOptions
+	skipCertVerify bool
 }
 
-func NewMqttFactory(sp messaging.SecretDataProvider, log logger.LoggingClient, mode string, path string, skipVerify bool,
-	secretAddedSignal chan struct{}) MqttFactory {
+func NewMqttFactory(sp messaging.SecretDataProvider, log logger.LoggingClient, mode string, path string, skipVerify bool) MqttFactory {
 	return MqttFactory{
-		sp:                sp,
-		logger:            log,
-		authMode:          mode,
-		secretPath:        path,
-		skipCertVerify:    skipVerify,
-		secretAddedSignal: secretAddedSignal,
+		sp:             sp,
+		logger:         log,
+		authMode:       mode,
+		secretPath:     path,
+		skipCertVerify: skipVerify,
 	}
 }
 
@@ -59,32 +52,22 @@ func (factory MqttFactory) Create(opts *mqtt.ClientOptions) (mqtt.Client, error)
 
 	factory.opts = opts
 
-	secretData, err := factory.getValidSecretData()
-	switch secret.IsSecurityEnabled() {
-	case true:
-		if err == nil {
-			break
-		}
-		factory.logger.Error(err.Error())
-		for {
-			factory.logger.Info("Waiting for the secret creation API call to seed the proper credentials...")
-			<-factory.secretAddedSignal
-			secretData, err = factory.getValidSecretData()
-			if err != nil {
-				factory.logger.Error(err.Error())
-			} else {
-				break
-			}
-		}
-	case false:
+	//get the secrets from the secret provider and populate the struct
+	secretData, err := messaging.GetSecretData(factory.authMode, factory.secretPath, factory.sp)
+	if err != nil {
+		return nil, err
+	}
+	//ensure that the authmode selected has the required secret values
+	if secretData != nil {
+		err = messaging.ValidateSecretData(factory.authMode, factory.secretPath, secretData)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	err = factory.configureMQTTClientForAuth(secretData)
-	if err != nil {
-		return nil, err
+		// configure the mqtt client with the retrieved secret values
+		err = factory.configureMQTTClientForAuth(secretData)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return mqtt.NewClient(factory.opts), nil
@@ -126,22 +109,4 @@ func (factory MqttFactory) configureMQTTClientForAuth(secretData *messaging.Secr
 	factory.opts.SetTLSConfig(tlsConfig)
 
 	return nil
-}
-
-func (factory MqttFactory) getValidSecretData() (*messaging.SecretData, error) {
-	//get the secrets from the secret provider and populate the struct
-	secretData, err := messaging.GetSecretData(factory.authMode, factory.secretPath, factory.sp)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get secret data from the secret provider, error: %s", err)
-	}
-	if secretData == nil {
-		return nil, nil
-	}
-	//ensure that the authmode selected has the required secret values
-	err = messaging.ValidateSecretData(factory.authMode, factory.secretPath, secretData)
-	if err != nil {
-		return nil, fmt.Errorf("invalid secret data, error: %s", err)
-	} else {
-		return secretData, nil
-	}
 }

--- a/pkg/transforms/mqttsecret.go
+++ b/pkg/transforms/mqttsecret.go
@@ -107,8 +107,7 @@ func (sender *MQTTSecretSender) initializeMQTTClient(ctx interfaces.AppFunctionC
 	}
 
 	config := sender.mqttConfig
-	// Do not use secertAddedSignal in MQTTSecretSender. Otherwise, when secrets are not ready and messages keep coming will cause the memory usage to keep rising.
-	mqttFactory := secure.NewMqttFactory(ctx, ctx.LoggingClient(), config.AuthMode, config.SecretPath, config.SkipCertVerify, nil)
+	mqttFactory := secure.NewMqttFactory(ctx, ctx.LoggingClient(), config.AuthMode, config.SecretPath, config.SkipCertVerify)
 
 	if len(sender.mqttConfig.KeepAlive) > 0 {
 		keepAlive, err := time.ParseDuration(sender.mqttConfig.KeepAlive)


### PR DESCRIPTION
Revert #1047
Implement the retry mechanism inside the External MQTT Trigger.

fix: #1052 #1053

Signed-off-by: Felix Ting <felix@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) Requires integration tests
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
      https://github.com/edgexfoundry/edgex-docs/pull/710

## Testing Instructions
<!-- How can the reviewers test your change? -->
Download this [Docker Compose file](https://github.com/edgexfoundry/edgex-compose/blob/main/docker-compose.yml)

Edit the Docker Compose file to add the custom App Service's service key to EdgeX service secretstore-setup's `ADD_SECRETSTORE_TOKENS` environment variable.
```
  secretstore-setup:
    container_name: edgex-security-secretstore-setup
    depends_on:
    - security-bootstrapper
    - vault
    environment:
      ADD_KNOWN_SECRETS: redisdb[app-rules-engine],redisdb[device-rest],redisdb[device-virtual]
      ADD_SECRETSTORE_TOKENS: 'app-external-mqtt-trigger'
```

Run EdgeX Foundry
`docker-compose -f docker-compose.yml up -d`

Download this [App Service configuration](https://github.com/edgexfoundry/app-service-configurable/blob/main/res/external-mqtt-trigger/configuration.toml)
Modify `[Trigger]` section with the following settings:
```
[Trigger]
Type="external-mqtt"
  [Trigger.externalmqtt]
  Url = "tls://test.mosquitto.org:8884"
  SubscribeTopics="edgex/#"
  ClientId ="app-external-mqtt-trigger"
  Qos            = 0
  KeepAlive      = 10
  Retained       = false
  AutoReconnect  = true
  ConnectTimeout = "30s"
  SkipCertVerify = false
  AuthMode = "clientcert"
  SecretPath = "mqtt"
  RetryDuration = 30
  RetryInterval = 5
```

Run App Service with the configuration and `EDGEX_SECURITY_SECRET_STORE=true`

Verify logs contain following messages
```
level=INFO ts=2022-03-14T05:15:54.536761Z app=app- source=mqtt.go:83 msg="Initializing MQTT Trigger"
level=INFO ts=2022-03-14T05:15:54.536801Z app=app- source=server.go:156 msg="Starting HTTP Web Server on address localhost:59706"
level=ERROR ts=2022-03-14T05:15:54.538563Z app=app- source=mqtt.go:124 msg="unable to create secure MQTT Client: Error found on handling secrets from underlying data-store: Received a '404' response from the secret store. Attempt to create MQTT client again after 5 seconds..."
```

Wait 30 seconds and verify logs contain following messages
```
level=ERROR ts=2022-03-14T05:15:54.538563Z app=app- source=mqtt.go:124 msg="unable to create secure MQTT Client: Error found on handling secrets from underlying data-store: Received a '404' response from the secret store. Attempt to create MQTT client again after 5 seconds..."
level=ERROR ts=2022-03-14T05:15:59.543072Z app=app- source=mqtt.go:124 msg="unable to create secure MQTT Client: Error found on handling secrets from underlying data-store: Received a '404' response from the secret store. Attempt to create MQTT client again after 5 seconds..."
level=ERROR ts=2022-03-14T05:16:04.546163Z app=app- source=mqtt.go:124 msg="unable to create secure MQTT Client: Error found on handling secrets from underlying data-store: Received a '404' response from the secret store. Attempt to create MQTT client again after 5 seconds..."
level=ERROR ts=2022-03-14T05:16:09.552204Z app=app- source=mqtt.go:124 msg="unable to create secure MQTT Client: Error found on handling secrets from underlying data-store: Received a '404' response from the secret store. Attempt to create MQTT client again after 5 seconds..."
level=ERROR ts=2022-03-14T05:16:14.555807Z app=app- source=mqtt.go:124 msg="unable to create secure MQTT Client: Error found on handling secrets from underlying data-store: Received a '404' response from the secret store. Attempt to create MQTT client again after 5 seconds..."
level=ERROR ts=2022-03-14T05:16:19.562778Z app=app- source=mqtt.go:124 msg="unable to create secure MQTT Client: Error found on handling secrets from underlying data-store: Received a '404' response from the secret store. Attempt to create MQTT client again after 5 seconds..."
level=ERROR ts=2022-03-14T05:16:24.565683Z app=app- source=service.go:190 msg="unable to create MQTT Client: unable to create secure MQTT Client: Error found on handling secrets from underlying data-store: Received a '404' response from the secret store"
level=ERROR ts=2022-03-14T05:16:24.565721Z app=app- source=main.go:64 msg="MakeItRun returned error: failed to initialize Trigger"
```

Restart App Service.
Generate a TLS client certificate for test.mosquitto.org, refer to https://test.mosquitto.org/ssl/

Add `clientcert` to Secret Store using this [App Service API](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/app-functions-sdk/2.1.0#/default/post_secret)

Verify logs contain following messages
```
level=ERROR ts=2022-03-14T05:17:37.329887Z app=app- source=mqtt.go:124 msg="unable to create secure MQTT Client: AuthModeCert selected however the key or cert PEM block was not found for secret=mqtt. Attempt to create MQTT client again after 5 seconds..."
```

Add `clientcert` and `clientkey` to Secret Store

Verify logs contain following messages
```
level=INFO ts=2022-03-14T05:17:42.331827Z app=app- source=mqtt.go:250 msg="Connecting to mqtt broker for MQTT trigger at: tls://104.171.201.135:8884"
level=INFO ts=2022-03-14T05:17:43.053758Z app=app- source=mqtt.go:256 msg="Connected to mqtt server for MQTT trigger"
level=INFO ts=2022-03-14T05:17:43.053796Z app=app- source=service.go:200 msg="StoreAndForward disabled. Not running retry loop."
level=INFO ts=2022-03-14T05:17:43.053809Z app=app- source=service.go:203 msg="app-external-mqtt-trigger has Started"
level=INFO ts=2022-03-14T05:17:43.229374Z app=app- source=mqtt.go:161 msg="Subscribed to topic(s) 'edgex/#' for MQTT trigger"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->