### PR TITLE
feat: Add error metrics for HTTP and MQTT export errors

### DIFF
--- a/internal/constant.go
+++ b/internal/constant.go
@@ -40,9 +40,9 @@ const (
 	PipelineMessageProcessingTimeName = "PipelineMessageProcessingTime-" + PipelineIdTxt
 	PipelineProcessingErrorsName      = "PipelineProcessingErrors-" + PipelineIdTxt
 	HttpExportSizeName                = "HttpExportSize"
-	HttpExportErrorName               = "HttpExportError"
+	HttpExportErrorsName              = "HttpExportErrors"
 	MqttExportSizeName                = "MqttExportSize"
-	MqttExportErrorName               = "MqttExportError"
+	MqttExportErrorsName              = "MqttExportErrors"
 	MessageBusSubscribeTopics         = "SubscribeTopics"
 	MessageBusPublishTopic            = "PublishTopic"
 )

--- a/internal/constant.go
+++ b/internal/constant.go
@@ -40,7 +40,9 @@ const (
 	PipelineMessageProcessingTimeName = "PipelineMessageProcessingTime-" + PipelineIdTxt
 	PipelineProcessingErrorsName      = "PipelineProcessingErrors-" + PipelineIdTxt
 	HttpExportSizeName                = "HttpExportSize"
+	HttpExportErrorName               = "HttpExportError"
 	MqttExportSizeName                = "MqttExportSize"
+	MqttExportErrorName               = "MqttExportError"
 	MessageBusSubscribeTopics         = "SubscribeTopics"
 	MessageBusPublishTopic            = "PublishTopic"
 )

--- a/pkg/transforms/helpers.go
+++ b/pkg/transforms/helpers.go
@@ -1,0 +1,49 @@
+//
+// Copyright (c) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package transforms
+
+import (
+	"errors"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/v3/pkg/interfaces"
+)
+
+func createRegisterMetric(ctx interfaces.AppFunctionContext,
+	fullNameFunc func() string, getMetric func() any, setMetric func(),
+	tags map[string]string) {
+	// Only need to create and register the metric if it hasn't been created yet.
+	if getMetric() == nil {
+		lc := ctx.LoggingClient()
+		var err error
+		fullName := fullNameFunc()
+		lc.Debugf("Initializing metric %s.", fullName)
+		setMetric()
+		metricsManger := ctx.MetricsManager()
+		if metricsManger != nil {
+			err = metricsManger.Register(fullName, getMetric(), tags)
+		} else {
+			err = errors.New("metrics manager not available")
+		}
+
+		if err != nil {
+			lc.Errorf("Unable to register metric %s. Collection will continue, but metric will not be reported: %s", fullName, err.Error())
+			return
+		}
+
+		lc.Infof("%s metric has been registered and will be reported (if enabled)", fullName)
+	}
+}

