### PR TITLE
build: Upgrade to latest V3 JSON Logic

### DIFF
--- a/app-service-template/Attribution.txt
+++ b/app-service-template/Attribution.txt
@@ -132,7 +132,7 @@ https://github.com/golang/sync/blob/master/LICENSE
 golang.org/x/text (Unspecified) https://github.com/golang/text
 https://github.com/golang/text/blob/master/LICENSE
 
-github.com/diegoholiveira/jsonlogic (MIT) https://github.com/diegoholiveira/
+github.com/diegoholiveira/jsonlogic/v3 (MIT) https://github.com/diegoholiveira/
 https://github.com/diegoholiveira/jsonlogic/blob/master/LICENSE
 
 github.com/go-redis/redis/v7 (BSD-2) https://github.com/go-redis/redis

--- a/app-service-template/go.mod
+++ b/app-service-template/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9 // indirect
+	github.com/diegoholiveira/jsonlogic/v3 v3.2.2 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.3.5 // indirect
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0 // indirect
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0 // indirect

--- a/app-service-template/go.sum
+++ b/app-service-template/go.sum
@@ -28,8 +28,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9 h1:NAHCNOHtaaYnBt6pGtdW++xkFHuAavi2G7Y1OFNu17E=
-github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9/go.mod h1:9STzWAIpeXT1gYFvw0JM+BkyMmPKYv/ztBNgXX4hAOw=
+github.com/diegoholiveira/jsonlogic/v3 v3.2.2 h1:qV3mShglvFIwnr37ZB6kL81Gk5vHrGDevQGy2j1AMQA=
+github.com/diegoholiveira/jsonlogic/v3 v3.2.2/go.mod h1:9oE8z9G+0OMxOoLHF3fhek3KuqD5CBqM0B6XFL08MSg=
 github.com/eclipse/paho.mqtt.golang v1.3.5 h1:sWtmgNxYM9P2sP+xEItMozsR3w0cqZFlqnNN1bdl41Y=
 github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=
 github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0 h1:4UVNGRaKbkH5aEhQrto26Q65ydmhZYReRw/6ZNQ5J5E=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
-	github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9
+	github.com/diegoholiveira/jsonlogic/v3 v3.2.2
 	github.com/eclipse/paho.mqtt.golang v1.3.5
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9 h1:NAHCNOHtaaYnBt6pGtdW++xkFHuAavi2G7Y1OFNu17E=
-github.com/diegoholiveira/jsonlogic v1.0.1-0.20200220175622-ab7989be08b9/go.mod h1:9STzWAIpeXT1gYFvw0JM+BkyMmPKYv/ztBNgXX4hAOw=
+github.com/diegoholiveira/jsonlogic/v3 v3.2.2 h1:qV3mShglvFIwnr37ZB6kL81Gk5vHrGDevQGy2j1AMQA=
+github.com/diegoholiveira/jsonlogic/v3 v3.2.2/go.mod h1:9oE8z9G+0OMxOoLHF3fhek3KuqD5CBqM0B6XFL08MSg=
 github.com/eclipse/paho.mqtt.golang v1.3.5 h1:sWtmgNxYM9P2sP+xEItMozsR3w0cqZFlqnNN1bdl41Y=
 github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=
 github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0 h1:4UVNGRaKbkH5aEhQrto26Q65ydmhZYReRw/6ZNQ5J5E=

--- a/pkg/transforms/jsonlogic.go
+++ b/pkg/transforms/jsonlogic.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/diegoholiveira/jsonlogic"
+	"github.com/diegoholiveira/jsonlogic/v3"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/pkg/interfaces"
 	"github.com/edgexfoundry/app-functions-sdk-go/v2/pkg/util"


### PR DESCRIPTION
They have now fixed thier go.mod issue allow us to use V3 release tags

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A existing suffice**
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) **Unit tests suffice**
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
      <link to docs PR>

## Testing Instructions
**N/A**
## New Dependency Instructions (If applicable)
**N/A**