### PR TITLE
fix: Make Compression functions thread safe

### DIFF
--- a/pkg/transforms/compression.go
+++ b/pkg/transforms/compression.go
@@ -55,6 +55,12 @@ func (compression *Compression) CompressWithGZIP(ctx interfaces.AppFunctionConte
 	var buf bytes.Buffer
 
 	gzipWriter := gzip.NewWriter(&buf)
+	defer func() {
+		defer func() {
+			// make sure writer is closed if error occurred before close is called below
+			_ = gzipWriter.Close()
+		}()
+	}()
 
 	_, err = gzipWriter.Write(rawData)
 	if err != nil {
@@ -87,6 +93,12 @@ func (compression *Compression) CompressWithZLIB(ctx interfaces.AppFunctionConte
 	var buf bytes.Buffer
 
 	zlibWriter := zlib.NewWriter(&buf)
+	defer func() {
+		defer func() {
+			// make sure writer is closed if error occurred before close is called below
+			_ = zlibWriter.Close()
+		}()
+	}()
 
 	_, err = zlibWriter.Write(byteData)
 	if err != nil {

--- a/pkg/transforms/compression.go
+++ b/pkg/transforms/compression.go
@@ -56,10 +56,8 @@ func (compression *Compression) CompressWithGZIP(ctx interfaces.AppFunctionConte
 
 	gzipWriter := gzip.NewWriter(&buf)
 	defer func() {
-		defer func() {
-			// make sure writer is closed if error occurred before close is called below
-			_ = gzipWriter.Close()
-		}()
+		// make sure writer is closed if error occurred before close is called below
+		_ = gzipWriter.Close()
 	}()
 
 	_, err = gzipWriter.Write(rawData)
@@ -94,10 +92,8 @@ func (compression *Compression) CompressWithZLIB(ctx interfaces.AppFunctionConte
 
 	zlibWriter := zlib.NewWriter(&buf)
 	defer func() {
-		defer func() {
-			// make sure writer is closed if error occurred before close is called below
-			_ = zlibWriter.Close()
-		}()
+		// make sure writer is closed if error occurred before close is called below
+		_ = zlibWriter.Close()
 	}()
 
 	_, err = zlibWriter.Write(byteData)

--- a/pkg/transforms/compression.go
+++ b/pkg/transforms/compression.go
@@ -33,8 +33,6 @@ import (
 )
 
 type Compression struct {
-	gzipWriter *gzip.Writer
-	zlibWriter *zlib.Writer
 }
 
 // NewCompression creates, initializes and returns a new instance of Compression
@@ -56,18 +54,14 @@ func (compression *Compression) CompressWithGZIP(ctx interfaces.AppFunctionConte
 	}
 	var buf bytes.Buffer
 
-	if compression.gzipWriter == nil {
-		compression.gzipWriter = gzip.NewWriter(&buf)
-	} else {
-		compression.gzipWriter.Reset(&buf)
-	}
+	gzipWriter := gzip.NewWriter(&buf)
 
-	_, err = compression.gzipWriter.Write(rawData)
+	_, err = gzipWriter.Write(rawData)
 	if err != nil {
 		return false, fmt.Errorf("unable to write GZIP data in pipeline '%s': %s", ctx.PipelineId(), err.Error())
 	}
 
-	err = compression.gzipWriter.Close()
+	err = gzipWriter.Close()
 	if err != nil {
 		return false, fmt.Errorf("unable to close GZIP data in pipeline '%s': %s", ctx.PipelineId(), err.Error())
 	}
@@ -76,7 +70,6 @@ func (compression *Compression) CompressWithGZIP(ctx interfaces.AppFunctionConte
 	ctx.SetResponseContentType(common.ContentTypeText)
 
 	return true, bytesBufferToBase64(ctx.LoggingClient(), buf)
-
 }
 
 // CompressWithZLIB compresses data received as either a string,[]byte, or json.Marshaller using zlib algorithm
@@ -93,18 +86,14 @@ func (compression *Compression) CompressWithZLIB(ctx interfaces.AppFunctionConte
 	}
 	var buf bytes.Buffer
 
-	if compression.zlibWriter == nil {
-		compression.zlibWriter = zlib.NewWriter(&buf)
-	} else {
-		compression.zlibWriter.Reset(&buf)
-	}
+	zlibWriter := zlib.NewWriter(&buf)
 
-	_, err = compression.zlibWriter.Write(byteData)
+	_, err = zlibWriter.Write(byteData)
 	if err != nil {
 		return false, fmt.Errorf("unable to write ZLIB data in pipeline '%s': %s", ctx.PipelineId(), err.Error())
 	}
 
-	err = compression.zlibWriter.Close()
+	err = zlibWriter.Close()
 	if err != nil {
 		return false, fmt.Errorf("unable to close ZLIB data in pipeline '%s': %s", ctx.PipelineId(), err.Error())
 	}
@@ -113,7 +102,6 @@ func (compression *Compression) CompressWithZLIB(ctx interfaces.AppFunctionConte
 	ctx.SetResponseContentType(common.ContentTypeText)
 
 	return true, bytesBufferToBase64(ctx.LoggingClient(), buf)
-
 }
 
 func bytesBufferToBase64(lc logger.LoggingClient, buf bytes.Buffer) []byte {


### PR DESCRIPTION
fixes #1250

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **existing suffice**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
      <link to docs PR>

## Testing Instructions
Using App Sample set all pipelines to just `Compression` (gzip)
Run with non-secure EdgeX stack with Device Virtual
Verify after 30 mins that the panic has been fixed.
Change Compression to be `zlib` and rerun test

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->