### PR TITLE
fix: correct the metric name  that is registered

### DIFF
--- a/pkg/transforms/http.go
+++ b/pkg/transforms/http.go
@@ -221,7 +221,7 @@ func (sender *HTTPSender) httpSend(ctx interfaces.AppFunctionContext, data inter
 		sender.httpSizeMetrics = gometrics.NewHistogram(gometrics.NewUniformSample(internal.MetricsReservoirSize))
 		metricsManger := ctx.MetricsManager()
 		if metricsManger != nil {
-			metricName := fmt.Sprintf("%s-%s", internal.MqttExportSizeName, sender.url)
+			metricName := fmt.Sprintf("%s-%s", internal.HttpExportSizeName, sender.url)
 
 			err = metricsManger.Register(metricName, sender.httpSizeMetrics, map[string]string{"url": sender.url})
 		} else {


### PR DESCRIPTION
closes: #1266

Signed-off-by: Marc-Philippe Fuller <marc-philippe.fuller@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions
`cd edgex-compose/compose-builder`
`make run no-secty ds-virtual`

`cd app-service-configurable`
./app-service-configurable  -p functional-test
--> open new terminal
`./app-service-configurable  -p sample  -cp`
change httpExport  url in consul to Http://localhost:59705/api/v2/trigger
changed execution order in consul to HTTPExport
 verified that metric for HTTPExport was reported

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->