### PR TITLE
refactor(sdk): Refactor Target Type flags for configurable functions …

### DIFF
--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -120,11 +120,8 @@ type PipelineInfo struct {
 	ExecutionOrder string
 	// PerTopicPipelines is a collection of pipelines that only execute if the incoming topic matched the pipelines configured topic
 	PerTopicPipelines map[string]TopicPipeline
-	// UseTargetTypeOfByteArray indicates if raw []byte type is to be used for the TargetType
-	UseTargetTypeOfByteArray bool
-	// TODO: for 3.0 rework this to be a single TargetType with empty, "raw" and "metric" as to allowed values
-	// UseTargetTypeOfMetric indicates the Dtos.Metric is to be used for the TargetType
-	UseTargetTypeOfMetric bool
+	// TargetType indicates if raw, []byte type, or metric, Dtos.Metric, is to be used for the TargetType
+	TargetType string
 	// Functions is a collection of pipeline functions with configured parameters to be used in the ExecutionOrder of one
 	// of the configured pipelines (default or pre topic)
 	Functions map[string]PipelineFunction


### PR DESCRIPTION
…pipeline

BREAKING CHANGE: UseTargetTypeOfByteArray and UseTargetTypeOfMetric has been replaced, use TargetType this takes string inputs: raw, metric or event

closes: #1267

Signed-off-by: Marc-Philippe Fuller <marc-philippe.fuller@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
      TBD

## Testing Instructions

1. `make test`
2. `cd /app-service-configurable/res`
3. update app-service-configurable profile configs to use target time
4. `cd ..`
5. add `replace github.com/edgexfoundry/app-functions-sdk-go/v3 => ../app-functions-sdk-go tp`  to go.mod in app-service-configurable
6. `cd /edgex-compose-compose-builder`
7. `make run no-secty ds-virtual`
8. `cd /app-service-configurable`
9. Run cmd for each profile `./app-service-configurable -p {profile_name} -s`
10.  verify pipeline is successfully working

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->