### PR TITLE
refactor(sdk): remove deprecated StoreSecret code

### DIFF
--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -575,12 +575,6 @@ func (svc *Service) ListenForCustomConfigChanges(configToWatch interface{}, sect
 	return nil
 }
 
-// StoreSecret stores the secret data to a secret store at the specified path.
-func (svc *Service) StoreSecret(path string, secretData map[string]string) error {
-	secretProvider := bootstrapContainer.SecretProviderFrom(svc.dic.Get)
-	return secretProvider.StoreSecret(path, secretData)
-}
-
 // SecretProvider returns the SecretProvider instance
 func (svc *Service) SecretProvider() bootstrapInterfaces.SecretProvider {
 	secretProvider := bootstrapContainer.SecretProviderFrom(svc.dic.Get)

--- a/pkg/interfaces/mocks/ApplicationService.go
+++ b/pkg/interfaces/mocks/ApplicationService.go
@@ -487,20 +487,6 @@ func (_m *ApplicationService) SetDefaultFunctionsPipeline(transforms ...func(int
 	return r0
 }
 
-// StoreSecret provides a mock function with given fields: path, secretData
-func (_m *ApplicationService) StoreSecret(path string, secretData map[string]string) error {
-	ret := _m.Called(path, secretData)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, map[string]string) error); ok {
-		r0 = rf(path, secretData)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // SubscriptionClient provides a mock function with given fields:
 func (_m *ApplicationService) SubscriptionClient() clientsinterfaces.SubscriptionClient {
 	ret := _m.Called()

--- a/pkg/interfaces/service.go
+++ b/pkg/interfaces/service.go
@@ -124,13 +124,6 @@ type ApplicationService interface {
 	// asynchronously to the Edgex MessageBus on the specified topic.
 	// Not valid for use with the HTTP or External MQTT triggers
 	AddBackgroundPublisherWithTopic(capacity int, topic string) (BackgroundPublisher, error)
-	// StoreSecret stores the specified secret data into the secret store (secure only) for the specified path
-	// An error is returned if:
-	//   - Specified secret data is empty
-	//   - Not using the secure secret store, i.e. not valid with InsecureSecrets configuration
-	//   - Secure secret provider is not properly initialized
-	//   - Connection issues with Secret Store service.
-	StoreSecret(path string, secretData map[string]string) error // LoggingClient returns the Logger client
 	// SecretProvider returns the SecretProvider instance
 	SecretProvider() bootstrapInterfaces.SecretProvider
 	// LoggingClient returns the Logger client


### PR DESCRIPTION
BREAKING CHANGE: remove deprecated StoreSecret code, use SecretProvider

Closes: #1224

Signed-off-by: Marc-Philippe Fuller <marc-philippe.fuller@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) N/A
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      https://github.com/edgexfoundry/edgex-docs/pull/929

## Testing Instructions
make test 

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->