### PR TITLE
refactor(sdk): remove deprecated NewTags() factory method and rename …

### DIFF
--- a/internal/app/configurable.go
+++ b/internal/app/configurable.go
@@ -666,7 +666,7 @@ func (app *Configurable) AddTags(parameters map[string]string) interfaces.AppFun
 		return nil
 	}
 
-	transform := transforms.NewGenericTags(tags)
+	transform := transforms.NewTags(tags)
 	return transform.AddTags
 }
 

--- a/pkg/transforms/tags.go
+++ b/pkg/transforms/tags.go
@@ -29,22 +29,8 @@ type Tags struct {
 	tags map[string]interface{}
 }
 
-// NewTags creates, initializes and returns a new instance of Tags using string values
-// This factory method is Deprecated. Use NewGenericTags which allows generic interface values
-func NewTags(tags map[string]string) Tags {
-	newTags := Tags{
-		tags: make(map[string]interface{}),
-	}
-
-	for tag, value := range tags {
-		newTags.tags[tag] = value
-	}
-
-	return newTags
-}
-
 // NewGenericTags creates, initializes and returns a new instance of Tags using generic interface values
-func NewGenericTags(tags map[string]interface{}) Tags {
+func NewTags(tags map[string]interface{}) Tags {
 	return Tags{
 		tags: tags,
 	}

--- a/pkg/transforms/tags.go
+++ b/pkg/transforms/tags.go
@@ -29,7 +29,7 @@ type Tags struct {
 	tags map[string]interface{}
 }
 
-// NewGenericTags creates, initializes and returns a new instance of Tags using generic interface values
+// NewTags creates, initializes and returns a new instance of Tags using generic interface values
 func NewTags(tags map[string]interface{}) Tags {
 	return Tags{
 		tags: tags,

--- a/pkg/transforms/tags_test.go
+++ b/pkg/transforms/tags_test.go
@@ -25,31 +25,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var stringTagsToAdd = map[string]interface{}{
-	"GatewayId": "HoustonStore000123",
-	"Latitude":  "29.630771",
-	"Longitude": "-95.377603",
+var coordinates = map[string]float32{
+	"Latitude":  29.630771,
+	"Longitude": -95.377603,
 }
 
-var expectedStringTags = map[string]interface{}{
-	"GatewayId": "HoustonStore000123",
-	"Latitude":  "29.630771",
-	"Longitude": "-95.377603",
+var TagsToAdd = map[string]interface{}{
+	"GatewayId":   "HoustonStore000123",
+	"Coordinates": coordinates,
+}
+
+var allTagsAdded = map[string]interface{}{
+	"Tag1":        1,
+	"Tag2":        2,
+	"GatewayId":   "HoustonStore000123",
+	"Coordinates": coordinates,
 }
 
 var eventWithExistingTags = dtos.Event{
 	Tags: map[string]interface{}{
-		"Tag1": "1",
-		"Tag2": "2",
+		"Tag1": 1,
+		"Tag2": 2,
 	},
-}
-
-var expectedAllStringTagsAdded = map[string]interface{}{
-	"Tag1":      "1",
-	"Tag2":      "2",
-	"GatewayId": "HoustonStore000123",
-	"Latitude":  "29.630771",
-	"Longitude": "-95.377603",
 }
 
 func TestTags_AddTags(t *testing.T) {
@@ -61,78 +58,9 @@ func TestTags_AddTags(t *testing.T) {
 		ErrorExpected bool
 		ErrorContains string
 	}{
-		{"Happy path - no existing Event tags", dtos.Event{}, stringTagsToAdd, expectedStringTags, false, ""},
-		{"Happy path - Event has existing tags", eventWithExistingTags, stringTagsToAdd, expectedAllStringTagsAdded, false, ""},
+		{"Happy path - no existing Event tags", dtos.Event{}, TagsToAdd, TagsToAdd, false, ""},
+		{"Happy path - Event has existing tags", eventWithExistingTags, TagsToAdd, allTagsAdded, false, ""},
 		{"Happy path - No tags added", eventWithExistingTags, map[string]interface{}{}, eventWithExistingTags.Tags, false, ""},
-		{"Error - No data", nil, nil, nil, true, "No Data Received"},
-		{"Error - Input not event", "Not an Event", nil, nil, true, "type received is not an Event"},
-	}
-
-	for _, testCase := range tests {
-		t.Run(testCase.Name, func(t *testing.T) {
-			var continuePipeline bool
-			var result interface{}
-
-			target := NewTags(testCase.TagsToAdd)
-
-			if testCase.FunctionInput != nil {
-				continuePipeline, result = target.AddTags(ctx, testCase.FunctionInput)
-			} else {
-				continuePipeline, result = target.AddTags(ctx, nil)
-			}
-
-			if testCase.ErrorExpected {
-				err := result.(error)
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), testCase.ErrorContains)
-				require.False(t, continuePipeline)
-				return // Test completed
-			}
-
-			assert.True(t, continuePipeline)
-			actual, ok := result.(dtos.Event)
-			require.True(t, ok, "Result not an Event")
-			assert.Equal(t, testCase.Expected, actual.Tags)
-		})
-	}
-}
-
-var coordinates = map[string]float32{
-	"Latitude":  29.630771,
-	"Longitude": -95.377603,
-}
-
-var genericTagsToAdd = map[string]interface{}{
-	"GatewayId":   "HoustonStore000123",
-	"Coordinates": coordinates,
-}
-
-var allGenericTagsAdded = map[string]interface{}{
-	"Tag1":        1,
-	"Tag2":        2,
-	"GatewayId":   "HoustonStore000123",
-	"Coordinates": coordinates,
-}
-
-var eventWithExistingGenericTags = dtos.Event{
-	Tags: map[string]interface{}{
-		"Tag1": 1,
-		"Tag2": 2,
-	},
-}
-
-func TestTags_AddGenericTags(t *testing.T) {
-	tests := []struct {
-		Name          string
-		FunctionInput interface{}
-		TagsToAdd     map[string]interface{}
-		Expected      map[string]interface{}
-		ErrorExpected bool
-		ErrorContains string
-	}{
-		{"Happy path - no existing Event tags", dtos.Event{}, genericTagsToAdd, genericTagsToAdd, false, ""},
-		{"Happy path - Event has existing tags", eventWithExistingGenericTags, genericTagsToAdd, allGenericTagsAdded, false, ""},
-		{"Happy path - No tags added", eventWithExistingGenericTags, map[string]interface{}{}, eventWithExistingGenericTags.Tags, false, ""},
 		{"Error - No data", nil, nil, nil, true, "No Data Received"},
 		{"Error - Input not event", "Not an Event", nil, nil, true, "type received is not an Event"},
 	}

--- a/pkg/transforms/tags_test.go
+++ b/pkg/transforms/tags_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var stringTagsToAdd = map[string]string{
+var stringTagsToAdd = map[string]interface{}{
 	"GatewayId": "HoustonStore000123",
 	"Latitude":  "29.630771",
 	"Longitude": "-95.377603",
@@ -56,14 +56,14 @@ func TestTags_AddTags(t *testing.T) {
 	tests := []struct {
 		Name          string
 		FunctionInput interface{}
-		TagsToAdd     map[string]string
+		TagsToAdd     map[string]interface{}
 		Expected      map[string]interface{}
 		ErrorExpected bool
 		ErrorContains string
 	}{
 		{"Happy path - no existing Event tags", dtos.Event{}, stringTagsToAdd, expectedStringTags, false, ""},
 		{"Happy path - Event has existing tags", eventWithExistingTags, stringTagsToAdd, expectedAllStringTagsAdded, false, ""},
-		{"Happy path - No tags added", eventWithExistingTags, map[string]string{}, eventWithExistingTags.Tags, false, ""},
+		{"Happy path - No tags added", eventWithExistingTags, map[string]interface{}{}, eventWithExistingTags.Tags, false, ""},
 		{"Error - No data", nil, nil, nil, true, "No Data Received"},
 		{"Error - Input not event", "Not an Event", nil, nil, true, "type received is not an Event"},
 	}
@@ -142,7 +142,7 @@ func TestTags_AddGenericTags(t *testing.T) {
 			var continuePipeline bool
 			var result interface{}
 
-			target := NewGenericTags(testCase.TagsToAdd)
+			target := NewTags(testCase.TagsToAdd)
 
 			if testCase.FunctionInput != nil {
 				continuePipeline, result = target.AddTags(ctx, testCase.FunctionInput)


### PR DESCRIPTION
…NewGenericTags to NewTags

BREAKING CHANGE: remove deprecated NewTags() factory method and rename NewGenericTags() to NewTags

Closes: #1225
Signed-off-by: Marc-Philippe Fuller <marc-philippe.fuller@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      https://github.com/edgexfoundry/edgex-docs/pull/933

## Testing Instructions
`make test`

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->