### PR TITLE
fix(webserver): fix a nil pointer crash when enabling the https web server

### DIFF
--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -156,6 +156,7 @@ func (webserver *WebServer) listenAndServe(serviceTimeout time.Duration, errChan
 			return
 		}
 
+		// ListenAndServeTLS below takes filenames for the certificate and key but the raw data is coming from Vault, so must generate the tlsConfig from raw data first.
 		tlsConfig, err := webserver.generateTLSConfig([]byte(httpsCert), []byte(httpsKey))
 		if err != nil {
 			lc.Errorf("unable to generate a TLS configuration.", err)
@@ -171,7 +172,7 @@ func (webserver *WebServer) listenAndServe(serviceTimeout time.Duration, errChan
 
 		lc.Infof("Starting HTTPS Web Server on address %s", addr)
 
-		// ListenAndServeTLS requires filenames for the certificate and key but the raw data is coming from Vault
+		// ListenAndServeTLS takes filenames for the certificate and key but the raw data is coming from Vault
 		// empty strings will make the server use the certificate and key from tls.Config{}
 		errChannel <- svr.ListenAndServeTLS("", "")
 	} else {

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -17,6 +17,7 @@
 package webserver
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"time"
@@ -59,6 +60,7 @@ func NewWebServer(dic *di.Container, router *mux.Router, serviceName string) *We
 		config:     container.ConfigurationFrom(dic.Get),
 		router:     router,
 		controller: rest.NewController(router, dic, serviceName),
+		dic:        dic,
 	}
 
 	return ws
@@ -154,11 +156,35 @@ func (webserver *WebServer) listenAndServe(serviceTimeout time.Duration, errChan
 			return
 		}
 
+		tlsConfig, err := webserver.generateTLSConfig([]byte(httpsCert), []byte(httpsKey))
+		if err != nil {
+			lc.Errorf("unable to generate a TLS configuration.", err)
+			errChannel <- err
+			return
+		}
+
+		svr := &http.Server{
+			Addr:      addr,
+			Handler:   http.TimeoutHandler(webserver.router, serviceTimeout, "Request timed out"),
+			TLSConfig: tlsConfig,
+		}
+
 		lc.Infof("Starting HTTPS Web Server on address %s", addr)
 
-		errChannel <- http.ListenAndServeTLS(addr, httpsCert, httpsKey, http.TimeoutHandler(webserver.router, serviceTimeout, "Request timed out"))
+		// ListenAndServeTLS requires filenames for the certificate and key but the raw data is coming from Vault
+		// empty strings will make the server use the certificate and key from tls.Config{}
+		errChannel <- svr.ListenAndServeTLS("", "")
 	} else {
 		lc.Infof("Starting HTTP Web Server on address %s", addr)
 		errChannel <- http.ListenAndServe(addr, http.TimeoutHandler(webserver.router, serviceTimeout, "Request timed out"))
 	}
+}
+
+func (webserver *WebServer) generateTLSConfig(httpsCert, httpsKey []byte) (*tls.Config, error) {
+	cert, err := tls.X509KeyPair(httpsCert, httpsKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{Certificates: []tls.Certificate{cert}}, nil
 }

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -186,5 +186,10 @@ func (webserver *WebServer) generateTLSConfig(httpsCert, httpsKey []byte) (*tls.
 		return nil, err
 	}
 
-	return &tls.Config{Certificates: []tls.Certificate{cert}}, nil
+	config := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	return config, nil
 }


### PR DESCRIPTION
When enabling HTTPS, the web server would try to use dic, but it was never set in the` NewWebServer()` function. This would result in a nil pointer panic when trying to access Vault.

Also, a tls.Config was created because `ListenAndServeTLS` requires the filename and path of a certificate and key but the raw certificate and key data was retrieved from Vault. Leaving the cert and key as empty strings uses the certificate in tls.Config.

Fixes: #1315

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) There is no unit tests for HTTPS web server.
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Setup a HTTPS web server following this [documentation.](https://docs.edgexfoundry.org/2.3/microservices/application/GeneralAppServiceConfig/#not-writable)

2. Store the certificate and private key in Vault for the new service.

3. Start your service.

4. Use curl to test the HTTPS communication: `curl -k https://localhost:{port}/api/v2/ping`

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->