### PR TITLE
feat: Added initial SDK level App service metrics

### DIFF
--- a/app-service-template/go.mod
+++ b/app-service-template/go.mod
@@ -6,7 +6,7 @@ go 1.17
 
 require (
 	github.com/edgexfoundry/app-functions-sdk-go/v2 v2.1.0
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.25
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.26
 	github.com/google/uuid v1.3.0
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
 	github.com/stretchr/testify v1.7.1
@@ -19,7 +19,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.3.5 // indirect
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.13 // indirect
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.16 // indirect
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0-dev.3 // indirect
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.12 // indirect
 	github.com/edgexfoundry/go-mod-registry/v2 v2.2.0-dev.3 // indirect

--- a/app-service-template/go.sum
+++ b/app-service-template/go.sum
@@ -32,12 +32,12 @@ github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9 h1:NAHC
 github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9/go.mod h1:9STzWAIpeXT1gYFvw0JM+BkyMmPKYv/ztBNgXX4hAOw=
 github.com/eclipse/paho.mqtt.golang v1.3.5 h1:sWtmgNxYM9P2sP+xEItMozsR3w0cqZFlqnNN1bdl41Y=
 github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.13 h1:KqMprarS3TFgWoSqNBCI3omvBC8MnRL34Rr92aUN2JE=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.13/go.mod h1:eolD76cvsIAUzn63YN7MGyeOWWMidsFKCJjIpo+DK14=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.16 h1:e6/XBUP88TVPUpKW+CiHdi6WNQfJape1FQq2ygXTMb0=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.16/go.mod h1:6Q+rUmzAizdpU3sqnzMzSHmX7Z69qN69xxl0up/mQQA=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0-dev.3 h1:dTTExUFHza9eJmTABr8G4KOE8JKBMzZCVC3wARiwIg4=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0-dev.3/go.mod h1:YP17JhMnXTitowXE13QJwFaKo0oc03iyoKLjWAYl4FE=
-github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.25 h1:EKkJf49mDUZF2N82bcHV//onD7qNTuZrNGWgP2byHqU=
-github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.25/go.mod h1:jyfVSx7mI3u/o/oo10COxBRBvJ8O/9I3z2xAwPmNt/Q=
+github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.26 h1:YebVI3gAJwFTMXKzB2erUonBC8eNrr+qLUGdtXFMjKs=
+github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.26/go.mod h1:jyfVSx7mI3u/o/oo10COxBRBvJ8O/9I3z2xAwPmNt/Q=
 github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.12 h1:u4ndXe8j1xYR1+axSgcgbD2OGvx7Z9v9thv0KBZp2TI=
 github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.12/go.mod h1:+X6C0h8ZTJe+lLU2AGJfiAzCJK3zL+yM6cej9VC+79E=
 github.com/edgexfoundry/go-mod-registry/v2 v2.2.0-dev.3 h1:Z1sR4g+guLsUNJw3z3gxaz472wt0gYu1XCQ4frqJl/o=

--- a/app-service-template/res/configuration.toml
+++ b/app-service-template/res/configuration.toml
@@ -25,7 +25,10 @@ LogLevel = "INFO"
   Interval = "30s"
   PublishTopicPrefix  = "edgex/telemetry" # /<service-name>/<metric-name> will be added to this Publish Topic prefix
     [Writable.Telemetry.Metrics] # All service's metric names must be present in this list.
-    # TODO: Remove sample metric and implement meaningful metrics if any needed.
+    MessagesReceived = true
+    PipelineMessagesProcessed = true # Your pipeline IDs are added to this name for the actual metric name reported
+    PipelineMessageProcessingTime = true # Your pipeline IDs are added to this name for the actual metric name reported
+    # TODO: Remove sample custom metric and implement meaningful custom metrics if any needed.
     EventsConvertedToXML = true
     [Writable.Telemetry.Tags] # Contains the service level tags to be attached to all the service's metrics
 #    Gateway="my-iot-gateway" # Tag must be added here or via Consul Env Override can only chnage existing value, not added new ones.

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9
 	github.com/eclipse/paho.mqtt.golang v1.3.5
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.13
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.25
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.16
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.26
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.12
 	github.com/edgexfoundry/go-mod-registry/v2 v2.2.0-dev.3
 	github.com/fxamacker/cbor/v2 v2.4.0
@@ -15,6 +15,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
 	github.com/stretchr/testify v1.7.1
 )
 
