### PR TITLE
fix(configuration): add handling for custom configuration section in c…

### DIFF
--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 	nethttp "net/http"
 	"os"
 	"os/signal"
@@ -53,6 +52,7 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/flags"
 	bootstrapInterfaces "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
+	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 
 	"github.com/gorilla/mux"
@@ -556,7 +556,14 @@ func (svc *Service) LoadCustomConfig(customConfig interfaces.UpdatableConfig, se
 	if svc.configProcessor == nil {
 		svc.configProcessor = config.NewProcessorForCustomConfig(svc.flags, svc.ctx.appCtx, svc.ctx.appWg, svc.dic)
 	}
-	return svc.configProcessor.LoadCustomConfigSection(customConfig, sectionName)
+
+	if err := svc.configProcessor.LoadCustomConfigSection(customConfig, sectionName); err != nil {
+		return err
+	}
+
+	svc.webserver.SetCustomConfigInfo(customConfig)
+
+	return nil
 }
 
 // ListenForCustomConfigChanges uses the Config Processor from go-mod-bootstrap to attempt to listen for

--- a/internal/controller/rest/controller.go
+++ b/internal/controller/rest/controller.go
@@ -29,8 +29,9 @@ import (
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/internal/bootstrap/container"
 	sdkCommon "github.com/edgexfoundry/app-functions-sdk-go/v2/internal/common"
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/internal/telemetry"
+	"github.com/edgexfoundry/app-functions-sdk-go/v2/pkg/interfaces"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
+	bootstrapInterfaces "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
@@ -41,9 +42,10 @@ import (
 // Controller controller for V2 REST APIs
 type Controller struct {
 	router         *mux.Router
-	secretProvider interfaces.SecretProvider
+	secretProvider bootstrapInterfaces.SecretProvider
 	lc             logger.LoggingClient
 	config         *sdkCommon.ConfigurationStruct
+	customConfig   interfaces.UpdatableConfig
 	serviceName    string
 }
 
@@ -56,6 +58,11 @@ func NewController(router *mux.Router, dic *di.Container, serviceName string) *C
 		config:         container.ConfigurationFrom(dic.Get),
 		serviceName:    serviceName,
 	}
+}
+
+// SetCustomConfigInfo sets the custom configuration, which is used to include the service's custom config in the /config endpoint response.
+func (c *Controller) SetCustomConfigInfo(customConfig interfaces.UpdatableConfig) {
+	c.customConfig = customConfig
 }
 
 // Ping handles the request to /ping endpoint. Is used to test if the service is working
@@ -75,7 +82,16 @@ func (c *Controller) Version(writer http.ResponseWriter, request *http.Request) 
 // Config handles the request to /config endpoint. Is used to request the service's configuration
 // It returns a response as specified by the V2 API swagger in openapi/v2
 func (c *Controller) Config(writer http.ResponseWriter, request *http.Request) {
-	response := commonDtos.NewConfigResponse(*c.config, c.serviceName)
+	// create a struct combining the common configuration and custom configuration sections
+	fullConfig := struct {
+		sdkCommon.ConfigurationStruct
+		CustomConfiguration interfaces.UpdatableConfig
+	}{
+		*c.config,
+		c.customConfig,
+	}
+
+	response := commonDtos.NewConfigResponse(fullConfig, c.serviceName)
 	c.sendResponse(writer, request, common.ApiVersionRoute, response, http.StatusOK)
 }
 

