### PR TITLE
feat: Expose Set and Clear operation of pipelines in ApplicationService interface

### DIFF
--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -430,6 +430,11 @@ func (svc *Service) AddFunctionsPipelineForTopics(id string, topics []string, tr
 	return nil
 }
 
+// RemoveAllFunctionPipelines removes all existing function pipelines
+func (svc *Service) RemoveAllFunctionPipelines() {
+	svc.runtime.RemoveAllFunctionPipelines()
+}
+
 // RequestTimeout returns the Request Timeout duration that was parsed from the Service.RequestTimeout configuration
 func (svc *Service) RequestTimeout() time.Duration {
 	return svc.requestTimeout

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -752,3 +752,36 @@ func TestGolangRuntime_ClearAllFunctionsPipelineTransforms(t *testing.T) {
 	pipeline = target.GetPipelineById(id2)
 	assert.Nil(t, pipeline.Transforms)
 }
+
+func TestGolangRuntime_RemoveAllFunctionPipelines(t *testing.T) {
+	target := NewGolangRuntime(serviceKey, nil, dic)
+
+	id1 := "pipeline1"
+	id2 := "pipeline2"
+	topics := []string{"edgex/events/#"}
+	transforms := []interfaces.AppFunction{
+		transforms.NewResponseData().SetResponseData,
+	}
+
+	target.SetDefaultFunctionsPipeline(transforms)
+	err := target.AddFunctionsPipeline(id1, topics, transforms)
+	require.NoError(t, err)
+	err = target.AddFunctionsPipeline(id2, topics, transforms)
+	require.NoError(t, err)
+
+	pipeline := target.GetDefaultPipeline()
+	require.NotNil(t, pipeline)
+	pipeline = target.GetPipelineById(id1)
+	require.NotNil(t, pipeline)
+	pipeline = target.GetPipelineById(id2)
+	require.NotNil(t, pipeline)
+
+	target.RemoveAllFunctionPipelines()
+
+	pipeline = target.GetDefaultPipeline()
+	require.Nil(t, pipeline.Transforms)
+	pipeline = target.GetPipelineById(id1)
+	assert.Nil(t, pipeline)
+	pipeline = target.GetPipelineById(id2)
+	assert.Nil(t, pipeline)
+}

--- a/internal/runtime/storeforward_test.go
+++ b/internal/runtime/storeforward_test.go
@@ -52,6 +52,7 @@ func TestMain(m *testing.M) {
 
 	mockMetricsManager := &mocks2.MetricsManager{}
 	mockMetricsManager.On("Register", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockMetricsManager.On("Unregister", mock.Anything)
 
 	dic = di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {

--- a/pkg/interfaces/mocks/ApplicationService.go
+++ b/pkg/interfaces/mocks/ApplicationService.go
@@ -485,6 +485,11 @@ func (_m *ApplicationService) RegistryClient() registry.Client {
 	return r0
 }
 
+// RemoveAllFunctionPipelines provides a mock function with given fields:
+func (_m *ApplicationService) RemoveAllFunctionPipelines() {
+	_m.Called()
+}
+
 // RequestTimeout provides a mock function with given fields:
 func (_m *ApplicationService) RequestTimeout() time.Duration {
 	ret := _m.Called()

--- a/pkg/interfaces/service.go
+++ b/pkg/interfaces/service.go
@@ -104,6 +104,8 @@ type ApplicationService interface {
 	// so that it matches multiple incoming topics. If just "#" is used for the specified topic it will match all incoming
 	// topics and the specified functions pipeline will execute on every message received.
 	AddFunctionsPipelineForTopics(id string, topic []string, transforms ...AppFunction) error
+	// RemoveAllFunctionPipelines removes all existing function pipelines
+	RemoveAllFunctionPipelines()
 	// MakeItRun starts the configured trigger to allow the functions pipeline to execute when the trigger
 	// receives data and starts the internal webserver. This is a long running function which does not return until
 	// the service is stopped or MakeItStop() is called.


### PR DESCRIPTION
We are developing an application-service without Consul, but we also want to configure the pipelines dynamically according to a local file or other system(such as k8s configmap). We expect to expose the Set and Clear operation of pipelines so that achieving our goals.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions
Just use unit tests is ok.
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->