### PR TITLE
feat: Add API to get SDK's App Context

### DIFF
--- a/app-service-template/main.go
+++ b/app-service-template/main.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"reflect"
 
@@ -38,6 +39,7 @@ const (
 type myApp struct {
 	service       interfaces.ApplicationService
 	lc            logger.LoggingClient
+	appCtx        context.Context
 	serviceConfig *config.ServiceConfig
 	configChanged chan bool
 }
@@ -139,6 +141,10 @@ func (app *myApp) CreateAndRunAppService(serviceKey string, newServiceFactory fu
 		app.lc.Errorf("AddFunctionsPipelineForTopic returned error: %s", err.Error())
 		return -1
 	}
+
+	// TODO: Use this context in long running function to detect when the context is cancel for function can exit.
+	//       Remove if no long running functions
+	app.appCtx = app.service.AppContext()
 
 	if err := app.service.Run(); err != nil {
 		app.lc.Errorf("Run returned error: %s", err.Error())

--- a/app-service-template/main_test.go
+++ b/app-service-template/main_test.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -39,6 +40,7 @@ func TestCreateAndRunService_Success(t *testing.T) {
 
 	mockFactory := func(_ string) (interfaces.ApplicationService, bool) {
 		mockAppService := &mocks.ApplicationService{}
+		mockAppService.On("AppContext").Return(context.Background())
 		mockAppService.On("LoggingClient").Return(logger.NewMockClient())
 		mockAppService.On("GetAppSettingStrings", "DeviceNames").
 			Return([]string{"Random-Boolean-Device, Random-Integer-Device"}, nil)
@@ -81,6 +83,7 @@ func TestCreateAndRunService_GetAppSettingStrings_Failed(t *testing.T) {
 	getAppSettingStringsCalled := false
 	mockFactory := func(_ string) (interfaces.ApplicationService, bool) {
 		mockAppService := &mocks.ApplicationService{}
+		mockAppService.On("AppContext").Return(context.Background())
 		mockAppService.On("LoggingClient").Return(logger.NewMockClient())
 		mockAppService.On("GetAppSettingStrings", "DeviceNames").
 			Return(nil, fmt.Errorf("Failed")).Run(func(args mock.Arguments) {
@@ -104,6 +107,7 @@ func TestCreateAndRunService_SetFunctionsPipeline_Failed(t *testing.T) {
 
 	mockFactory := func(_ string) (interfaces.ApplicationService, bool) {
 		mockAppService := &mocks.ApplicationService{}
+		mockAppService.On("AppContext").Return(context.Background())
 		mockAppService.On("LoggingClient").Return(logger.NewMockClient())
 		mockAppService.On("GetAppSettingStrings", "DeviceNames").
 			Return([]string{"Random-Boolean-Device, Random-Integer-Device"}, nil)
@@ -137,6 +141,7 @@ func TestCreateAndRunService_Run_Failed(t *testing.T) {
 
 	mockFactory := func(_ string) (interfaces.ApplicationService, bool) {
 		mockAppService := &mocks.ApplicationService{}
+		mockAppService.On("AppContext").Return(context.Background())
 		mockAppService.On("LoggingClient").Return(logger.NewMockClient())
 		mockAppService.On("GetAppSettingStrings", "DeviceNames").
 			Return([]string{"Random-Boolean-Device, Random-Integer-Device"}, nil)

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -116,6 +116,12 @@ type contextGroup struct {
 	stop                  context.CancelFunc
 }
 
+// AppContext returns the application service context used to detect cancelled context when the service is terminating.
+// Used by custom app service to appropriately exit any long-running functions.
+func (svc *Service) AppContext() context.Context {
+	return svc.ctx.appCtx
+}
+
 // AddRoute allows you to leverage the existing webserver to add routes.
 func (svc *Service) AddRoute(route string, handler func(nethttp.ResponseWriter, *nethttp.Request), methods ...string) error {
 	if route == commonConstants.ApiPingRoute ||

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -967,7 +967,7 @@ func TestService_SecretProvider(t *testing.T) {
 }
 
 func TestService_AppContext(t *testing.T) {
-	expected, _ := context.WithCancel(context.Background())
+	expected, cancel := context.WithCancel(context.Background())
 	sdk := Service{
 		ctx: contextGroup{
 			appCtx: expected,
@@ -976,4 +976,6 @@ func TestService_AppContext(t *testing.T) {
 
 	actual := sdk.AppContext()
 	assert.Equal(t, expected, actual)
+	// Linter requires use cancel function
+	cancel()
 }

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -17,6 +17,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -963,4 +964,16 @@ func TestService_SecretProvider(t *testing.T) {
 	actual := sdk.SecretProvider()
 	require.NotNil(t, actual)
 	assert.Equal(t, mockSecretProvider, actual)
+}
+
+func TestService_AppContext(t *testing.T) {
+	expected, _ := context.WithCancel(context.Background())
+	sdk := Service{
+		ctx: contextGroup{
+			appCtx: expected,
+		},
+	}
+
+	actual := sdk.AppContext()
+	assert.Equal(t, expected, actual)
 }

--- a/pkg/interfaces/mocks/ApplicationService.go
+++ b/pkg/interfaces/mocks/ApplicationService.go
@@ -8,6 +8,8 @@ import (
 
 	config "github.com/edgexfoundry/go-mod-bootstrap/v3/config"
 
+	context "context"
+
 	http "net/http"
 
 	interfaces "github.com/edgexfoundry/app-functions-sdk-go/v3/pkg/interfaces"
@@ -115,6 +117,22 @@ func (_m *ApplicationService) AddRoute(route string, handler func(http.ResponseW
 		r0 = rf(route, handler, methods...)
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// AppContext provides a mock function with given fields:
+func (_m *ApplicationService) AppContext() context.Context {
+	ret := _m.Called()
+
+	var r0 context.Context
+	if rf, ok := ret.Get(0).(func() context.Context); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(context.Context)
+		}
 	}
 
 	return r0

--- a/pkg/interfaces/service.go
+++ b/pkg/interfaces/service.go
@@ -16,6 +16,7 @@
 package interfaces
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -75,6 +76,9 @@ type UpdatableConfig interface {
 
 // ApplicationService defines the interface for an edgex Application Service
 type ApplicationService interface {
+	// AppContext returns the application service context used to detect cancelled context when the service is terminating.
+	// Used by custom app service to appropriately exit any long-running functions.
+	AppContext() context.Context
 	// AddRoute a custom REST route to the application service's internal webserver
 	// A reference to this ApplicationService is add the the context that is passed to the handler, which
 	// can be retrieved using the `AppService` key


### PR DESCRIPTION
Use the App Context in custom app service to exit long running functions when the context is canceled due to termination signal.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x ] I have opened a PR for the related docs change (if not, why?)
https://github.com/edgexfoundry/edgex-docs/pull/1149

## Testing Instructions
Build and run the App Template
Verify no errors.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->