--- a/pkg/transforms/helpers_test.go
+++ b/pkg/transforms/helpers_test.go
@@ -50,6 +50,7 @@ func TestCreateRegisterMetric(t *testing.T) {
 			mockMetricsMgr.On("Register", expectedFullName, mock.Anything, expectedTags).Return(test.RegisterError).Once()
 			mockLogger := &loggerMocks.LoggingClient{}
 			mockLogger.On("Debugf", mock.Anything, mock.Anything)
+			mockLogger.On("Infof", mock.Anything, mock.Anything)
 			mockCtx := &mocks.AppFunctionContext{}
 			mockCtx.On("LoggingClient").Return(mockLogger)
 			if test.NilMetricsManager {

--- a/pkg/transforms/helpers_test.go
+++ b/pkg/transforms/helpers_test.go
@@ -1,0 +1,76 @@
+//
+// Copyright (c) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package transforms
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/v3/pkg/interfaces/mocks"
+	mocks2 "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces/mocks"
+	loggerMocks "github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger/mocks"
+	gometrics "github.com/rcrowley/go-metrics"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateRegisterMetric(t *testing.T) {
+	expectedName := "testCounter"
+	expectedFullName := expectedName + "-https://somewhere.com"
+	expectedUrl := "https://somewhere.com"
+	expectedTags := map[string]string{"url": expectedUrl}
+
+	tests := []struct {
+		Name              string
+		NilMetricsManager bool
+		RegisterError     error
+	}{
+		{"Happy Path", false, nil},
+		{"Error - No Metrics Manager", true, nil},
+		{"Error - Register error", false, errors.New("register failed")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			mockMetricsMgr := &mocks2.MetricsManager{}
+			mockMetricsMgr.On("Register", expectedFullName, mock.Anything, expectedTags).Return(test.RegisterError).Once()
+			mockLogger := &loggerMocks.LoggingClient{}
+			mockLogger.On("Debugf", mock.Anything, mock.Anything)
+			mockCtx := &mocks.AppFunctionContext{}
+			mockCtx.On("LoggingClient").Return(mockLogger)
+			if test.NilMetricsManager {
+				mockCtx.On("MetricsManager").Return(nil)
+				mockLogger.On("Errorf", mock.Anything, expectedFullName, "metrics manager not available")
+			} else {
+				mockCtx.On("MetricsManager").Return(mockMetricsMgr)
+			}
+
+			if test.RegisterError != nil {
+				mockLogger.On("Errorf", mock.Anything, expectedFullName, "register failed")
+			}
+
+			var metric gometrics.Counter
+			createRegisterMetric(mockCtx,
+				func() string { return expectedFullName },
+				func() any { return metric },
+				func() { metric = gometrics.NewCounter() },
+				expectedTags)
+			require.NotNil(t, metric)
+
+		})
+	}
+}

--- a/pkg/transforms/http.go
+++ b/pkg/transforms/http.go
@@ -164,7 +164,7 @@ func (sender *HTTPSender) httpSend(ctx interfaces.AppFunctionContext, data inter
 	}
 
 	createRegisterMetric(ctx,
-		func() string { return fmt.Sprintf("%s-%s", internal.HttpExportErrorName, parsedUrl.Redacted()) },
+		func() string { return fmt.Sprintf("%s-%s", internal.HttpExportErrorsName, parsedUrl.Redacted()) },
 		func() any { return sender.httpErrorMetric },
 		func() { sender.httpErrorMetric = gometrics.NewCounter() },
 		map[string]string{"url": parsedUrl.Redacted()})

--- a/pkg/transforms/http.go
+++ b/pkg/transforms/http.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Intel Corporation
+// Copyright (c) 2023 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package transforms
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -44,6 +43,7 @@ type HTTPSender struct {
 	secretName          string
 	urlFormatter        StringValuesFormatter
 	httpSizeMetrics     gometrics.Histogram
+	httpErrorMetric     gometrics.Counter
 	httpRequestHeaders  map[string]string
 }
 
@@ -154,16 +154,28 @@ func (sender *HTTPSender) httpSend(ctx interfaces.AppFunctionContext, data inter
 	}
 
 	formattedUrl, err := sender.urlFormatter.invoke(sender.url, ctx, data)
-
 	if err != nil {
 		return false, err
 	}
 
 	parsedUrl, err := url.Parse(formattedUrl)
-
 	if err != nil {
 		return false, err
 	}
+
+	createRegisterMetric(ctx,
+		func() string { return fmt.Sprintf("%s-%s", internal.HttpExportErrorName, parsedUrl.Redacted()) },
+		func() any { return sender.httpErrorMetric },
+		func() { sender.httpErrorMetric = gometrics.NewCounter() },
+		map[string]string{"url": parsedUrl.Redacted()})
+
+	createRegisterMetric(ctx,
+		func() string { return fmt.Sprintf("%s-%s", internal.HttpExportSizeName, parsedUrl.Redacted()) },
+		func() any { return sender.httpSizeMetrics },
+		func() {
+			sender.httpSizeMetrics = gometrics.NewHistogram(gometrics.NewUniformSample(internal.MetricsReservoirSize))
+		},
+		map[string]string{"url": parsedUrl.Redacted()})
 
 	client := &http.Client{}
 	req, err := http.NewRequest(method, parsedUrl.String(), bytes.NewReader(exportData))
@@ -194,7 +206,7 @@ func (sender *HTTPSender) httpSend(ctx interfaces.AppFunctionContext, data inter
 
 	}
 
-	ctx.LoggingClient().Debugf("POSTing data to %s in pipeline '%s'", sender.url, ctx.PipelineId())
+	ctx.LoggingClient().Debugf("POSTing data to %s in pipeline '%s'", parsedUrl.Redacted(), ctx.PipelineId())
 
 	response, err := client.Do(req)
 	// Pipeline continues if we get a 2xx response, non-2xx response may stop pipeline
@@ -204,6 +216,8 @@ func (sender *HTTPSender) httpSend(ctx interfaces.AppFunctionContext, data inter
 		} else {
 			err = fmt.Errorf("export failed in pipeline '%s': %s", ctx.PipelineId(), err.Error())
 		}
+
+		sender.httpErrorMetric.Inc(1)
 
 		// If continuing on send error then can't be persisting on error since Store and Forward retries starting
 		// with the function that failed and stopped the execution of the pipeline.
@@ -222,25 +236,6 @@ func (sender *HTTPSender) httpSend(ctx interfaces.AppFunctionContext, data inter
 
 	// capture the size into metrics
 	exportDataBytes := len(exportData)
-	if sender.httpSizeMetrics == nil {
-		var err error
-		lc.Debugf("Initializing metric %s.", internal.HttpExportSizeName)
-		sender.httpSizeMetrics = gometrics.NewHistogram(gometrics.NewUniformSample(internal.MetricsReservoirSize))
-		metricsManger := ctx.MetricsManager()
-		if metricsManger != nil {
-			metricName := fmt.Sprintf("%s-%s", internal.HttpExportSizeName, sender.url)
-
-			err = metricsManger.Register(metricName, sender.httpSizeMetrics, map[string]string{"url": sender.url})
-		} else {
-			err = errors.New("metrics manager not available")
-		}
-
-		if err != nil {
-			lc.Errorf("Unable to register metric %s. Collection will continue, but metric will not be reported: %s", internal.HttpExportSizeName, err.Error())
-		}
-
-	}
-
 	sender.httpSizeMetrics.Update(int64(exportDataBytes))
 
 	ctx.LoggingClient().Debugf("Sent %d bytes of data in pipeline '%s'. Response status is %s", exportDataBytes, ctx.PipelineId(), response.Status)

--- a/pkg/transforms/http_test.go
+++ b/pkg/transforms/http_test.go
@@ -27,9 +27,8 @@ import (
 	"testing"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
-	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
-
 	mocks2 "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces/mocks"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/transforms/mqttsecret.go
+++ b/pkg/transforms/mqttsecret.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Intel Corporation
+// Copyright (c) 2023 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package transforms
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -43,6 +42,7 @@ type MQTTSecretSender struct {
 	secretsLastRetrieved time.Time
 	topicFormatter       StringValuesFormatter
 	mqttSizeMetrics      gometrics.Histogram
+	mqttErrorMetric      gometrics.Counter
 }
 
 // MQTTSecretConfig ...
@@ -187,14 +187,38 @@ func (sender *MQTTSecretSender) MQTTSend(ctx interfaces.AppFunctionContext, data
 		}
 	}
 
+	publishTopic, err := sender.topicFormatter.invoke(sender.mqttConfig.Topic, ctx, data)
+	if err != nil {
+		return false, fmt.Errorf("in pipeline '%s', MQTT topic formatting failed: %s", ctx.PipelineId(), err.Error())
+	}
+
+	tagValue := fmt.Sprintf("%s/%s", sender.mqttConfig.BrokerAddress, publishTopic)
+	tag := map[string]string{"address/topic": tagValue}
+
+	createRegisterMetric(ctx,
+		func() string { return fmt.Sprintf("%s-%s", internal.MqttExportErrorName, tagValue) },
+		func() any { return sender.mqttErrorMetric },
+		func() { sender.mqttErrorMetric = gometrics.NewCounter() },
+		tag)
+
+	createRegisterMetric(ctx,
+		func() string { return fmt.Sprintf("%s-%s", internal.MqttExportSizeName, tagValue) },
+		func() any { return sender.mqttSizeMetrics },
+		func() {
+			sender.mqttSizeMetrics = gometrics.NewHistogram(gometrics.NewUniformSample(internal.MetricsReservoirSize))
+		},
+		tag)
+
 	if !sender.client.IsConnected() {
 		err := sender.connectToBroker(ctx, exportData)
 		if err != nil {
+			sender.mqttErrorMetric.Inc(1)
 			return false, err
 		}
 	}
 
 	if !sender.client.IsConnectionOpen() {
+		sender.mqttErrorMetric.Inc(1)
 		sender.setRetryData(ctx, exportData)
 		subMessage := "dropping event"
 		if sender.persistOnError {
@@ -203,38 +227,18 @@ func (sender *MQTTSecretSender) MQTTSend(ctx interfaces.AppFunctionContext, data
 		return false, fmt.Errorf("in pipeline '%s', connection to mqtt server for export not open, %s", ctx.PipelineId(), subMessage)
 	}
 
-	publishTopic, err := sender.topicFormatter.invoke(sender.mqttConfig.Topic, ctx, data)
-	if err != nil {
-		return false, fmt.Errorf("in pipeline '%s', MQTT topic formatting failed: %s", ctx.PipelineId(), err.Error())
-	}
-
 	token := sender.client.Publish(publishTopic, sender.mqttConfig.QoS, sender.mqttConfig.Retain, exportData)
 	token.Wait()
 	if token.Error() != nil {
+		sender.mqttErrorMetric.Inc(1)
 		sender.setRetryData(ctx, exportData)
 		return false, token.Error()
 	}
+
 	// capture the size for metrics
 	exportDataBytes := len(exportData)
-	if sender.mqttSizeMetrics == nil {
-		var err error
-		tag := fmt.Sprintf("%s/%s", sender.mqttConfig.BrokerAddress, publishTopic)
-		metricName := fmt.Sprintf("%s-%s", internal.MqttExportSizeName, tag)
-		ctx.LoggingClient().Debugf("Initializing metric %s.", metricName)
-		sender.mqttSizeMetrics = gometrics.NewHistogram(gometrics.NewUniformSample(internal.MetricsReservoirSize))
-		metricsManger := ctx.MetricsManager()
-		if metricsManger != nil {
-			err = metricsManger.Register(metricName, sender.mqttSizeMetrics, map[string]string{"address/topic": tag})
-		} else {
-			err = errors.New("metrics manager not available")
-		}
-
-		if err != nil {
-			ctx.LoggingClient().Errorf("Unable to register metric %s. Collection will continue, but metric will not be reported: %s", internal.MqttExportSizeName, err.Error())
-		}
-
-	}
 	sender.mqttSizeMetrics.Update(int64(exportDataBytes))
+
 	ctx.LoggingClient().Debugf("Sent %d bytes of data to MQTT Broker in pipeline '%s'", exportDataBytes, ctx.PipelineId())
 	ctx.LoggingClient().Tracef("Data exported", "Transport", "MQTT", "pipeline", ctx.PipelineId(), common.CorrelationHeader, ctx.CorrelationID())
 

--- a/pkg/transforms/mqttsecret.go
+++ b/pkg/transforms/mqttsecret.go
@@ -196,7 +196,7 @@ func (sender *MQTTSecretSender) MQTTSend(ctx interfaces.AppFunctionContext, data
 	tag := map[string]string{"address/topic": tagValue}
 
 	createRegisterMetric(ctx,
-		func() string { return fmt.Sprintf("%s-%s", internal.MqttExportErrorName, tagValue) },
+		func() string { return fmt.Sprintf("%s-%s", internal.MqttExportErrorsName, tagValue) },
 		func() any { return sender.mqttErrorMetric },
 		func() { sender.mqttErrorMetric = gometrics.NewCounter() },
 		tag)


### PR DESCRIPTION
closes #1467

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
      github.com/edgexfoundry/edgex-docs/pull/1237

## Testing Instructions
Run non-secure EdgeX stack with device REST
Build ASC with this branch of the SDK
### HTTP Export
Add the following to `http-export` profile under `Writable`
```
  Telemetry:
    Interval: "5s"
    Metrics:
      HttpExportErrors: true
```
Set URL under `HTTPExport` to 
```
Url: "me:junk@http://nowhere.com/nodata"
```
Run ASC 
```
WRITABLE_LOGLEVEL=DEBUG ./app-service-configurable -p=http-export -cp -d
```
Send data thru Device Rest
Verify following logs
```
level=DEBUG ts=2023-09-25T23:27:11.549514342Z app=app-http-export source=helpers.go:33 msg="Initializing metric HttpExportErrors-http://nowhere.com/nodata."
level=INFO ts=2023-09-25T23:27:11.549606543Z app=app-http-export source=helpers.go:47 msg="HttpExportErrors-http://nowhere.com/nodata metric has been registered and will be reported (if enabled)"
level=DEBUG ts=2023-09-25T23:27:11.549639243Z app=app-http-export source=helpers.go:33 msg="Initializing metric HttpExportSize-http://nowhere.com/nodata."
level=DEBUG ts=2023-09-25T23:28:42.591454162Z app=app-http-export source=reporter.go:195 msg="Publish 1 metrics to the 'edgex/telemetry/app-http-export' base topic"
```
Run ASC in separate terminal with metrics profile
```
WRITABLE_LOGLEVEL=DEBUG ./app-service-configurable -cp -d -p metrics-influxdb | grep "Transformed Metric to"
```
Verify logs contains 
```
level=DEBUG ts=2023-09-25T23:32:32.591464313Z app=app-metrics-influxdb source=metrics.go:70 msg="Transformed Metric to 'HttpExportErrors,service=app-http-export,url=http://nowhere.com/nodata counter-count=1 1695684752590712509\n' in pipeline 'default-pipeline"
```
Send more data via Device Rest and verify counter in above log increases by 1 for each new data sent
### MQTT Export
Add the following to `http-export` profile under `Writable`
```
  Telemetry:
    Interval: "5s"
    Metrics:
      MqttExportErrors: true
```
Run ASC 
```
WRITABLE_LOGLEVEL=DEBUG ./app-service-configurable -p=mqtt-export -cp -d
```
Send data thru Device Rest
Verify following logs
```
level=DEBUG ts=2023-09-25T23:35:41.94982575Z app=app-mqtt-export source=helpers.go:33 msg="Initializing metric MqttExportErrors-tcp://localhost:1883/edgex-export."
level=INFO ts=2023-09-25T23:35:41.949846951Z app=app-mqtt-export source=helpers.go:47 msg="MqttExportErrors-tcp://localhost:1883/edgex-export metric has been registered and will be reported (if enabled)"
level=DEBUG ts=2023-09-25T23:35:41.949857551Z app=app-mqtt-export source=helpers.go:33 msg="Initializing metric MqttExportSize-tcp://localhost:1883/edgex-export."
level=INFO ts=2023-09-25T23:35:41.949899351Z app=app-mqtt-export source=helpers.go:47 msg="MqttExportSize-tcp://localhost:1883/edgex-export metric has been registered and will be reported (if enabled)"
```
Run ASC in separate terminal with metrics profile
```
WRITABLE_LOGLEVEL=DEBUG ./app-service-configurable -cp -d -p metrics-influxdb | grep "Transformed Metric to"
```
Verify logs contains 
```
level=DEBUG ts=2023-09-25T23:37:42.248370623Z app=app-metrics-influxdb source=metrics.go:70 msg="Transformed Metric to 'MqttExportErrors,service=app-mqtt-export,address/topic=tcp://localhost:1883/edgex-export counter-count=1 1695685062247398314\n' in pipeline 'default-pipeline"
```
Send more data via Device Rest and verify counter in above log increases by 1 for each new data sent

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->