### PR TITLE
fix: Update Pipeline topics when writable pipeline changed

### DIFF
--- a/internal/app/configupdates.go
+++ b/internal/app/configupdates.go
@@ -140,7 +140,9 @@ func (processor *ConfigUpdateProcessor) processConfigChangedPipeline() {
 
 		// Update the pipelines with their new transforms
 		for _, pipeline := range pipelines {
+			// TODO: Look at better way to apply pipeline updates
 			sdk.runtime.SetFunctionsPipelineTransforms(pipeline.Id, pipeline.Transforms)
+			sdk.runtime.SetFunctionsPipelineTopics(pipeline.Id, pipeline.Topics)
 		}
 
 		sdk.LoggingClient().Info("Configurable Pipeline successfully reloaded from new configuration")

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -119,6 +119,20 @@ func (gr *GolangRuntime) SetFunctionsPipelineTransforms(id string, transforms []
 	}
 }
 
+// SetFunctionsPipelineTopics sets the topics for an existing function pipeline.
+// Non-existent pipelines are ignored
+func (gr *GolangRuntime) SetFunctionsPipelineTopics(id string, topics []string) {
+	pipeline := gr.pipelines[id]
+	if pipeline != nil {
+		gr.isBusyCopying.Lock()
+		pipeline.Topics = topics
+		gr.isBusyCopying.Unlock()
+		gr.lc.Infof("Topics set for `%s` pipeline", id)
+	} else {
+		gr.lc.Warnf("Unable to set topica for `%s` pipeline: Pipeline not found", id)
+	}
+}
+
 // ClearAllFunctionsPipelineTransforms clears the transforms for all existing function pipelines.
 func (gr *GolangRuntime) ClearAllFunctionsPipelineTransforms() {
 	gr.isBusyCopying.Lock()


### PR DESCRIPTION
fixes #1187

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
      <link to docs PR>

## Testing Instructions
Run non-secure EdgeX stack
Build ASC with SDK from this PR
Run ASC with profile sample and -cp option
Verify Float pipeline is executed when topic matches
Change topic for Float pipeline from Consul to something that will never match
Verify Float pipeline is never executed when topic would have matched previously

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->