### PR TITLE
feat: add ability to wrap data into an event

### DIFF
--- a/internal/app/configurable.go
+++ b/internal/app/configurable.go
@@ -256,7 +256,7 @@ func (app *Configurable) PushToCore(parameters map[string]string) interfaces.App
 	return transform.PushToCoreData
 }
 
-// WrapIntoEvent wraps the provided value as an event to CoreData using the configured event/reading metadata that have been
+// WrapIntoEvent wraps the provided value as an EdgeX Event using the configured event/reading metadata that have been
 // set. The new Event/Reading is returned to the next pipeline function. This function is a configuration function and
 // returns a function pointer.
 func (app *Configurable) WrapIntoEvent(parameters map[string]string) interfaces.AppFunction {

--- a/internal/app/configurable.go
+++ b/internal/app/configurable.go
@@ -256,9 +256,9 @@ func (app *Configurable) PushToCore(parameters map[string]string) interfaces.App
 	return transform.PushToCoreData
 }
 
-// WrapIntoEvent pushes the provided value as an event to CoreData using the device name and reading name that have been
-// set. If validation is turned on in CoreServices then your deviceName and readingName must exist in the CoreMetadata
-// and be properly registered in EdgeX. This function is a configuration function and returns a function pointer.
+// WrapIntoEvent wraps the provided value as an event to CoreData using the configured event/reading metadata that have been
+// set. The new Event/Reading is returned to the next pipeline function. This function is a configuration function and
+// returns a function pointer.
 func (app *Configurable) WrapIntoEvent(parameters map[string]string) interfaces.AppFunction {
 	profileName, ok := parameters[ProfileName]
 	if !ok {
@@ -288,7 +288,7 @@ func (app *Configurable) WrapIntoEvent(parameters map[string]string) interfaces.
 
 	var transform *transforms.EventWrapper
 
-	// Converts to upper case and validates it is a validates ValueType
+	// Converts to upper case and validates it is a valid ValueType
 	valueType, err := common.NormalizeValueType(valueType)
 	if err != nil {
 		app.lc.Error(err.Error())

--- a/pkg/transforms/event.go
+++ b/pkg/transforms/event.go
@@ -69,18 +69,12 @@ func NewEventWrapperObjectReading(profileName string, deviceName string, resourc
 	return eventWrapper
 }
 
-// Wrap creates an EventRequest using the device name and reading name that have been set. If validation is turned on in
-// CoreServices then your deviceName and readingName must exist in the CoreMetadata and be properly registered in EdgeX.
+// // Wrap creates an EventRequest using the Event/Reading metadata that have been set.
 func (ew *EventWrapper) Wrap(ctx interfaces.AppFunctionContext, data interface{}) (bool, interface{}) {
 	ctx.LoggingClient().Info("Creating Event...")
 
 	if data == nil {
-		return false, fmt.Errorf("function EventCreator in pipeline '%s': No Data Received", ctx.PipelineId())
-	}
-
-	client := ctx.EventClient()
-	if client == nil {
-		return false, fmt.Errorf("function EventCreator in pipeline '%s': EventClient not initialized. Core Data is missing from clients configuration", ctx.PipelineId())
+		return false, fmt.Errorf("function EventWrapper in pipeline '%s': No Data Received", ctx.PipelineId())
 	}
 
 	event := dtos.NewEvent(ew.profileName, ew.deviceName, ew.resourceName)
@@ -119,7 +113,7 @@ func (ew *EventWrapper) Wrap(ctx interfaces.AppFunctionContext, data interface{}
 	ctx.AddValue(interfaces.DEVICENAME, ew.deviceName)
 	ctx.AddValue(interfaces.SOURCENAME, ew.resourceName)
 
-	// need to wrap in Add Event Request for Core Data to process it
+	// need to wrap in Add Event Request for Core Data to process it if published to the MessageBus
 	eventRequest := requests.NewAddEventRequest(event)
 
 	return true, eventRequest

--- a/pkg/transforms/event.go
+++ b/pkg/transforms/event.go
@@ -1,0 +1,126 @@
+//
+// Copyright (c) 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package transforms
+
+import (
+	"fmt"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/v2/pkg/interfaces"
+	"github.com/edgexfoundry/app-functions-sdk-go/v2/pkg/util"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+)
+
+type EventWrapper struct {
+	profileName  string
+	deviceName   string
+	resourceName string
+	valueType    string
+	mediaType    string
+}
+
+// NewEventWrapperSimpleReading is provided to interact with EventWrapper to add a simple reading
+func NewEventWrapperSimpleReading(profileName string, deviceName string, resourceName string, valueType string) *EventWrapper {
+	eventWrapper := &EventWrapper{
+		profileName:  profileName,
+		deviceName:   deviceName,
+		resourceName: resourceName,
+		valueType:    valueType,
+	}
+	return eventWrapper
+}
+
+// NewEventWrapperBinaryReading is provided to interact with EventWrapper to add a binary reading
+func NewEventWrapperBinaryReading(profileName string, deviceName string, resourceName string, mediaType string) *EventWrapper {
+	eventWrapper := &EventWrapper{
+		profileName:  profileName,
+		deviceName:   deviceName,
+		resourceName: resourceName,
+		valueType:    common.ValueTypeBinary,
+		mediaType:    mediaType,
+	}
+	return eventWrapper
+}
+
+// NewEventWrapperObjectReading is provided to interact with EventWrapper to add a object reading type
+func NewEventWrapperObjectReading(profileName string, deviceName string, resourceName string) *EventWrapper {
+	eventWrapper := &EventWrapper{
+		profileName:  profileName,
+		deviceName:   deviceName,
+		resourceName: resourceName,
+		valueType:    common.ValueTypeObject,
+	}
+	return eventWrapper
+}
+
+// Wrap creates an EventRequest using the device name and reading name that have been set. If validation is turned on in
+// CoreServices then your deviceName and readingName must exist in the CoreMetadata and be properly registered in EdgeX.
+func (ew *EventWrapper) Wrap(ctx interfaces.AppFunctionContext, data interface{}) (bool, interface{}) {
+	ctx.LoggingClient().Info("Creating Event...")
+
+	if data == nil {
+		return false, fmt.Errorf("function EventCreator in pipeline '%s': No Data Received", ctx.PipelineId())
+	}
+
+	client := ctx.EventClient()
+	if client == nil {
+		return false, fmt.Errorf("function EventCreator in pipeline '%s': EventClient not initialized. Core Data is missing from clients configuration", ctx.PipelineId())
+	}
+
+	event := dtos.NewEvent(ew.profileName, ew.deviceName, ew.resourceName)
+
+	switch ew.valueType {
+	case common.ValueTypeBinary:
+		reading, err := util.CoerceType(data)
+		if err != nil {
+			return false, err
+		}
+		event.AddBinaryReading(ew.resourceName, reading, ew.mediaType)
+
+	case common.ValueTypeString:
+		reading, err := util.CoerceType(data)
+		if err != nil {
+			return false, err
+		}
+		err = event.AddSimpleReading(ew.resourceName, ew.valueType, string(reading))
+		if err != nil {
+			return false, fmt.Errorf("error adding Reading in pipeline '%s': %s", ctx.PipelineId(), err.Error())
+		}
+
+	case common.ValueTypeObject:
+		event.AddObjectReading(ew.resourceName, data)
+
+	default:
+		err := event.AddSimpleReading(ew.resourceName, ew.valueType, data)
+		if err != nil {
+			return false, fmt.Errorf("error adding Reading in pipeline '%s': %s", ctx.PipelineId(), err.Error())
+		}
+	}
+
+	// unsetting content type to send back as event
+	ctx.SetResponseContentType("")
+	ctx.AddValue(interfaces.PROFILENAME, ew.profileName)
+	ctx.AddValue(interfaces.DEVICENAME, ew.deviceName)
+	ctx.AddValue(interfaces.SOURCENAME, ew.resourceName)
+
+	// need to wrap in Add Event Request for Core Data to process it
+	eventRequest := requests.NewAddEventRequest(event)
+
+	return true, eventRequest
+}

--- a/pkg/transforms/event_test.go
+++ b/pkg/transforms/event_test.go
@@ -46,7 +46,7 @@ func TestEventWrapper_Wrap(t *testing.T) {
 	}{
 		{"Successful Binary Reading", "MyProfile", "MyDevice", "BinaryEvent", common.ValueTypeBinary, "stuff", true, ""},
 		{"Successful Object Reading", "MyProfile", "MyDevice", "ObjectEvent", common.ValueTypeObject, "", obj, ""},
-		{"Successful Simple Reading", "MyProfile", "MyDevice", "ObjectEvent", common.ValueTypeObject, "", "hello there", ""},
+		{"Successful Simple Reading", "MyProfile", "MyDevice", "ObjectEvent", common.ValueTypeString, "", "hello there", ""},
 	}
 
 	for _, test := range tests {
@@ -59,15 +59,15 @@ func TestEventWrapper_Wrap(t *testing.T) {
 		default:
 			transform = NewEventWrapperSimpleReading(test.ProfileName, test.DeviceName, test.ResourceName, test.ValueType)
 		}
-		expectedBool, expectedInterface := transform.Wrap(ctx, test.Data)
+		actualBool, actualInterface := transform.Wrap(ctx, test.Data)
 		if test.ExpectedError == "" {
-			require.True(t, expectedBool)
+			require.True(t, actualBool)
 			require.Equal(t, "", ctx.ResponseContentType())
 			ctxValues := ctx.GetAllValues()
 			require.Equal(t, test.ProfileName, ctxValues[interfaces.PROFILENAME])
 			require.Equal(t, test.DeviceName, ctxValues[interfaces.DEVICENAME])
 			require.Equal(t, test.ResourceName, ctxValues[interfaces.SOURCENAME])
-			eventRequest := expectedInterface.(requests.AddEventRequest)
+			eventRequest := actualInterface.(requests.AddEventRequest)
 			require.Equal(t, test.DeviceName, eventRequest.Event.DeviceName)
 			require.Equal(t, test.ProfileName, eventRequest.Event.ProfileName)
 			require.Equal(t, test.ResourceName, eventRequest.Event.SourceName)
@@ -86,7 +86,7 @@ func TestEventWrapper_Wrap(t *testing.T) {
 			}
 			return
 		}
-		require.False(t, expectedBool)
-		require.Equal(t, test.ExpectedError, expectedInterface)
+		require.False(t, actualBool)
+		require.Equal(t, test.ExpectedError, actualInterface)
 	}
 }

--- a/pkg/transforms/event_test.go
+++ b/pkg/transforms/event_test.go
@@ -1,0 +1,92 @@
+//
+// Copyright (c) 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package transforms
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/v2/pkg/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventWrapper_Wrap(t *testing.T) {
+	obj := struct {
+		myInt int
+		myStr string
+	}{
+		myInt: 3,
+		myStr: "hello world",
+	}
+	tests := []struct {
+		Name          string
+		ProfileName   string
+		DeviceName    string
+		ResourceName  string
+		ValueType     string
+		MediaType     string
+		Data          interface{}
+		ExpectedError interface{}
+	}{
+		{"Successful Binary Reading", "MyProfile", "MyDevice", "BinaryEvent", common.ValueTypeBinary, "stuff", true, ""},
+		{"Successful Object Reading", "MyProfile", "MyDevice", "ObjectEvent", common.ValueTypeObject, "", obj, ""},
+		{"Successful Simple Reading", "MyProfile", "MyDevice", "ObjectEvent", common.ValueTypeObject, "", "hello there", ""},
+	}
+
+	for _, test := range tests {
+		var transform *EventWrapper
+		switch test.ValueType {
+		case common.ValueTypeBinary:
+			transform = NewEventWrapperBinaryReading(test.ProfileName, test.DeviceName, test.ResourceName, test.MediaType)
+		case common.ValueTypeObject:
+			transform = NewEventWrapperObjectReading(test.ProfileName, test.DeviceName, test.ResourceName)
+		default:
+			transform = NewEventWrapperSimpleReading(test.ProfileName, test.DeviceName, test.ResourceName, test.ValueType)
+		}
+		expectedBool, expectedInterface := transform.Wrap(ctx, test.Data)
+		if test.ExpectedError == "" {
+			require.True(t, expectedBool)
+			require.Equal(t, "", ctx.ResponseContentType())
+			ctxValues := ctx.GetAllValues()
+			require.Equal(t, test.ProfileName, ctxValues[interfaces.PROFILENAME])
+			require.Equal(t, test.DeviceName, ctxValues[interfaces.DEVICENAME])
+			require.Equal(t, test.ResourceName, ctxValues[interfaces.SOURCENAME])
+			eventRequest := expectedInterface.(requests.AddEventRequest)
+			require.Equal(t, test.DeviceName, eventRequest.Event.DeviceName)
+			require.Equal(t, test.ProfileName, eventRequest.Event.ProfileName)
+			require.Equal(t, test.ResourceName, eventRequest.Event.SourceName)
+			require.Equal(t, test.DeviceName, eventRequest.Event.Readings[0].DeviceName)
+			require.Equal(t, test.ProfileName, eventRequest.Event.Readings[0].ProfileName)
+			require.Equal(t, test.ResourceName, eventRequest.Event.Readings[0].ResourceName)
+			switch test.ValueType {
+			case common.ValueTypeBinary:
+				value, err := strconv.ParseBool(string(eventRequest.Event.Readings[0].BinaryReading.BinaryValue))
+				require.NoError(t, err)
+				require.Equal(t, test.Data, value)
+			case common.ValueTypeObject:
+				require.Equal(t, test.Data, eventRequest.Event.Readings[0].ObjectReading.ObjectValue)
+			default:
+				require.Equal(t, test.Data, eventRequest.Event.Readings[0].SimpleReading.Value)
+			}
+			return
+		}
+		require.False(t, expectedBool)
+		require.Equal(t, test.ExpectedError, expectedInterface)
+	}
+}


### PR DESCRIPTION
closes #1149

Signed-off-by: Elizabeth J Lee <elizabeth.j.lee@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
      [https://github.com/edgexfoundry/edgex-docs/pull/799](https://github.com/edgexfoundry/edgex-docs/pull/799)

## Testing Instructions
1. run the base edgex components
2. set the following changes in the sample profile
    ```
    [Writable.Pipeline]
    ExecutionOrder = "Compress, WrapIntoEvent, SetResponseData"
    ...
    [Writable.Pipeline.Functions.WrapIntoEvent]
      [Writable.Pipeline.Functions.WrapIntoEvent.Parameters]
      ProfileName = "MyProfile"
      DeviceName = "MyDevice"
      ResourceName = "XMLEvent"
      ValueType = "String"
      MediaType = ""  # Required only when ValueType=Binary
    ...
    [Trigger.EdgexMessageBus.SubscribeHost]
    Host = "localhost"
    Port = 6379
    Protocol = "redis"
    SubscribeTopics="edgex/events/device/Random-Boolean-Device/#"
    [Trigger.EdgexMessageBus.PublishHost]
    Host = "localhost"
    Port = 6379
    Protocol = "redis"
    PublishTopic="edgex/events/device/{profilename}/{devicename}/{sourcename}"
    ```
4. build and run the sample profile
5. wait for the data to come through
6. check this endpoint for the event info localhost:59880/api/v2/event/device/name/MyDevice


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->