### PR TITLE
refactor(sdk): implement error interface for MessageError

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -82,6 +82,10 @@ type MessageError struct {
 	ErrorCode int
 }
 
+func (merr *MessageError) Error() string {
+	return merr.Err.Error()
+}
+
 // NewFunctionPipelineRuntime creates and initializes the AppServiceRuntime instance
 func NewFunctionPipelineRuntime(serviceKey string, targetType interface{}, dic *di.Container) *FunctionsPipelineRuntime {
 	fpr := &FunctionsPipelineRuntime{

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -268,7 +268,6 @@ func TestProcessMessageTransformError(t *testing.T) {
 
 	msgErr := runtime.ProcessMessage(context, messageData, runtime.GetDefaultPipeline())
 
-	require.NotNil(t, msgErr, "Expected an error")
 	require.Error(t, msgErr, "Expected an error")
 	assert.Contains(t, msgErr.Error(), expectedError)
 	assert.Equal(t, expectedErrorCode, msgErr.ErrorCode)
@@ -448,7 +447,6 @@ func TestDecode_Process_MessageTargetType(t *testing.T) {
 
 			targetData, err, _ := runtime.DecodeMessage(context, envelope)
 			if currentTest.ErrorExpected {
-				assert.NotNil(t, err, fmt.Sprintf("expected an error for test '%s'", currentTest.Name))
 				assert.Error(t, err, fmt.Sprintf("expected an error for test '%s'", currentTest.Name))
 				return
 			} else {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -269,8 +269,8 @@ func TestProcessMessageTransformError(t *testing.T) {
 	msgErr := runtime.ProcessMessage(context, messageData, runtime.GetDefaultPipeline())
 
 	require.NotNil(t, msgErr, "Expected an error")
-	require.Error(t, msgErr.Err, "Expected an error")
-	assert.Contains(t, msgErr.Err.Error(), expectedError)
+	require.Error(t, msgErr, "Expected an error")
+	assert.Contains(t, msgErr.Error(), expectedError)
 	assert.Equal(t, expectedErrorCode, msgErr.ErrorCode)
 
 	assertReceivedTopicSet(t, context, envelope)
@@ -449,7 +449,7 @@ func TestDecode_Process_MessageTargetType(t *testing.T) {
 			targetData, err, _ := runtime.DecodeMessage(context, envelope)
 			if currentTest.ErrorExpected {
 				assert.NotNil(t, err, fmt.Sprintf("expected an error for test '%s'", currentTest.Name))
-				assert.Error(t, err.Err, fmt.Sprintf("expected an error for test '%s'", currentTest.Name))
+				assert.Error(t, err, fmt.Sprintf("expected an error for test '%s'", currentTest.Name))
 				return
 			} else {
 				require.Nil(t, err, fmt.Sprintf("unexpected error for test '%s'", currentTest.Name))


### PR DESCRIPTION
Closes: #1125

Signed-off-by: Marc-Philippe Fuller <marc-philippe.fuller@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions
`make test`

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->