### PR TITLE
feat: Expose SecretProvider so new APIs are accessible

### DIFF
--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -604,6 +604,12 @@ func (svc *Service) StoreSecret(path string, secretData map[string]string) error
 	return secretProvider.StoreSecret(path, secretData)
 }
 
+// SecretProvider returns the SecretProvider instance
+func (svc *Service) SecretProvider() bootstrapInterfaces.SecretProvider {
+	secretProvider := bootstrapContainer.SecretProviderFrom(svc.dic.Get)
+	return secretProvider
+}
+
 // LoggingClient returns the Logging client from the dependency injection container
 func (svc *Service) LoggingClient() logger.LoggingClient {
 	return svc.lc

--- a/internal/appfunction/context.go
+++ b/internal/appfunction/context.go
@@ -152,6 +152,12 @@ func (appContext *Context) SecretsLastUpdated() time.Time {
 	return secretProvider.SecretsLastUpdated()
 }
 
+// SecretProvider returns the SecretProvider instance
+func (appContext *Context) SecretProvider() bootstrapInterfaces.SecretProvider {
+	secretProvider := container.SecretProviderFrom(appContext.Dic.Get)
+	return secretProvider
+}
+
 // LoggingClient returns the Logging client from the dependency injection container
 func (appContext *Context) LoggingClient() logger.LoggingClient {
 	return container.LoggingClientFrom(appContext.Dic.Get)

--- a/internal/appfunction/context_test.go
+++ b/internal/appfunction/context_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
 
 	v2clients "github.com/edgexfoundry/go-mod-core-contracts/v2/clients/http"
 	clientMocks "github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces/mocks"
@@ -47,11 +48,17 @@ import (
 var target *Context
 var dic *di.Container
 var baseUrl = "http://localhost:"
+var mockSecretProvider interfaces.SecretProvider
 
 func TestMain(m *testing.M) {
+	mockSecretProvider = &mocks.SecretProvider{}
+
 	dic = di.NewContainer(di.ServiceConstructorMap{
 		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
 			return logger.NewMockClient()
+		},
+		bootstrapContainer.SecretProviderName: func(get di.Get) interface{} {
+			return mockSecretProvider
 		},
 	})
 	target = NewContext("", dic, "")
@@ -172,6 +179,12 @@ func TestContext_MetricsManager(t *testing.T) {
 
 	actual = target.MetricsManager()
 	assert.NotNil(t, actual)
+}
+
+func TestContext_SecretProvider(t *testing.T) {
+	actual := target.SecretProvider()
+	require.NotNil(t, actual)
+	assert.Equal(t, mockSecretProvider, actual)
 }
 
 func TestContext_LoggingClient(t *testing.T) {

--- a/pkg/interfaces/context.go
+++ b/pkg/interfaces/context.go
@@ -72,6 +72,8 @@ type AppFunctionContext interface {
 	// SecretsLastUpdated returns that timestamp for when the secrets in the SecretStore where last updated.
 	// Useful when a connection to external source needs to be redone when the credentials have been updated.
 	SecretsLastUpdated() time.Time
+	// SecretProvider returns the SecretProvider instance
+	SecretProvider() bootstrapInterfaces.SecretProvider
 	// LoggingClient returns the Logger client
 	LoggingClient() logger.LoggingClient
 	// EventClient returns the Event client. Note if Core Data is not specified in the Clients configuration,

--- a/pkg/interfaces/service.go
+++ b/pkg/interfaces/service.go
@@ -136,6 +136,9 @@ type ApplicationService interface {
 	//   - Secure secret provider is not properly initialized
 	//   - Connection issues with Secret Store service.
 	StoreSecret(path string, secretData map[string]string) error // LoggingClient returns the Logger client
+	// SecretProvider returns the SecretProvider instance
+	SecretProvider() bootstrapInterfaces.SecretProvider
+	// LoggingClient returns the Logger client
 	LoggingClient() logger.LoggingClient
 	// EventClient returns the Event client. Note if Core Data is not specified in the Clients configuration,
 	// this will return nil.


### PR DESCRIPTION
close #1169

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->