### PR TITLE
build: Disable CGO for all docker builds so always work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,13 @@ ARCH=$(shell uname -m)
 
 .PHONY: test
 
-GO=go
-
 GOTESTFLAGS?=-race
 
 build:
 	make -C ./app-service-template build
+
+docker:
+	make -C ./app-service-template docker
 
 lint:
 	@which golangci-lint >/dev/null || echo "WARNING: go linter not installed. To install, run\n  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b \$$(go env GOPATH)/bin v1.46.2"
@@ -36,10 +37,10 @@ test-template:
 	make -C ./app-service-template test
 
 test-sdk:
-	$(GO) test $(GOTESTFLAGS) -coverprofile=coverage.out ./...
+	go test $(GOTESTFLAGS) -coverprofile=coverage.out ./...
 
 vet:
-	$(GO) vet ./...
+	go vet ./...
 
 fmt:
 	gofmt -l $$(find . -type f -name '*.go'| grep -v "/vendor/")
@@ -49,4 +50,4 @@ test: build test-template test-sdk vet fmt lint
 
 vendor:
 	make -C ./app-service-template vendor
-	$(GO) mod vendor
+	go mod vendor

--- a/app-service-template/Makefile
+++ b/app-service-template/Makefile
@@ -16,8 +16,6 @@
 
 .PHONY: build test clean docker
 
-GO=go
-
 GOTESTFLAGS?=-race
 
 # VERSION file is not needed for local development, In the CI/CD pipeline, a temporary VERSION file is written
@@ -38,8 +36,10 @@ GOFLAGS=-ldflags "-X github.com/edgexfoundry/app-functions-sdk-go/v3/internal.SD
 #GIT_SHA=$(shell git rev-parse HEAD)
 GIT_SHA=no-sha
 
+# CGO is enabled by default and causes docker builds to fail due to no gcc,
+# but is required for test with -race, so must disable it for the builds only
 build: tidy
-	$(GO) build $(GOFLAGS) -o $(MICROSERVICE)
+	CGO_ENABLED=0 go build $(GOFLAGS) -o $(MICROSERVICE)
 
 tidy:
 	go mod tidy
@@ -61,8 +61,8 @@ docker:
 # The test-attribution-txt.sh scripts are required for upstreaming to EdgeX Foundry.
 # TODO: Remove bin folder and reference to script below if NOT upstreaming to EdgeX Foundry.
 test:
-	$(GO) test $(GOTESTFLAGS) -coverprofile=coverage.out ./...
-	$(GO) vet ./...
+	go test $(GOTESTFLAGS) -coverprofile=coverage.out ./...
+	go vet ./...
 	gofmt -l $$(find . -type f -name '*.go'| grep -v "/vendor/")
 	[ "`gofmt -l $$(find . -type f -name '*.go'| grep -v "/vendor/")`" = "" ]
 	./bin/test-attribution-txt.sh
@@ -71,4 +71,4 @@ clean:
 	rm -f $(MICROSERVICE)
 
 vendor:
-	$(GO) mod vendor
+	go mod vendor

--- a/app-service-template/go.mod
+++ b/app-service-template/go.mod
@@ -4,10 +4,12 @@ module app-new-service
 
 go 1.18
 
+// To build local docker image of the template App you must
+// comment out this replace statement and update the SDK version to latest
 replace github.com/edgexfoundry/app-functions-sdk-go/v3 => ../
 
 require (
-	github.com/edgexfoundry/app-functions-sdk-go/v3 v3.0.0
+	github.com/edgexfoundry/app-functions-sdk-go/v3 v3.0.0-dev.9
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.2
 	github.com/google/uuid v1.3.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475


### PR DESCRIPTION
Docker builds were failing localy, but not in pipeline.

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) **N/A**
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
      <link to docs PR>

## Testing Instructions
cd app-template
run `make docker`
Verify builds successfully

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->