### PR TITLE
feat: Add Will configuration elements for External MQTT trigger config

### DIFF
--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -85,6 +85,19 @@ type HttpConfig struct {
 	HTTPSKeyName string
 }
 
+type WillConfig struct {
+	// Enabled enables Last Will capability on the client connection
+	Enabled bool
+	// Payload is the Last Will Message sent to other clients that are subscribed to the will topic
+	Payload string
+	// Qos is the Quality of Service for the will topic
+	Qos byte
+	// Retained is the "retain" setting for the will topic
+	Retained bool
+	// Topic is the topic for Last Will
+	Topic string
+}
+
 // ExternalMqttConfig contains the MQTT broker configuration for MQTT Trigger
 type ExternalMqttConfig struct {
 	// Url contains the fully qualified URL to connect to the MQTT broker
@@ -112,6 +125,8 @@ type ExternalMqttConfig struct {
 	RetryDuration int
 	// RetryInterval indicates the time (in seconds) that will be waited between attempts to create MQTT client
 	RetryInterval int
+	// Will contains the Last Will configuration for the MQTT Client
+	Will WillConfig
 }
 
 // PipelineInfo defines the top level data for configurable pipelines

--- a/internal/trigger/mqtt/mqtt.go
+++ b/internal/trigger/mqtt/mqtt.go
@@ -69,7 +69,7 @@ func NewTrigger(bnd trigger.ServiceBinding, mp trigger.MessageProcessor) *Trigge
 
 // Initialize initializes the Trigger for an external MQTT broker
 func (trigger *Trigger) Initialize(_ *sync.WaitGroup, ctx context.Context, background <-chan interfaces.BackgroundMessage) (bootstrap.Deferred, error) {
-	// Convenience short cuts
+	// Convenience shortcuts
 	lc := trigger.serviceBinding.LoggingClient()
 	config := trigger.serviceBinding.Config()
 
@@ -108,6 +108,12 @@ func (trigger *Trigger) Initialize(_ *sync.WaitGroup, ctx context.Context, backg
 	}
 	opts.KeepAlive = brokerConfig.KeepAlive
 	opts.Servers = []*url.URL{brokerUrl}
+
+	will := brokerConfig.Will
+	if will.Enabled {
+		opts.SetWill(will.Topic, will.Payload, will.Qos, will.Retained)
+		lc.Infof("Last Will options set for MQTT Trigger: %+v", will)
+	}
 
 	if brokerConfig.RetryDuration <= 0 {
 		brokerConfig.RetryDuration = defaultRetryDuration
@@ -148,7 +154,7 @@ func (trigger *Trigger) Initialize(_ *sync.WaitGroup, ctx context.Context, backg
 }
 
 func (trigger *Trigger) onConnectHandler(mqttClient pahoMqtt.Client) {
-	// Convenience short cuts
+	// Convenience shortcuts
 	lc := trigger.serviceBinding.LoggingClient()
 	config := trigger.serviceBinding.Config()
 	topics := util.DeleteEmptyAndTrim(strings.FieldsFunc(config.Trigger.SubscribeTopics, util.SplitComma))
@@ -166,7 +172,7 @@ func (trigger *Trigger) onConnectHandler(mqttClient pahoMqtt.Client) {
 }
 
 func (trigger *Trigger) messageHandler(_ pahoMqtt.Client, mqttMessage pahoMqtt.Message) {
-	// Convenience short cuts
+	// Convenience shortcuts
 	lc := trigger.serviceBinding.LoggingClient()
 
 	data := mqttMessage.Payload()


### PR DESCRIPTION
closes #1117

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
TBD one refactor PR is merged

## Testing Instructions
Run edgex Stack
```
 make run mqtt-broker mqtt-verbose no-secty
```
Build ASC with the SDK from this branch
Modified `external-mqtt-trigger` profile to add the following to `Trigger.ExternalMqtt` section
```
    Will:
      Enabled: true
      Payload: "goodbye"
      Qos: 2
      Retained: true
      Topic: "me/be/gone"
```
Run ASC
```
./app-service-configurable -d -cp -p=external-mqtt-trigger
```
Verify the following is in log file.
```
msg="Last Will options set for MQTT Trigger: {Enabled:true Payload:goodbye Qos:2 Retained:true Topic:me/be/gone}"
```
Verify logs for the Mqtt Broker contain
```
Will message specified (7 bytes) 
```
Connect mqtt.FX to MQTT Broker ad subscribe to `me/be/gone` topic
Stop ASC
Verify mqtt.FX received `goodbye` message on  `me/be/gone` topic

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->