### PR TITLE
fix: Username may be required when MQTT cert authentication

### DIFF
--- a/pkg/secure/mqttfactory.go
+++ b/pkg/secure/mqttfactory.go
@@ -82,9 +82,12 @@ func (factory MqttFactory) configureMQTTClientForAuth(secretData *messaging.Secr
 		InsecureSkipVerify: factory.skipCertVerify,
 		MinVersion:         tls.VersionTLS12,
 	}
+	// Username may be required when cert authentication
+	if secretData.Username != "" {
+		factory.opts.SetUsername(secretData.Username)
+	}
 	switch factory.authMode {
 	case messaging.AuthModeUsernamePassword:
-		factory.opts.SetUsername(secretData.Username)
 		factory.opts.SetPassword(secretData.Password)
 	case messaging.AuthModeCert:
 		cert, err = tls.X509KeyPair(secretData.CertPemBlock, secretData.KeyPemBlock)

--- a/pkg/secure/mqttfactory_test.go
+++ b/pkg/secure/mqttfactory_test.go
@@ -143,7 +143,7 @@ func TestConfigureMQTTClientForAuthWithCACert(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotNil(t, target.opts.TLSConfig.RootCAs)
-	assert.Empty(t, target.opts.Username)
+	//assert.Empty(t, target.opts.Username) // Username may be required when cert authentication
 	assert.Empty(t, target.opts.Password)
 	assert.Nil(t, target.opts.TLSConfig.Certificates)
 }
@@ -159,7 +159,7 @@ func TestConfigureMQTTClientForAuthWithClientCert(t *testing.T) {
 		CaPemBlock:   []byte(testCACert),
 	})
 	require.NoError(t, err)
-	assert.Empty(t, target.opts.Username)
+	//assert.Empty(t, target.opts.Username) // Username may be required when cert authentication
 	assert.Empty(t, target.opts.Password)
 	assert.NotNil(t, target.opts.TLSConfig.Certificates)
 	assert.NotNil(t, target.opts.TLSConfig.RootCAs)
@@ -177,7 +177,7 @@ func TestConfigureMQTTClientForAuthWithClientCertNoCA(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Empty(t, target.opts.Username)
+	//assert.Empty(t, target.opts.Username) // Username may be required when cert authentication
 	assert.Empty(t, target.opts.Password)
 	assert.NotNil(t, target.opts.TLSConfig.Certificates)
 	assert.Nil(t, target.opts.TLSConfig.RootCAs)

--- a/pkg/secure/mqttfactory_test.go
+++ b/pkg/secure/mqttfactory_test.go
@@ -143,6 +143,7 @@ func TestConfigureMQTTClientForAuthWithCACert(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotNil(t, target.opts.TLSConfig.RootCAs)
+	assert.Equal(t, target.opts.Username, "Username")
 	assert.Empty(t, target.opts.Password)
 	assert.Nil(t, target.opts.TLSConfig.Certificates)
 }
@@ -158,6 +159,7 @@ func TestConfigureMQTTClientForAuthWithClientCert(t *testing.T) {
 		CaPemBlock:   []byte(testCACert),
 	})
 	require.NoError(t, err)
+	assert.Equal(t, target.opts.Username, "Username")
 	assert.Empty(t, target.opts.Password)
 	assert.NotNil(t, target.opts.TLSConfig.Certificates)
 	assert.NotNil(t, target.opts.TLSConfig.RootCAs)
@@ -175,6 +177,7 @@ func TestConfigureMQTTClientForAuthWithClientCertNoCA(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+	assert.Equal(t, target.opts.Username, messaging.SecretUsernameKey)
 	assert.Empty(t, target.opts.Password)
 	assert.NotNil(t, target.opts.TLSConfig.Certificates)
 	assert.Nil(t, target.opts.TLSConfig.RootCAs)

--- a/pkg/secure/mqttfactory_test.go
+++ b/pkg/secure/mqttfactory_test.go
@@ -20,10 +20,10 @@
 package secure
 
 import (
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"os"
 	"testing"
 
-	"github.com/eclipse/paho.mqtt.golang"
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/messaging"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
@@ -143,7 +143,6 @@ func TestConfigureMQTTClientForAuthWithCACert(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotNil(t, target.opts.TLSConfig.RootCAs)
-	//assert.Empty(t, target.opts.Username) // Username may be required when cert authentication
 	assert.Empty(t, target.opts.Password)
 	assert.Nil(t, target.opts.TLSConfig.Certificates)
 }
@@ -159,7 +158,6 @@ func TestConfigureMQTTClientForAuthWithClientCert(t *testing.T) {
 		CaPemBlock:   []byte(testCACert),
 	})
 	require.NoError(t, err)
-	//assert.Empty(t, target.opts.Username) // Username may be required when cert authentication
 	assert.Empty(t, target.opts.Password)
 	assert.NotNil(t, target.opts.TLSConfig.Certificates)
 	assert.NotNil(t, target.opts.TLSConfig.RootCAs)
@@ -177,7 +175,6 @@ func TestConfigureMQTTClientForAuthWithClientCertNoCA(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	//assert.Empty(t, target.opts.Username) // Username may be required when cert authentication
 	assert.Empty(t, target.opts.Password)
 	assert.NotNil(t, target.opts.TLSConfig.Certificates)
 	assert.Nil(t, target.opts.TLSConfig.RootCAs)


### PR DESCRIPTION
Username may be required when MQTT cert authentication.

Signed-off-by: Ian <ancientxu@gmail.com> 

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions


## New Dependency Instructions (If applicable)

## Test configuration.toml

```toml
[Writable]
LogLevel = "INFO"
  [Writable.StoreAndForward]
  Enabled = false
  RetryInterval = "5m"
  MaxRetryCount = 10
  [Writable.InsecureSecrets]
    [Writable.InsecureSecrets.DB]
    path = "redisdb"
      [Writable.InsecureSecrets.DB.Secrets]
      username = ""
      password = ""
    [Writable.InsecureSecrets.mqtt]
    path = "mqtt"
      [Writable.InsecureSecrets.mqtt.Secrets]
      username = "device1.azure-devices.net/device1/?api-version=2021-04-12"
      clientkey = """-----BEGIN PRIVATE KEY-----
xxxx
-----END PRIVATE KEY-----
"""
      clientcert = """-----BEGIN CERTIFICATE-----
xxxx
-----END CERTIFICATE-----
"""

[MqttExportConfig]
BrokerAddress = "ssl://xxx.azure-devices.net:8883"
ClientId = "device1"
AutoReconnect = true
Topic = "devices/device1/messages/events/" # iot device name MUST match client ID
AuthMode = "clientcert" # Change if auth required. See https://docs.edgexfoundry.org/2.0/microservices/application/BuiltIn/#mqtt-export for details
SecretPath = "mqtt"
```