@@ -52,7 +53,6 @@ require (
 	github.com/pebbe/zmq4 v1.2.7 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a // indirect
 	github.com/spiffe/go-spiffe/v2 v2.0.0 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,12 +32,12 @@ github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9 h1:NAHC
 github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9/go.mod h1:9STzWAIpeXT1gYFvw0JM+BkyMmPKYv/ztBNgXX4hAOw=
 github.com/eclipse/paho.mqtt.golang v1.3.5 h1:sWtmgNxYM9P2sP+xEItMozsR3w0cqZFlqnNN1bdl41Y=
 github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.13 h1:KqMprarS3TFgWoSqNBCI3omvBC8MnRL34Rr92aUN2JE=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.13/go.mod h1:eolD76cvsIAUzn63YN7MGyeOWWMidsFKCJjIpo+DK14=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.16 h1:e6/XBUP88TVPUpKW+CiHdi6WNQfJape1FQq2ygXTMb0=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.16/go.mod h1:6Q+rUmzAizdpU3sqnzMzSHmX7Z69qN69xxl0up/mQQA=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0-dev.3 h1:dTTExUFHza9eJmTABr8G4KOE8JKBMzZCVC3wARiwIg4=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0-dev.3/go.mod h1:YP17JhMnXTitowXE13QJwFaKo0oc03iyoKLjWAYl4FE=
-github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.25 h1:EKkJf49mDUZF2N82bcHV//onD7qNTuZrNGWgP2byHqU=
-github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.25/go.mod h1:jyfVSx7mI3u/o/oo10COxBRBvJ8O/9I3z2xAwPmNt/Q=
+github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.26 h1:YebVI3gAJwFTMXKzB2erUonBC8eNrr+qLUGdtXFMjKs=
+github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.26/go.mod h1:jyfVSx7mI3u/o/oo10COxBRBvJ8O/9I3z2xAwPmNt/Q=
 github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.12 h1:u4ndXe8j1xYR1+axSgcgbD2OGvx7Z9v9thv0KBZp2TI=
 github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.12/go.mod h1:+X6C0h8ZTJe+lLU2AGJfiAzCJK3zL+yM6cej9VC+79E=
 github.com/edgexfoundry/go-mod-registry/v2 v2.2.0-dev.3 h1:Z1sR4g+guLsUNJw3z3gxaz472wt0gYu1XCQ4frqJl/o=

--- a/internal/app/triggerfactory.go
+++ b/internal/app/triggerfactory.go
@@ -22,6 +22,9 @@ import (
 	"fmt"
 	"strings"
 
+	gometrics "github.com/rcrowley/go-metrics"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/v2/internal"
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/internal/common"
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/internal/trigger/http"
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/internal/trigger/messagebus"
@@ -40,7 +43,12 @@ func (svc *Service) setupTrigger(configuration *common.ConfigurationStruct) inte
 	var t interfaces.Trigger
 
 	bnd := NewTriggerServiceBinding(svc)
-	mp := &triggerMessageProcessor{bnd}
+	mp := &triggerMessageProcessor{
+		bnd:              bnd,
+		messagesReceived: gometrics.NewCounter()}
+
+	svc.MetricsManager().Register(internal.MessagesReceivedName, mp.messagesReceived, nil)
+	svc.lc.Infof("%s metric has been registered and will be reported", internal.MessagesReceivedName)
 
 	switch triggerType := strings.ToUpper(configuration.Trigger.Type); triggerType {
 	case TriggerTypeHTTP:
@@ -88,7 +96,12 @@ func (svc *Service) RegisterCustomTriggerFactory(name string,
 
 	svc.customTriggerFactories[nu] = func(sdk *Service) (interfaces.Trigger, error) {
 		binding := NewTriggerServiceBinding(sdk)
-		messageProcessor := &triggerMessageProcessor{binding}
+		messageProcessor := &triggerMessageProcessor{
+			bnd:              binding,
+			messagesReceived: gometrics.NewCounter()}
+
+		svc.MetricsManager().Register(internal.MessagesReceivedName, messageProcessor.messagesReceived, nil)
+		svc.lc.Infof("%s metric has been registered and will be reported", internal.MessagesReceivedName)
 
 		cfg := interfaces.TriggerConfig{
 			Logger:           sdk.lc,

--- a/internal/app/triggerfactory.go
+++ b/internal/app/triggerfactory.go
@@ -47,8 +47,11 @@ func (svc *Service) setupTrigger(configuration *common.ConfigurationStruct) inte
 		bnd:              bnd,
 		messagesReceived: gometrics.NewCounter()}
 
-	svc.MetricsManager().Register(internal.MessagesReceivedName, mp.messagesReceived, nil)
-	svc.lc.Infof("%s metric has been registered and will be reported", internal.MessagesReceivedName)
+	if err := svc.MetricsManager().Register(internal.MessagesReceivedName, mp.messagesReceived, nil); err != nil {
+		svc.lc.Warnf("%s metric failed to register and will not be reported: %s", internal.MessagesReceivedName, err.Error())
+	} else {
+		svc.lc.Infof("%s metric has been registered and will be reported", internal.MessagesReceivedName)
+	}
 
 	switch triggerType := strings.ToUpper(configuration.Trigger.Type); triggerType {
 	case TriggerTypeHTTP:
@@ -100,8 +103,11 @@ func (svc *Service) RegisterCustomTriggerFactory(name string,
 			bnd:              binding,
 			messagesReceived: gometrics.NewCounter()}
 
-		svc.MetricsManager().Register(internal.MessagesReceivedName, messageProcessor.messagesReceived, nil)
-		svc.lc.Infof("%s metric has been registered and will be reported", internal.MessagesReceivedName)
+		if err := svc.MetricsManager().Register(internal.MessagesReceivedName, messageProcessor.messagesReceived, nil); err != nil {
+			svc.lc.Warnf("%s metric failed to register and will not be reported: %s", internal.MessagesReceivedName, err.Error())
+		} else {
+			svc.lc.Infof("%s metric has been registered and will be reported", internal.MessagesReceivedName)
+		}
 
 		cfg := interfaces.TriggerConfig{
 			Logger:           sdk.lc,

--- a/internal/app/triggerfactory_test.go
+++ b/internal/app/triggerfactory_test.go
@@ -77,7 +77,7 @@ func TestRegisterCustomTrigger(t *testing.T) {
 	builder := func(c interfaces.TriggerConfig) (interfaces.Trigger, error) {
 		return &trig, nil
 	}
-	sdk := Service{config: &common.ConfigurationStruct{}}
+	sdk := Service{config: &common.ConfigurationStruct{}, dic: dic}
 
 	err := sdk.RegisterCustomTriggerFactory(name, builder)
 
@@ -99,7 +99,8 @@ func TestSetupTrigger_HTTP(t *testing.T) {
 				Type: TriggerTypeHTTP,
 			},
 		},
-		lc: logger.MockLogger{},
+		lc:  logger.MockLogger{},
+		dic: dic,
 	}
 
 	trigger := sdk.setupTrigger(sdk.config)
@@ -115,7 +116,8 @@ func TestSetupTrigger_EdgeXMessageBus(t *testing.T) {
 				Type: TriggerTypeMessageBus,
 			},
 		},
-		lc: logger.MockLogger{},
+		lc:  logger.MockLogger{},
+		dic: dic,
 	}
 
 	trigger := sdk.setupTrigger(sdk.config)
@@ -165,7 +167,8 @@ func Test_Service_setupTrigger_CustomType(t *testing.T) {
 				Type: triggerName,
 			},
 		},
-		lc: logger.MockLogger{},
+		lc:  logger.MockLogger{},
+		dic: dic,
 	}
 
 	err := sdk.RegisterCustomTriggerFactory(triggerName, func(c interfaces.TriggerConfig) (interfaces.Trigger, error) {
@@ -188,7 +191,8 @@ func Test_Service_SetupTrigger_CustomTypeError(t *testing.T) {
 				Type: triggerName,
 			},
 		},
-		lc: logger.MockLogger{},
+		lc:  logger.MockLogger{},
+		dic: dic,
 	}
 
 	err := sdk.RegisterCustomTriggerFactory(triggerName, func(c interfaces.TriggerConfig) (interfaces.Trigger, error) {
@@ -210,7 +214,8 @@ func Test_Service_SetupTrigger_CustomTypeNotFound(t *testing.T) {
 				Type: triggerName,
 			},
 		},
-		lc: logger.MockLogger{},
+		lc:  logger.MockLogger{},
+		dic: dic,
 	}
 
 	trigger := sdk.setupTrigger(sdk.config)

--- a/internal/app/triggerfactory_test.go
+++ b/internal/app/triggerfactory_test.go
@@ -77,7 +77,10 @@ func TestRegisterCustomTrigger(t *testing.T) {
 	builder := func(c interfaces.TriggerConfig) (interfaces.Trigger, error) {
 		return &trig, nil
 	}
-	sdk := Service{config: &common.ConfigurationStruct{}, dic: dic}
+	sdk := Service{
+		config: &common.ConfigurationStruct{},
+		lc:     logger.NewMockClient(),
+		dic:    dic}
 
 	err := sdk.RegisterCustomTriggerFactory(name, builder)
 

--- a/internal/constant.go
+++ b/internal/constant.go
@@ -32,3 +32,11 @@ var SDKVersion = "0.0.0"
 
 // ApplicationVersion indicates the version of the application itself, not the SDK - will be overwritten by build
 var ApplicationVersion = "0.0.0"
+
+// Names for the Common Application Service Metrics
+const (
+	MessagesReceivedName              = "MessagesReceived"
+	PipelineIdTxt                     = "{PipelineId}"
+	PipelineMessagesProcessedName     = "PipelineMessagesProcessed-" + PipelineIdTxt
+	PipelineMessageProcessingTimeName = "PipelineMessageProcessingTime-" + PipelineIdTxt
+)

--- a/internal/runtime/storeforward_test.go
+++ b/internal/runtime/storeforward_test.go
@@ -18,9 +18,12 @@ package runtime
 
 import (
 	"errors"
-	"github.com/edgexfoundry/app-functions-sdk-go/v2/pkg/interfaces/mocks"
 	"os"
 	"testing"
+
+	mocks2 "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces/mocks"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/v2/pkg/interfaces/mocks"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
@@ -47,12 +50,18 @@ func TestMain(m *testing.M) {
 		},
 	}
 
+	mockMetricsManager := &mocks2.MetricsManager{}
+	mockMetricsManager.On("Register", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
 	dic = di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return &config
 		},
 		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
 			return logger.NewMockClient()
+		},
+		bootstrapContainer.MetricsManagerInterfaceName: func(get di.Get) interface{} {
+			return mockMetricsManager
 		},
 	})
 

--- a/pkg/interfaces/service.go
+++ b/pkg/interfaces/service.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
+	gometrics "github.com/rcrowley/go-metrics"
 
 	bootstrapInterfaces "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces"
@@ -56,6 +57,9 @@ type FunctionPipeline struct {
 	Topics []string
 	// Hash of the list of transforms set and used internally for Store and Forward
 	Hash string
+
+	MessagesProcessed     gometrics.Counter
+	MessageProcessingTime gometrics.Timer
 }
 
 // UpdatableConfig interface allows services to have custom configuration populated from configuration stored


### PR DESCRIPTION
closes #1085

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      **TBD**

## Testing Instructions
Run non-secure edgex stack with device virtual
Build and run template app from this branch with DEBUG logging
Verify the logs show 4 different pipeline metrics registered
Verify every 30secs, the logs show 6 metrics reported.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->