### PR TITLE
feat: Expose Set and Clear operation of pipelines in ApplicationService interface

### DIFF
--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -430,6 +430,22 @@ func (svc *Service) AddFunctionsPipelineForTopics(id string, topics []string, tr
 	return nil
 }
 
+// SetFunctionsPipelineTransforms updates the functions pipeline for the specified id
+func (svc *Service) SetFunctionsPipelineTransforms(id string, transforms ...interfaces.AppFunction) error {
+	if len(transforms) == 0 {
+		return errors.New("no transforms provided to pipeline")
+	}
+
+	svc.runtime.SetFunctionsPipelineTransforms(id, transforms)
+	svc.lc.Debugf("Pipeline '%s' updated with %d transform(s)", id, len(transforms))
+	return nil
+}
+
+// ClearAllFunctionsPipelineTransforms clears all the functions pipelines
+func (svc *Service) ClearAllFunctionsPipelineTransforms() {
+	svc.runtime.ClearAllFunctionsPipelineTransforms()
+}
+
 // RequestTimeout returns the Request Timeout duration that was parsed from the Service.RequestTimeout configuration
 func (svc *Service) RequestTimeout() time.Duration {
 	return svc.requestTimeout

--- a/pkg/interfaces/service.go
+++ b/pkg/interfaces/service.go
@@ -104,6 +104,11 @@ type ApplicationService interface {
 	// so that it matches multiple incoming topics. If just "#" is used for the specified topic it will match all incoming
 	// topics and the specified functions pipeline will execute on every message received.
 	AddFunctionsPipelineForTopics(id string, topic []string, transforms ...AppFunction) error
+	// SetFunctionsPipelineTransforms updates the functions pipeline for the list of Application Functions to be executed
+	// with the specified unique id.
+	SetFunctionsPipelineTransforms(id string, transforms ...AppFunction) error
+	// ClearAllFunctionsPipelineTransforms clears all the functions pipelines
+	ClearAllFunctionsPipelineTransforms()
 	// MakeItRun starts the configured trigger to allow the functions pipeline to execute when the trigger
 	// receives data and starts the internal webserver. This is a long running function which does not return until
 	// the service is stopped or MakeItStop() is called.


### PR DESCRIPTION
We are developing an application-service without Consul, but we also want to configure the pipelines dynamically according to a local file or other system(such as k8s configmap). We expect to expose the Set and Clear operation of pipelines so that achieving our goals. 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions
Just use unit tests is ok.
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->