### PR TITLE
feat(security): Add authentication hooks to routes (backport)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@
 edgeXBuildGoApp (
     project: 'app-functions-sdk-go',
     semver: true,
+    goVersion: '1.20',
     testScript: 'make test',
     buildImage: false,
     publishSwaggerDocs: true,

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -97,8 +97,9 @@ func TestAddRoute(t *testing.T) {
 	sdk := Service{
 		webserver: ws,
 	}
-	_ = sdk.AddRoute("/test", func(http.ResponseWriter, *http.Request) {}, http.MethodGet)
-	_ = router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+	err := sdk.AddRoute("/test", func(http.ResponseWriter, *http.Request) {}, http.MethodGet)
+	require.NoError(t, err)
+	err = router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
 		path, err := route.GetPathTemplate()
 		if err != nil {
 			return err
@@ -106,6 +107,7 @@ func TestAddRoute(t *testing.T) {
 		assert.Equal(t, "/test", path)
 		return nil
 	})
+	require.NoError(t, err)
 
 }
 

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -17,11 +17,12 @@
 package webserver
 
 import (
-	"github.com/google/uuid"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/google/uuid"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces/mocks"
@@ -69,6 +70,12 @@ func TestAddRoute(t *testing.T) {
 }
 
 func TestSetupTriggerRoute(t *testing.T) {
+	envDisableSecurity := os.Getenv("EDGEX_DISABLE_JWT_VALIDATION")
+	os.Setenv("EDGEX_DISABLE_JWT_VALIDATION", "true")
+	defer func() {
+		os.Setenv("EDGEX_DISABLE_JWT_VALIDATION", envDisableSecurity)
+	}()
+
 	webserver := NewWebServer(dic, mux.NewRouter(), uuid.NewString())
 
 	handlerFunctionNotCalled := true


### PR DESCRIPTION
BREAKING CHANGE: EdgeX standard routes will require authentication. AddCustomRoute is a new interface method that enables adding authenticated routes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [X] I have opened a PR for the related docs change (if not, why?)
      <[link to docs PR](https://github.com/edgexfoundry/edgex-docs/pull/1169)>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->