### PR TITLE
feat!: Prepend base topic to all topics

### DIFF
--- a/app-service-template/main.go
+++ b/app-service-template/main.go
@@ -27,7 +27,6 @@ import (
 	"github.com/edgexfoundry/app-functions-sdk-go/v3/pkg"
 	"github.com/edgexfoundry/app-functions-sdk-go/v3/pkg/interfaces"
 	"github.com/edgexfoundry/app-functions-sdk-go/v3/pkg/transforms"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 )
 
@@ -105,7 +104,6 @@ func (app *myApp) CreateAndRunAppService(serviceKey string, newServiceFactory fu
 	err = app.service.SetDefaultFunctionsPipeline(
 		transforms.NewFilterFor(deviceNames).FilterByDeviceName,
 		sample.LogEventDetails,
-		sample.SendGetCommand,
 		sample.ConvertEventToXML,
 		sample.OutputXML)
 	if err != nil {
@@ -122,8 +120,7 @@ func (app *myApp) CreateAndRunAppService(serviceKey string, newServiceFactory fu
 	// Note: This example with default above causes Events from Random-Float-Device device to be processed twice
 	//       resulting in the XML to be published back to the MessageBus twice.
 	// See https://docs.edgexfoundry.org/latest/microservices/application/AdvancedTopics/#pipeline-per-topics for more details.
-	err = app.service.AddFunctionsPipelineForTopics("Floats", []string{"edgex/events/+/device-virtual/+/Random-Float-Device/#"},
-		transforms.NewFilterFor(deviceNames).FilterByDeviceName,
+	err = app.service.AddFunctionsPipelineForTopics("Floats", []string{"events/device/device-virtual/+/Random-Float-Device/#"},
 		sample.LogEventDetails,
 		sample.ConvertEventToXML,
 		sample.OutputXML)
@@ -133,9 +130,9 @@ func (app *myApp) CreateAndRunAppService(serviceKey string, newServiceFactory fu
 	}
 	// Note: This example with default above causes Events from Int32 source to be processed twice
 	//       resulting in the XML to be published back to the MessageBus twice.
-	err = app.service.AddFunctionsPipelineForTopics("Int32s", []string{"edgex/events/+/device-virtual/+/+/Int32"},
-		transforms.NewFilterFor(deviceNames).FilterByDeviceName,
+	err = app.service.AddFunctionsPipelineForTopics("Int32s", []string{"events/device/device-virtual/+/+/Int32"},
 		sample.LogEventDetails,
+		sample.SendGetCommand,
 		sample.ConvertEventToXML,
 		sample.OutputXML)
 	if err != nil {

--- a/app-service-template/res/configuration.toml
+++ b/app-service-template/res/configuration.toml
@@ -59,10 +59,9 @@ Disabled = false  # TODO: set to true if not using edgex-messagebus Trigger belo
   ClientId ="app-new-service"
 
 [Trigger]
-# Note that the MessaegBus connection above is used by edgex-messagebus trigger
-Type="edgex-messagebus"
-SubscribeTopics = "edgex/events/#"
-PublishTopic="event-xml"
+# Note that the MessageBus connection above is used by edgex-messagebus trigger which is the default set in common config
+# Default value for SubscribeTopics is aslo set in common config
+PublishTopic="event-xml"  # Base topic is prepened to this topic when using edgex-messagebus
 
 # TODO: Add custom settings needed by your app service or remove if you don't have any settings.
 # This can be any Key/Value pair you need.

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Intel Corporation
+// Copyright (c) 2023 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -130,6 +130,8 @@ func TestAddBackgroundPublisherMessageBus(t *testing.T) {
 		},
 	}
 
+	expectedPublishTopic := "edgex/topic"
+
 	p, err := sdk.AddBackgroundPublisher(1)
 
 	require.NoError(t, err)
@@ -142,7 +144,7 @@ func TestAddBackgroundPublisherMessageBus(t *testing.T) {
 
 	require.NotNil(t, pub.output, "publisher should have an output channel set")
 	require.NotNil(t, sdk.backgroundPublishChannel, "svc should have a background channel set for passing to trigger initialization")
-	require.Equal(t, sdk.config.Trigger.PublishTopic, pub.topic)
+	require.Equal(t, expectedPublishTopic, pub.topic)
 
 	// compare addresses since types will not match
 	assert.Equal(t, fmt.Sprintf("%p", sdk.backgroundPublishChannel), fmt.Sprintf("%p", pub.output),
@@ -159,6 +161,8 @@ func TestAddBackgroundPublisher_Arbitrary(t *testing.T) {
 		},
 	}
 
+	expectedPublishTopic := "edgex/topic"
+
 	p, err := sdk.AddBackgroundPublisher(1)
 
 	require.NoError(t, err)
@@ -171,7 +175,7 @@ func TestAddBackgroundPublisher_Arbitrary(t *testing.T) {
 
 	require.NotNil(t, pub.output, "publisher should have an output channel set")
 	require.NotNil(t, sdk.backgroundPublishChannel, "svc should have a background channel set for passing to trigger initialization")
-	require.Equal(t, sdk.config.Trigger.PublishTopic, pub.topic)
+	require.Equal(t, expectedPublishTopic, pub.topic)
 
 	// compare addresses since types will not match
 	assert.Equal(t, fmt.Sprintf("%p", sdk.backgroundPublishChannel), fmt.Sprintf("%p", pub.output),
@@ -185,6 +189,8 @@ func TestAddBackgroundPublisher_Custom_Topic(t *testing.T) {
 
 	p, err := sdk.AddBackgroundPublisherWithTopic(1, topic)
 
+	expectedPublishTopic := "edgex/" + topic
+
 	require.NoError(t, err)
 
 	pub, ok := p.(*backgroundPublisher)
@@ -195,7 +201,7 @@ func TestAddBackgroundPublisher_Custom_Topic(t *testing.T) {
 
 	require.NotNil(t, pub.output, "publisher should have an output channel set")
 	require.NotNil(t, sdk.backgroundPublishChannel, "svc should have a background channel set for passing to trigger initialization")
-	require.Equal(t, topic, pub.topic)
+	require.Equal(t, expectedPublishTopic, pub.topic)
 
 	// compare addresses since types will not match
 	assert.Equal(t, fmt.Sprintf("%p", sdk.backgroundPublishChannel), fmt.Sprintf("%p", pub.output),

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -133,9 +133,9 @@ func (fpr *FunctionsPipelineRuntime) SetFunctionsPipelineTopics(id string, topic
 		fpr.isBusyCopying.Lock()
 		pipeline.Topics = topics
 		fpr.isBusyCopying.Unlock()
-		fpr.lc.Infof("Topics set for `%s` pipeline", id)
+		fpr.lc.Infof("Topics '%v' set for `%s` pipeline", topics, id)
 	} else {
-		fpr.lc.Warnf("Unable to set topica for `%s` pipeline: Pipeline not found", id)
+		fpr.lc.Warnf("Unable to set topic for `%s` pipeline: Pipeline not found", id)
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -645,6 +645,10 @@ func TestGetMatchingPipelines(t *testing.T) {
 	require.NoError(t, err)
 	err = target.AddFunctionsPipeline("three", []string{"edgex/events/P1/D1/S1"}, expectedTransforms)
 	require.NoError(t, err)
+	err = target.AddFunctionsPipeline("four", []string{"edgex/events/device/device-virtual/+/Random-Float-Device/#"}, expectedTransforms)
+	require.NoError(t, err)
+	err = target.AddFunctionsPipeline("five", []string{"edgex/events/device/device-virtual/+/+/Int32"}, expectedTransforms)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name          string
@@ -655,6 +659,8 @@ func TestGetMatchingPipelines(t *testing.T) {
 		{"Match 2", "edgex/events/P1/D1/S2", 2},
 		{"Match 1", "edgex/events/P2/D1/S2", 1},
 		{"Match 0", "edgex/events/P2/D2/S2", 0},
+		{"Match 1", "edgex/events/device/device-virtual/Random-Float-Device/Random-Float-Device/Float32", 1},
+		{"Match 1", "edgex/events/device/device-virtual/Random-Integer-Device/Random-Integer-Device/Int32", 1},
 	}
 
 	for _, test := range tests {

--- a/internal/trigger/messagebus/messaging_test.go
+++ b/internal/trigger/messagebus/messaging_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Intel Corporation
+// Copyright (c) 2023 Intel Corporation
 // Copyright (c) 2021 One Track Consulting
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -89,7 +89,7 @@ func TestInitialize(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, trigger.client, "Expected client to be set")
 	assert.Equal(t, 1, len(trigger.topics))
-	assert.Equal(t, "events", trigger.topics[0].Topic)
+	assert.Equal(t, "edgex/events", trigger.topics[0].Topic)
 	assert.NotNil(t, trigger.topics[0].Messages)
 }
 


### PR DESCRIPTION
BREAKING CHANGE: All subcribe and publish topics now have the configured base topic (`edgex/` by default) prepened automatically. Configured topics and topics in code need to have "edgex/" removed.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?) 
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions
Run non-secure edgex with Device Virtual and mqtt-broker
Build App Template from this branch
Run `./app-new-service -cp` with DEBUG logging
Verify the following are in the log message and `edgex` isn't duplicated in the topics logged.
```
msg="Pipeline 'Floats' added for topics '[edgex/events/+/device-virtual/+/Random-Float-Device/#]' with 4 transform(s)"
msg="Pipeline 'Int32s' added for topics '[edgex/events/+/device-virtual/+/+/Int32]' with 4 transform(s)"
msg="Subscribing to topic: edgex/events/#"
msg="Publishing to topic: edgex/event-xml"
msg="Waiting for messages from the MessageBus on the 'edgex/events/#' topic"
```
Verify data from Device Virtual is flowing. Ignore timeout errors on commands.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->