### PR TITLE
refactor: Clean up all remaining reverences to v2 in the code

### DIFF
--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -685,7 +685,7 @@ func TestSetServiceKey(t *testing.T) {
 			expectedServiceKey: "MyAppService-mqtt-export",
 		},
 		{
-			name:               "Profile specified with V2 override",
+			name:               "Profile specified with override",
 			profile:            "rules-engine",
 			profileEnvVar:      envProfile,
 			profileEnvValue:    "rules-engine-redis",
@@ -693,7 +693,7 @@ func TestSetServiceKey(t *testing.T) {
 			expectedServiceKey: "MyAppService-rules-engine-redis",
 		},
 		{
-			name:               "No profile specified with V2 override",
+			name:               "No profile specified with override",
 			profileEnvVar:      envProfile,
 			profileEnvValue:    "http-export",
 			originalServiceKey: "MyAppService-" + interfaces.ProfileSuffixPlaceholder,

--- a/internal/appfunction/context_test.go
+++ b/internal/appfunction/context_test.go
@@ -28,7 +28,7 @@ import (
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
 
-	v2clients "github.com/edgexfoundry/go-mod-core-contracts/v3/clients/http"
+	clients "github.com/edgexfoundry/go-mod-core-contracts/v3/clients/http"
 	clientMocks "github.com/edgexfoundry/go-mod-core-contracts/v3/clients/interfaces/mocks"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
@@ -70,7 +70,7 @@ func TestContext_EventClient(t *testing.T) {
 
 	dic.Update(di.ServiceConstructorMap{
 		bootstrapContainer.EventClientName: func(get di.Get) interface{} {
-			return v2clients.NewEventClient(baseUrl+"59880", nil)
+			return clients.NewEventClient(baseUrl+"59880", nil)
 		},
 	})
 
@@ -84,7 +84,7 @@ func TestContext_CommandClient(t *testing.T) {
 
 	dic.Update(di.ServiceConstructorMap{
 		bootstrapContainer.CommandClientName: func(get di.Get) interface{} {
-			return v2clients.NewCommandClient(baseUrl+"59882", nil)
+			return clients.NewCommandClient(baseUrl+"59882", nil)
 		},
 	})
 
@@ -98,7 +98,7 @@ func TestContext_DeviceServiceClient(t *testing.T) {
 
 	dic.Update(di.ServiceConstructorMap{
 		bootstrapContainer.DeviceServiceClientName: func(get di.Get) interface{} {
-			return v2clients.NewDeviceServiceClient(baseUrl+"59881", nil)
+			return clients.NewDeviceServiceClient(baseUrl+"59881", nil)
 		},
 	})
 
@@ -113,7 +113,7 @@ func TestContext_DeviceProfileClient(t *testing.T) {
 
 	dic.Update(di.ServiceConstructorMap{
 		bootstrapContainer.DeviceProfileClientName: func(get di.Get) interface{} {
-			return v2clients.NewDeviceProfileClient(baseUrl+"59881", nil)
+			return clients.NewDeviceProfileClient(baseUrl+"59881", nil)
 		},
 	})
 
@@ -127,7 +127,7 @@ func TestContext_DeviceClient(t *testing.T) {
 
 	dic.Update(di.ServiceConstructorMap{
 		bootstrapContainer.DeviceClientName: func(get di.Get) interface{} {
-			return v2clients.NewDeviceClient(baseUrl+"59881", nil)
+			return clients.NewDeviceClient(baseUrl+"59881", nil)
 		},
 	})
 
@@ -142,7 +142,7 @@ func TestContext_NotificationClient(t *testing.T) {
 
 	dic.Update(di.ServiceConstructorMap{
 		bootstrapContainer.NotificationClientName: func(get di.Get) interface{} {
-			return v2clients.NewNotificationClient(baseUrl+"59860", nil)
+			return clients.NewNotificationClient(baseUrl+"59860", nil)
 		},
 	})
 
@@ -157,7 +157,7 @@ func TestContext_SubscriptionClient(t *testing.T) {
 
 	dic.Update(di.ServiceConstructorMap{
 		bootstrapContainer.SubscriptionClientName: func(get di.Get) interface{} {
-			return v2clients.NewSubscriptionClient(baseUrl+"59860", nil)
+			return clients.NewSubscriptionClient(baseUrl+"59860", nil)
 		},
 	})
 

--- a/internal/bootstrap/handlers/version_test.go
+++ b/internal/bootstrap/handlers/version_test.go
@@ -77,12 +77,12 @@ func TestValidateVersionMatch(t *testing.T) {
 		skipVersionCheck bool
 		ExpectFailure    bool
 	}{
-		{"Compatible Versions", "1.1.0", "v1.0.0", false, false},
-		{"SDK Dev Compatible Versions", "2.0.0", "v2.0.0-dev.11", false, false},
+		{"Compatible Versions", "3.1.0", "v3.0.0", false, false},
+		{"SDK Dev Compatible Versions", "3.0.0", "v3.0.0-dev.11", false, false},
 		{"Core Dev Compatible Versions", "1.2.1-dev.1", "v1.2.0", false, false},
 		{"Both Dev Compatible Versions", "1.2.1-dev.1", "v1.2.0-dev.4", false, false},
-		{"Un-compatible Versions", "2.0.0", "v1.0.0", false, true},
-		{"Skip Version Check", "2.0.0", "v1.0.0", true, false},
+		{"Un-compatible Versions", "3.0.0", "v2.0.0", false, true},
+		{"Skip Version Check", "3.0.0", "v2.0.0", true, false},
 		{"Running in Debugger", "1.0.0", "v0.0.0", false, false},
 		{"SDK Beta Version", "1.0.0", "v0.2.0", false, false},
 		{"SDK Version malformed", "1.0.0", "", false, true},

--- a/internal/controller/rest/controller.go
+++ b/internal/controller/rest/controller.go
@@ -38,7 +38,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// Controller controller for V2 REST APIs
+// Controller controller for REST APIs
 type Controller struct {
 	router         *mux.Router
 	secretProvider bootstrapInterfaces.SecretProvider
@@ -65,21 +65,21 @@ func (c *Controller) SetCustomConfigInfo(customConfig interfaces.UpdatableConfig
 }
 
 // Ping handles the request to /ping endpoint. Is used to test if the service is working
-// It returns a response as specified by the V2 API swagger in openapi/v2
+// It returns a response as specified by the API swagger in openapi
 func (c *Controller) Ping(writer http.ResponseWriter, request *http.Request) {
 	response := commonDtos.NewPingResponse(c.serviceName)
 	c.sendResponse(writer, request, common.ApiPingRoute, response, http.StatusOK)
 }
 
 // Version handles the request to /version endpoint. Is used to request the service's versions
-// It returns a response as specified by the V2 API swagger in openapi/v2
+// It returns a response as specified by the API swagger in openapi
 func (c *Controller) Version(writer http.ResponseWriter, request *http.Request) {
 	response := commonDtos.NewVersionSdkResponse(internal.ApplicationVersion, internal.SDKVersion, c.serviceName)
 	c.sendResponse(writer, request, common.ApiVersionRoute, response, http.StatusOK)
 }
 
 // Config handles the request to /config endpoint. Is used to request the service's configuration
-// It returns a response as specified by the V2 API swagger in openapi/v2
+// It returns a response as specified by the API swagger in openapi
 func (c *Controller) Config(writer http.ResponseWriter, request *http.Request) {
 	var fullConfig interface{}
 
@@ -102,7 +102,7 @@ func (c *Controller) Config(writer http.ResponseWriter, request *http.Request) {
 }
 
 // AddSecret handles the request to add App Service exclusive secret to the Secret Store
-// It returns a response as specified by the V2 API swagger in openapi/v2
+// It returns a response as specified by the API swagger in openapi
 func (c *Controller) AddSecret(writer http.ResponseWriter, request *http.Request) {
 	defer func() {
 		_ = request.Body.Close()
@@ -140,7 +140,7 @@ func (c *Controller) sendError(
 	c.sendResponse(writer, request, internal.ApiAddSecretRoute, response, edgexErr.Code())
 }
 
-// sendResponse puts together the response packet for the V2 API
+// sendResponse puts together the response packet for the API
 func (c *Controller) sendResponse(
 	writer http.ResponseWriter,
 	request *http.Request,

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -44,7 +44,7 @@ const (
 )
 
 var testAddEventRequest = createAddEventRequest()
-var testV2Event = testAddEventRequest.Event
+var testEvent = testAddEventRequest.Event
 
 func createAddEventRequest() requests.AddEventRequest {
 	event := dtos.NewEvent("Thermostat", "FamilyRoomThermostat", "Temperature")
@@ -122,7 +122,7 @@ func TestProcessMessageOneCustomTransform(t *testing.T) {
 		require.NotNil(t, data, "should have been passed the first event from CoreData")
 		if result, ok := data.(*dtos.Event); ok {
 			require.True(t, ok, "Should have received EdgeX event")
-			require.Equal(t, testV2Event.DeviceName, result.DeviceName, "Did not receive expected EdgeX event")
+			require.Equal(t, testEvent.DeviceName, result.DeviceName, "Did not receive expected EdgeX event")
 		}
 		transform1WasCalled = true
 		return true, "Hello"
@@ -160,7 +160,7 @@ func TestProcessMessageTwoCustomTransforms(t *testing.T) {
 		require.NotNil(t, data, "should have been passed the first event from CoreData")
 		if result, ok := data.(dtos.Event); ok {
 			require.True(t, ok, "Should have received Event")
-			assert.Equal(t, testV2Event.DeviceName, result.DeviceName, "Did not receive expected Event")
+			assert.Equal(t, testEvent.DeviceName, result.DeviceName, "Did not receive expected Event")
 		}
 
 		return true, "Transform1Result"
@@ -209,7 +209,7 @@ func TestProcessMessageThreeCustomTransformsOneFail(t *testing.T) {
 
 		if result, ok := data.(*dtos.Event); ok {
 			require.True(t, ok, "Should have received EdgeX event")
-			require.Equal(t, testV2Event.DeviceName, result.DeviceName, "Did not receive expected EdgeX event")
+			require.Equal(t, testEvent.DeviceName, result.DeviceName, "Did not receive expected EdgeX event")
 		}
 
 		return false, "Transform1Result"
@@ -247,7 +247,7 @@ func TestProcessMessageTransformError(t *testing.T) {
 
 	// Send a RegistryInfo to the pipeline, instead of an Event
 	registryInfo := config.RegistryInfo{
-		Host: testV2Event.DeviceName,
+		Host: testEvent.DeviceName,
 	}
 	payload, _ := json.Marshal(registryInfo)
 	envelope := types.MessageEnvelope{
@@ -321,8 +321,8 @@ func TestProcessMessageJSON(t *testing.T) {
 
 		if result, ok := data.(*dtos.Event); ok {
 			require.True(t, ok, "Should have received EdgeX event")
-			assert.Equal(t, testV2Event.DeviceName, result.DeviceName, "Did not receive expected EdgeX event, wrong device")
-			assert.Equal(t, testV2Event.Id, result.Id, "Did not receive expected EdgeX event, wrong ID")
+			assert.Equal(t, testEvent.DeviceName, result.DeviceName, "Did not receive expected EdgeX event, wrong device")
+			assert.Equal(t, testEvent.Id, result.Id, "Did not receive expected EdgeX event, wrong ID")
 		}
 
 		return false, nil
@@ -363,8 +363,8 @@ func TestProcessMessageCBOR(t *testing.T) {
 
 		if result, ok := data.(*dtos.Event); ok {
 			require.True(t, ok, "Should have received EdgeX event")
-			assert.Equal(t, testV2Event.DeviceName, result.DeviceName, "Did not receive expected EdgeX event, wrong device")
-			assert.Equal(t, testV2Event.Id, result.Id, "Did not receive expected EdgeX event, wrong ID")
+			assert.Equal(t, testEvent.DeviceName, result.DeviceName, "Did not receive expected EdgeX event, wrong device")
+			assert.Equal(t, testEvent.Id, result.Id, "Did not receive expected EdgeX event, wrong ID")
 		}
 
 		return false, nil
@@ -401,13 +401,13 @@ func TestDecode_Process_MessageTargetType(t *testing.T) {
 	jsonPayload, err := json.Marshal(testAddEventRequest)
 	require.NoError(t, err)
 
-	eventJsonPayload, err := json.Marshal(testV2Event)
+	eventJsonPayload, err := json.Marshal(testEvent)
 	require.NoError(t, err)
 
 	cborPayload, err := cbor.Marshal(testAddEventRequest)
 	assert.NoError(t, err)
 
-	eventCborPayload, err := cbor.Marshal(testV2Event)
+	eventCborPayload, err := cbor.Marshal(testEvent)
 	require.NoError(t, err)
 
 	expected := CustomType{
@@ -501,10 +501,10 @@ func TestExecutePipelinePersist(t *testing.T) {
 }
 
 func TestGolangRuntime_processEventPayload(t *testing.T) {
-	jsonV2AddEventPayload, _ := json.Marshal(testAddEventRequest)
-	cborV2AddEventPayload, _ := cbor.Marshal(testAddEventRequest)
-	jsonV2EventPayload, _ := json.Marshal(testAddEventRequest.Event)
-	cborV2EventPayload, _ := cbor.Marshal(testAddEventRequest.Event)
+	jsonAddEventPayload, _ := json.Marshal(testAddEventRequest)
+	cborAddEventPayload, _ := cbor.Marshal(testAddEventRequest)
+	jsonEventPayload, _ := json.Marshal(testAddEventRequest.Event)
+	cborEventPayload, _ := cbor.Marshal(testAddEventRequest.Event)
 
 	notAnEvent := dtos.DeviceResource{
 		Description: "Not An Event",
@@ -513,7 +513,7 @@ func TestGolangRuntime_processEventPayload(t *testing.T) {
 	jsonInvalidPayload, _ := json.Marshal(notAnEvent)
 	cborInvalidPayload, _ := cbor.Marshal(notAnEvent)
 
-	expectedV2Event := testV2Event
+	expectedEvent := testEvent
 
 	tests := []struct {
 		Name        string
@@ -522,10 +522,10 @@ func TestGolangRuntime_processEventPayload(t *testing.T) {
 		Expected    *dtos.Event
 		ExpectError bool
 	}{
-		{"JSON V2 Add Event DTO", jsonV2AddEventPayload, common.ContentTypeJSON, &expectedV2Event, false},
-		{"CBOR V2 Add Event DTO", cborV2AddEventPayload, common.ContentTypeCBOR, &expectedV2Event, false},
-		{"JSON V2 Event DTO", jsonV2EventPayload, common.ContentTypeJSON, &expectedV2Event, false},
-		{"CBOR V2 Event DTO", cborV2EventPayload, common.ContentTypeCBOR, &expectedV2Event, false},
+		{"JSON Add Event DTO", jsonAddEventPayload, common.ContentTypeJSON, &expectedEvent, false},
+		{"CBOR Add Event DTO", cborAddEventPayload, common.ContentTypeCBOR, &expectedEvent, false},
+		{"JSON Event DTO", jsonEventPayload, common.ContentTypeJSON, &expectedEvent, false},
+		{"CBOR Event DTO", cborEventPayload, common.ContentTypeCBOR, &expectedEvent, false},
 		{"invalid JSON", jsonInvalidPayload, common.ContentTypeJSON, nil, true},
 		{"invalid CBOR", cborInvalidPayload, common.ContentTypeCBOR, nil, true},
 	}


### PR DESCRIPTION
closes #1395

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) **N/A**
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
      <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->