### PR TITLE
feat: Add MQTT Will configuration for MQTT Export

### DIFF
--- a/app-service-template/go.mod
+++ b/app-service-template/go.mod
@@ -4,8 +4,6 @@ module app-new-service
 
 go 1.21
 
-toolchain go1.21.0
-
 // To build local docker image of the template App you must
 // comment out this replace statement and update the SDK version to latest
 replace github.com/edgexfoundry/app-functions-sdk-go/v3 => ../
@@ -24,7 +22,7 @@ require (
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/diegoholiveira/jsonlogic/v3 v3.3.0 // indirect
+	github.com/diegoholiveira/jsonlogic/v3 v3.3.1 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.4.3 // indirect
 	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.1.0-dev.49 // indirect
 	github.com/edgexfoundry/go-mod-configuration/v3 v3.1.0-dev.7 // indirect

--- a/app-service-template/go.sum
+++ b/app-service-template/go.sum
@@ -24,8 +24,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/diegoholiveira/jsonlogic/v3 v3.3.0 h1:XdIxQ+ICFcQB9tVf46cmiCkc5K9MN8Sh/x+XDHL+iXM=
-github.com/diegoholiveira/jsonlogic/v3 v3.3.0/go.mod h1:9oE8z9G+0OMxOoLHF3fhek3KuqD5CBqM0B6XFL08MSg=
+github.com/diegoholiveira/jsonlogic/v3 v3.3.1 h1:XVHpFel6ZTVYiXQlgDrlxJYYDNZoQXP54BR33w2nAJ4=
+github.com/diegoholiveira/jsonlogic/v3 v3.3.1/go.mod h1:9oE8z9G+0OMxOoLHF3fhek3KuqD5CBqM0B6XFL08MSg=
 github.com/eclipse/paho.mqtt.golang v1.4.3 h1:2kwcUGn8seMUfWndX0hGbvH8r7crgcJguQNCyp70xik=
 github.com/eclipse/paho.mqtt.golang v1.4.3/go.mod h1:CSYvoAlsMkhYOXh/oKyxa8EcBci6dVkLCbo5tTC1RIE=
 github.com/edgexfoundry/go-mod-bootstrap/v3 v3.1.0-dev.49 h1:HmfusqiLSGlC0+ojDeYc2Cg9g2kMe7kizvuV8471hOo=

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -59,7 +59,7 @@ var mockSecretProvider bootstrapInterfaces.SecretProvider
 
 func TestMain(m *testing.M) {
 	// No remote and no file results in STDOUT logging only
-	lc = logger.NewMockClient()
+	lc = logger.NewClient("test", "DEBUG")
 	mockMetricsManager := &mocks.MetricsManager{}
 	mockMetricsManager.On("Register", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mockMetricsManager.On("Unregister", mock.Anything)


### PR DESCRIPTION
closes #1117

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
TBD

## Testing Instructions
run non-secure edgex as follows
```
 make run mqtt-broker mqtt-verbose no-secty ds-rest
```
Build ASC with this branch
Add the following to `mqtt-export` profile under `MQTTExport.Parameters`
```
          WillEnabled: "true"
          WillPayload: "goodbye"
          WillQos: "2"
          WillRetained: "true"
          WillTopic: "me/be/gone"
```
run ASC as follows
```
./app-service-configurable -d -o -cp -p=mqtt-export
```
Verify expected 5 Will parameters are in following log message
```
configurable pipeline with parameters: [secretname='mqtt', willqos='2', authmode='none', skipverify='false', brokeraddress='tcp://localhost:1883', clientid='MQTT-Export', persistonerror='false', willenabled='true', autoreconnect='false', willtopic='me/be/gone', connecttimeout='', retain='false', topic='edgex-export', willpayload='goodbye', willretained='true', qos='0', keepalive='']
```
Send data to Device Rest
```
curl -d "1234" -X POST localhost:59986/api/v3/resource/sample-numeric/int
```
Verify ASC logs contain the following:
```
msg="Last Will options set for MQTT Export: {Enabled:true Payload:goodbye Qos:2 Retained:true Topic:me/be/gone}"
```
Connect mqtt.FX to broker and subscribe to `me/be/gone` topic
Stop ASC
Verify mqtt.FX received new  `goodbye` message on  `me/be/gone` topic with QOS = 2

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->