### PR TITLE
fix: Remove attempt to connect to the MessageBus from trigger

### DIFF
--- a/internal/trigger/messagebus/messaging.go
+++ b/internal/trigger/messagebus/messaging.go
@@ -58,13 +58,12 @@ func NewTrigger(bnd trigger.ServiceBinding, mp trigger.MessageProcessor, dic *di
 
 // Initialize ...
 func (trigger *Trigger) Initialize(appWg *sync.WaitGroup, appCtx context.Context, background <-chan interfaces.BackgroundMessage) (bootstrap.Deferred, error) {
-	var err error
-
 	lc := trigger.serviceBinding.LoggingClient()
 	config := trigger.serviceBinding.Config()
 
 	lc.Infof("Initializing EdgeX Message Bus Trigger for '%s'", config.MessageBus.Type)
 
+	// MessageBus client is now created and connected by the MessageBus bootstrap handler and placed in the DIC.
 	trigger.client = container.MessagingClientFrom(trigger.dic.Get)
 	if trigger.client == nil {
 		return nil, errors.New("unable to find MessageBus Client. Make sure it is configured properly")
@@ -86,11 +85,6 @@ func (trigger *Trigger) Initialize(appWg *sync.WaitGroup, appCtx context.Context
 	}
 
 	messageErrors := make(chan error)
-
-	err = trigger.client.Connect()
-	if err != nil {
-		return nil, err
-	}
 
 	trigger.publishTopic = strings.TrimSpace(config.Trigger.PublishTopic)
 	if len(trigger.publishTopic) > 0 {


### PR DESCRIPTION
This is now handled by the MessageBus bootstrap handler.

closes #1479

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A existing suffice**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
      <link to docs PR>

## Testing Instructions
build ASC with NATS capability locally (non-docker) with this branch of the SDK

### NATS 
Build edgex-go Docker with NATS capability
Build Device Virtual Docker for NATS
Run non-secure EdgeX stack with NATS Bus
```
make run ds-virtual no-secty nats-bus
```
Stop app-rules-engine container
Verify app-rules-engine no longer fails with "already connected to NATS" message
Run ASC with NATS locally
```
./app-service-configurable -cp -d -p rules-engine
```
Verify app-rules-engine (ASC) bootstraps w/o error 

### Redis
Run non-secure EdgeX stack with REDIS Bus
Stop app-rules-engine container
```
make run ds-virtual no-secty app-dev
```
Run ASC with NATS locally
```
./app-service-configurable -cp -d -p rules-engine
```
Verify app-rules-engine (ASC) bootstraps w/o error 

### MQTT
Run non-secure EdgeX stack with MQTT Bus
Stop app-rules-engine container
```
make run ds-virtual no-secty app-dev mqtt-bus
```
Verify app-rules-engine bootstraps w/o error 

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->