--- a/internal/controller/rest/controller.go
+++ b/internal/controller/rest/controller.go
@@ -82,13 +82,20 @@ func (c *Controller) Version(writer http.ResponseWriter, request *http.Request) 
 // Config handles the request to /config endpoint. Is used to request the service's configuration
 // It returns a response as specified by the V2 API swagger in openapi/v2
 func (c *Controller) Config(writer http.ResponseWriter, request *http.Request) {
-	// create a struct combining the common configuration and custom configuration sections
-	fullConfig := struct {
-		sdkCommon.ConfigurationStruct
-		CustomConfiguration interfaces.UpdatableConfig
-	}{
-		*c.config,
-		c.customConfig,
+	var fullConfig interface{}
+
+	if c.customConfig == nil {
+		// case of no custom configs
+		fullConfig = *c.config
+	} else {
+		// create a struct combining the common configuration and custom configuration sections
+		fullConfig = struct {
+			sdkCommon.ConfigurationStruct
+			CustomConfiguration interfaces.UpdatableConfig
+		}{
+			*c.config,
+			c.customConfig,
+		}
 	}
 
 	response := commonDtos.NewConfigResponse(fullConfig, c.serviceName)

--- a/internal/controller/rest/controller_test.go
+++ b/internal/controller/rest/controller_test.go
@@ -184,6 +184,72 @@ func TestConfigRequest(t *testing.T) {
 	assert.Equal(t, expectedConfig, actualConfig)
 }
 
+func TestConfigRequest_CustomConfig(t *testing.T) {
+	serviceName := uuid.NewString()
+
+	expectedConfig := sdkCommon.ConfigurationStruct{
+		Writable: sdkCommon.WritableInfo{
+			LogLevel: "DEBUG",
+		},
+		Registry: bootstrapConfig.RegistryInfo{
+			Host: "localhost",
+			Port: 8500,
+			Type: "consul",
+		},
+	}
+
+	dic.Update(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return &expectedConfig
+		},
+	})
+
+	expectedCustomConfig := TestCustomConfig{
+		"test custom config",
+	}
+
+	type fullConfig struct {
+		sdkCommon.ConfigurationStruct
+		CustomConfiguration TestCustomConfig
+	}
+
+	expectedFullConfig := fullConfig{
+		expectedConfig,
+		expectedCustomConfig,
+	}
+
+	target := NewController(nil, dic, serviceName)
+	target.SetCustomConfigInfo(&expectedCustomConfig)
+
+	recorder := doRequest(t, http.MethodGet, common.ApiConfigRoute, target.Config, nil)
+
+	actualResponse := commonDtos.ConfigResponse{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &actualResponse)
+	require.NoError(t, err)
+
+	assert.Equal(t, common.ApiVersion, actualResponse.ApiVersion)
+	assert.Equal(t, serviceName, actualResponse.ServiceName)
+
+	// actualResponse.Config is an interface{} so need to re-marshal/un-marshal into sdkCommon.ConfigurationStruct
+	configJson, err := json.Marshal(actualResponse.Config)
+	require.NoError(t, err)
+	require.Less(t, 0, len(configJson))
+
+	actualConfig := fullConfig{}
+	err = json.Unmarshal(configJson, &actualConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedFullConfig, actualConfig)
+}
+
+type TestCustomConfig struct {
+	Sample string
+}
+
+func (t TestCustomConfig) UpdateFromRaw(_ interface{}) bool {
+	return true
+}
+
 func TestAddSecretRequest(t *testing.T) {
 	expectedRequestId := "82eb2e26-0f24-48aa-ae4c-de9dac3fb9bc"
 

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/internal/bootstrap/container"
 	sdkCommon "github.com/edgexfoundry/app-functions-sdk-go/v2/internal/common"
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/internal/controller/rest"
+	"github.com/edgexfoundry/app-functions-sdk-go/v2/pkg/interfaces"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
@@ -61,6 +62,11 @@ func NewWebServer(dic *di.Container, router *mux.Router, serviceName string) *We
 	}
 
 	return ws
+}
+
+// SetCustomConfigInfo sets the custom configurations
+func (webserver *WebServer) SetCustomConfigInfo(customConfig interfaces.UpdatableConfig) {
+	webserver.controller.SetCustomConfigInfo(customConfig)
 }
 
 // AddRoute enables support to leverage the existing webserver to add routes.


### PR DESCRIPTION
…onfig response

Fixes #1035

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions
From `app-functions-sdk-go/app-service-template` use `make build` and run the new service `./new-app-service`. Make a REST call using Postman or curl to query the service configurations to be returned in the response:
`http://localhost:59740/api/v2/config`

Observe at the bottom of the `config` struct is the previously missing AppCustom configurations, now included as `CustomConfiguration`:

```
        "CustomConfiguration": {
            "AppCustom": {
                "ResourceNames": "Boolean, Int32, Uint32, Float32, Binary",
                "SomeValue": 123,
                "SomeService": {
                    "Host": "localhost",
                    "Port": 9080,
                    "Protocol": "http"
                }
            }
        }
```
Note - The app custom contents are nested under CustomConfiguration. This is due to a limitation of in-lining with direct versus indirect struct types (I'll let him expand/explain more detail). We (Lenny and I) agree that next best option is using interfaces.UpdatableConfig and naming the field CustomConfiguration.