### PR TITLE
feat: Add capability to pre-connect to MQTT Broker for MQTT Export

### DIFF
--- a/app-service-template/go.mod
+++ b/app-service-template/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/diegoholiveira/jsonlogic/v3 v3.3.2 // indirect
+	github.com/diegoholiveira/jsonlogic/v3 v3.4.0 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.4.3 // indirect
 	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.2.0-dev.6 // indirect
 	github.com/edgexfoundry/go-mod-configuration/v3 v3.2.0-dev.1 // indirect

--- a/app-service-template/go.sum
+++ b/app-service-template/go.sum
@@ -24,8 +24,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/diegoholiveira/jsonlogic/v3 v3.3.2 h1:srg/h16pzyuS0/+P2HOt2zdDPDnzaFZtsHtfTugRPVc=
-github.com/diegoholiveira/jsonlogic/v3 v3.3.2/go.mod h1:9oE8z9G+0OMxOoLHF3fhek3KuqD5CBqM0B6XFL08MSg=
+github.com/diegoholiveira/jsonlogic/v3 v3.4.0 h1:TN++nRmEMA5UHzKl8MJ1kbF5SSzWtKHE0PZ6ITbJeH4=
+github.com/diegoholiveira/jsonlogic/v3 v3.4.0/go.mod h1:9oE8z9G+0OMxOoLHF3fhek3KuqD5CBqM0B6XFL08MSg=
 github.com/eclipse/paho.mqtt.golang v1.4.3 h1:2kwcUGn8seMUfWndX0hGbvH8r7crgcJguQNCyp70xik=
 github.com/eclipse/paho.mqtt.golang v1.4.3/go.mod h1:CSYvoAlsMkhYOXh/oKyxa8EcBci6dVkLCbo5tTC1RIE=
 github.com/edgexfoundry/go-mod-bootstrap/v3 v3.2.0-dev.6 h1:8W0q+EJUnSt5YkvbZKSWScaKt/yrBdITX7ga0Y/z188=

--- a/internal/app/configurable_test.go
+++ b/internal/app/configurable_test.go
@@ -359,6 +359,9 @@ func TestMQTTExport(t *testing.T) {
 	params[WillEnabled] = "true"
 	params[WillTopic] = "will"
 	params[WillPayload] = "goodbye"
+	params[PreConnectRetryCount] = "10"
+	params[PreConnectRetryInterval] = "6s"
+	params[MaxReconnectInterval] = "10s"
 
 	trx := configurable.MQTTExport(params)
 	assert.NotNil(t, trx, "return result from MQTTSecretSend should not be nil")

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -295,7 +295,7 @@ func (svc *Service) LoadConfigurableFunctionPipelines() (map[string]interfaces.F
 		return nil, fmt.Errorf("pipline TargetType of '%s' is not supported", svc.config.Writable.Pipeline.TargetType)
 	}
 
-	configurable := reflect.ValueOf(NewConfigurable(svc.lc))
+	configurable := reflect.ValueOf(NewConfigurable(svc.lc, svc.SecretProvider()))
 	pipelineConfig := svc.config.Writable.Pipeline
 
 	defaultExecutionOrder := strings.TrimSpace(pipelineConfig.ExecutionOrder)

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -526,7 +526,8 @@ func TestGetAppSettingStringsNoAppSettings(t *testing.T) {
 
 func TestLoadConfigurableFunctionPipelinesDefaultNotFound(t *testing.T) {
 	service := Service{
-		lc: lc,
+		lc:  lc,
+		dic: dic,
 		config: &common.ConfigurationStruct{
 			Writable: common.WritableInfo{
 				Pipeline: common.PipelineInfo{
@@ -572,7 +573,8 @@ func TestLoadConfigurableFunctionPipelinesNotABuiltInSdkFunction(t *testing.T) {
 	functions["Bogus"] = common.PipelineFunction{}
 
 	sdk := Service{
-		lc: lc,
+		lc:  lc,
+		dic: dic,
 		config: &common.ConfigurationStruct{
 			Writable: common.WritableInfo{
 				Pipeline: common.PipelineInfo{
@@ -604,7 +606,8 @@ func TestLoadConfigurableFunctionPipelinesNumFunctions(t *testing.T) {
 	transforms["SetResponseData"] = common.PipelineFunction{}
 
 	sdk := Service{
-		lc: lc,
+		lc:  lc,
+		dic: dic,
 		config: &common.ConfigurationStruct{
 			Writable: common.WritableInfo{
 				Pipeline: common.PipelineInfo{
@@ -661,7 +664,8 @@ func TestTargetType(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			sdk := Service{
-				lc: lc,
+				lc:  lc,
+				dic: dic,
 				config: &common.ConfigurationStruct{
 					Writable: common.WritableInfo{
 						Pipeline: common.PipelineInfo{
@@ -821,11 +825,12 @@ func TestStop(t *testing.T) {
 func TestFindMatchingFunction(t *testing.T) {
 	svc := Service{
 		lc:                       lc,
+		dic:                      dic,
 		serviceKey:               "MyAppService",
 		profileSuffixPlaceholder: interfaces.ProfileSuffixPlaceholder,
 	}
 
-	configurable := reflect.ValueOf(NewConfigurable(svc.lc))
+	configurable := reflect.ValueOf(NewConfigurable(svc.lc, svc.SecretProvider()))
 
 	tests := []struct {
 		Name         string

--- a/pkg/transforms/mqttsecret.go
+++ b/pkg/transforms/mqttsecret.go
@@ -25,6 +25,8 @@ import (
 	MQTT "github.com/eclipse/paho.mqtt.golang"
 	"github.com/edgexfoundry/app-functions-sdk-go/v3/internal"
 	"github.com/edgexfoundry/app-functions-sdk-go/v3/internal/common"
+	bootstrapInterfaces "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	coreCommon "github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	gometrics "github.com/rcrowley/go-metrics"
 
@@ -36,6 +38,7 @@ import (
 // MQTTSecretSender ...
 type MQTTSecretSender struct {
 	lock                 sync.Mutex
+	lc                   logger.LoggingClient
 	client               MQTT.Client
 	mqttConfig           MQTTSecretConfig
 	persistOnError       bool
@@ -44,6 +47,7 @@ type MQTTSecretSender struct {
 	topicFormatter       StringValuesFormatter
 	mqttSizeMetrics      gometrics.Histogram
 	mqttErrorMetric      gometrics.Counter
+	preConnected         bool
 }
 
 // MQTTSecretConfig ...
@@ -60,6 +64,8 @@ type MQTTSecretConfig struct {
 	KeepAlive string
 	// ConnectTimeout is the duration for timing out on connecting to the broker
 	ConnectTimeout string
+	// MaxReconnectInterval is the max duration for attempting to reconnect to the broker
+	MaxReconnectInterval string
 	// Topic that you wish to publish to
 	Topic string
 	// QoS for MQTT Connection
@@ -89,8 +95,12 @@ func NewMQTTSecretSender(mqttConfig MQTTSecretConfig, persistOnError bool) *MQTT
 		client:         nil,
 		mqttConfig:     mqttConfig,
 		persistOnError: persistOnError,
-		opts:           opts,
 	}
+
+	opts.OnConnect = sender.onConnected
+	opts.OnConnectionLost = sender.onConnectionLost
+	opts.OnReconnecting = sender.onReconnecting
+	sender.opts = opts
 
 	return sender
 }
@@ -103,26 +113,25 @@ func NewMQTTSecretSenderWithTopicFormatter(mqttConfig MQTTSecretConfig, persistO
 	return sender
 }
 
-func (sender *MQTTSecretSender) initializeMQTTClient(ctx interfaces.AppFunctionContext) error {
+func (sender *MQTTSecretSender) initializeMQTTClient(lc logger.LoggingClient, secretProvider bootstrapInterfaces.SecretProvider) error {
 	sender.lock.Lock()
 	defer sender.lock.Unlock()
 
 	// If the conditions changed while waiting for the lock, i.e. other thread completed the initialization,
 	// then skip doing anything
-	secretProvider := ctx.SecretProvider()
 	if sender.client != nil && !sender.secretsLastRetrieved.Before(secretProvider.SecretsLastUpdated()) {
 		return nil
 	}
 
-	ctx.LoggingClient().Info("Initializing MQTT Client")
+	lc.Info("Initializing MQTT Client")
 
 	config := sender.mqttConfig
-	mqttFactory := secure.NewMqttFactory(ctx.SecretProvider(), ctx.LoggingClient(), config.AuthMode, config.SecretName, config.SkipCertVerify)
+	mqttFactory := secure.NewMqttFactory(secretProvider, lc, config.AuthMode, config.SecretName, config.SkipCertVerify)
 
 	if len(sender.mqttConfig.KeepAlive) > 0 {
 		keepAlive, err := time.ParseDuration(sender.mqttConfig.KeepAlive)
 		if err != nil {
-			return fmt.Errorf("in pipeline '%s', unable to parse KeepAlive value of '%s': %s", ctx.PipelineId(), sender.mqttConfig.KeepAlive, err.Error())
+			return fmt.Errorf("unable to parse MQTT Export KeepAlive value of '%s': %s", sender.mqttConfig.KeepAlive, err.Error())
 		}
 
 		sender.opts.SetKeepAlive(keepAlive)
@@ -131,20 +140,29 @@ func (sender *MQTTSecretSender) initializeMQTTClient(ctx interfaces.AppFunctionC
 	if len(sender.mqttConfig.ConnectTimeout) > 0 {
 		timeout, err := time.ParseDuration(sender.mqttConfig.ConnectTimeout)
 		if err != nil {
-			return fmt.Errorf("in pipeline '%s', unable to parse ConnectTimeout value of '%s': %s", ctx.PipelineId(), sender.mqttConfig.ConnectTimeout, err.Error())
+			return fmt.Errorf("unable to parse MQTT Export ConnectTimeout value of '%s': %s", sender.mqttConfig.ConnectTimeout, err.Error())
 		}
 
 		sender.opts.SetConnectTimeout(timeout)
 	}
 
+	if len(sender.mqttConfig.MaxReconnectInterval) > 0 {
+		interval, err := time.ParseDuration(sender.mqttConfig.MaxReconnectInterval)
+		if err != nil {
+			return fmt.Errorf("unable to parse MQTT Export MaxReconnectInterval value of '%s': %s", sender.mqttConfig.MaxReconnectInterval, err.Error())
+		}
+
+		sender.opts.SetMaxReconnectInterval(interval)
+	}
+
 	if config.Will.Enabled {
 		sender.opts.SetWill(config.Will.Topic, config.Will.Payload, config.Will.Qos, config.Will.Retained)
-		ctx.LoggingClient().Infof("Last Will options set for MQTT Export: %+v", config.Will)
+		lc.Infof("Last Will options set for MQTT Export: %+v", config.Will)
 	}
 
 	client, err := mqttFactory.Create(sender.opts)
 	if err != nil {
-		return fmt.Errorf("in pipeline '%s', unable to create MQTT Client: %s", ctx.PipelineId(), err.Error())
+		return fmt.Errorf("unable to create MQTT Client for export: %s", err.Error())
 	}
 
 	sender.client = client
@@ -176,9 +194,32 @@ func (sender *MQTTSecretSender) connectToBroker(ctx interfaces.AppFunctionContex
 	return nil
 }
 
+func (sender *MQTTSecretSender) setRetryData(ctx interfaces.AppFunctionContext, exportData []byte) {
+	if sender.persistOnError {
+		ctx.SetRetryData(exportData)
+	}
+}
+
+func (sender *MQTTSecretSender) onConnected(_ MQTT.Client) {
+	sender.lc.Tracef("MQTT Broker for export connected")
+}
+
+func (sender *MQTTSecretSender) onConnectionLost(_ MQTT.Client, _ error) {
+	sender.lc.Tracef("MQTT Broker for export lost connection")
+
+}
+
+func (sender *MQTTSecretSender) onReconnecting(_ MQTT.Client, _ *MQTT.ClientOptions) {
+	sender.lc.Tracef("MQTT Broker for export re-connecting")
+}
+
 // MQTTSend sends data from the previous function to the specified MQTT broker.
 // If no previous function exists, then the event that triggered the pipeline will be used.
 func (sender *MQTTSecretSender) MQTTSend(ctx interfaces.AppFunctionContext, data interface{}) (bool, interface{}) {
+	if sender.lc == nil {
+		sender.lc = ctx.LoggingClient()
+	}
+
 	if data == nil {
 		// We didn't receive a result
 		return false, fmt.Errorf("function MQTTSend in pipeline '%s': No Data Received", ctx.PipelineId())
@@ -191,7 +232,7 @@ func (sender *MQTTSecretSender) MQTTSend(ctx interfaces.AppFunctionContext, data
 	// if we haven't initialized the client yet OR the cache has been invalidated (due to new/updated secrets) we need to (re)initialize the client
 	secretProvider := ctx.SecretProvider()
 	if sender.client == nil || sender.secretsLastRetrieved.Before(secretProvider.SecretsLastUpdated()) {
-		err := sender.initializeMQTTClient(ctx)
+		err := sender.initializeMQTTClient(ctx.LoggingClient(), ctx.SecretProvider())
 		if err != nil {
 			return false, err
 		}
@@ -219,7 +260,7 @@ func (sender *MQTTSecretSender) MQTTSend(ctx interfaces.AppFunctionContext, data
 		},
 		tag)
 
-	if !sender.client.IsConnected() {
+	if !sender.client.IsConnected() && !sender.preConnected {
 		err := sender.connectToBroker(ctx, exportData)
 		if err != nil {
 			sender.mqttErrorMetric.Inc(1)
@@ -249,14 +290,43 @@ func (sender *MQTTSecretSender) MQTTSend(ctx interfaces.AppFunctionContext, data
 	exportDataBytes := len(exportData)
 	sender.mqttSizeMetrics.Update(int64(exportDataBytes))
 
-	ctx.LoggingClient().Debugf("Sent %d bytes of data to MQTT Broker in pipeline '%s'", exportDataBytes, ctx.PipelineId())
-	ctx.LoggingClient().Tracef("Data exported", "Transport", "MQTT", "pipeline", ctx.PipelineId(), coreCommon.CorrelationHeader, ctx.CorrelationID())
+	sender.lc.Debugf("Sent %d bytes of data to MQTT Broker in pipeline '%s' to topic '%s'", exportDataBytes, ctx.PipelineId(), publishTopic)
+	sender.lc.Tracef("Data exported to MQTT Broker in pipeline '%s': %s=%s", ctx.PipelineId(), coreCommon.CorrelationHeader, ctx.CorrelationID())
 
 	return true, nil
 }
 
-func (sender *MQTTSecretSender) setRetryData(ctx interfaces.AppFunctionContext, exportData []byte) {
-	if sender.persistOnError {
-		ctx.SetRetryData(exportData)
+// ConnectToBroker attempts to connect to the MQTT broker for export prior to processing the first data to be exported.
+// If a failure occurs the connection is retried when processing the first data to be exported.
+func (sender *MQTTSecretSender) ConnectToBroker(lc logger.LoggingClient, sp bootstrapInterfaces.SecretProvider, retryCount int, retryInterval time.Duration) {
+	sender.lc = lc
+
+	if sender.client == nil {
+		if err := sender.initializeMQTTClient(lc, sp); err != nil {
+			lc.Errorf("Failed to pre-connect to MQTT Broker: %v. Will try again on first export", err)
+			return
+		}
+	}
+
+	if !sender.client.IsConnected() {
+		var token MQTT.Token
+
+		lc.Info("Attempting to Pre-Connect to mqtt server for export")
+
+		for i := 0; i < retryCount; i++ {
+			token = sender.client.Connect()
+			if token.Wait() && token.Error() != nil {
+				lc.Warnf("failed to pre-connect to mqtt server for export: %v. trying again in %v", token.Error(), retryInterval)
+				time.Sleep(retryInterval)
+			}
+		}
+
+		if !sender.client.IsConnected() {
+			lc.Errorf("failed to pre-connect to mqtt server for export: %v. Will try again on first export", token.Error())
+			return
+		}
+
+		lc.Infof("Pre-Connected to mqtt server for export")
+		sender.preConnected = true
 	}
 }

--- a/pkg/transforms/mqttsecret.go
+++ b/pkg/transforms/mqttsecret.go
@@ -315,10 +315,12 @@ func (sender *MQTTSecretSender) ConnectToBroker(lc logger.LoggingClient, sp boot
 
 		for i := 0; i < retryCount; i++ {
 			token = sender.client.Connect()
-			if token.Wait() && token.Error() != nil {
-				lc.Warnf("failed to pre-connect to mqtt server for export: %v. trying again in %v", token.Error(), retryInterval)
-				time.Sleep(retryInterval)
+			if token.Wait() && token.Error() == nil {
+				break
 			}
+
+			lc.Warnf("failed to pre-connect to mqtt server for export: %v. trying again in %v", token.Error(), retryInterval)
+			time.Sleep(retryInterval)
 		}
 
 		if !sender.client.IsConnected() {


### PR DESCRIPTION
Performance enhancement for when service is processing many events very fast causing back ups when using lazy connection.

closes #1516

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
      TBD

## Testing Instructions
Run non-secure edgex stack with Device Virtual and MQTT Broker
```
make run no-secty ds-virtual mqtt-broker
```
Comment out existing pipeline function init code in app template
Add the following pipeline function int code
```go
	export := transforms.NewMQTTSecretSender(mqttConfig, false)
	export.ConnectToBroker(app.service.LoggingClient(), app.service.SecretProvider(), 5, time.Second*3)

	err := app.service.SetDefaultFunctionsPipeline(export.MQTTSend)
	if err != nil {
		app.lc.Errorf("SetFunctionsPipeline returned error: %s", err.Error())
		return -1
	}

```
Build and run app-template with TRACE logging
```
 WRITABLE_LOGLEVEL=TRACE ./app-new-service -cp -d 
```
Verify events are being processed and exported
```
level=DEBUG ts=2023-12-13T23:33:02.999684216Z app=app-new-service source=mqttsecret.go:293 msg="Sent 459 bytes of data to MQTT Broker in pipeline 'defa
ult-pipeline' to topic 'mqtt-export'"
```
Stop the MQTT Broker
verify logs contain
```
level=TRACE ts=2023-12-13T23:29:13.556428606Z app=app-new-service source=mqttsecret.go:208 msg="MQTT Broker for export lost connection"
level=TRACE ts=2023-12-13T23:29:13.556462306Z app=app-new-service source=mqttsecret.go:213 msg="MQTT Broker for export re-connecting"
level=ERROR ts=2023-12-13T23:32:58.024660412Z app=app-new-service source=triggermessageprocessor.go:154 msg="message error in pipeline default-pipeline
 (c6de0722-9197-4192-99be-9256a64e9918): in pipeline 'default-pipeline', connection to mqtt server for export not open, dropping event"
```
Restart the MQTT Broker
Verify logs contain
```
level=TRACE ts=2023-12-13T23:32:58.546204672Z app=app-new-service source=mqttsecret.go:204 msg="MQTT Broker for export connected"
```
Verify events are again being processed and exported
```
level=DEBUG ts=2023-12-13T23:36:33.088627053Z app=app-new-service source=mqttsecret.go:293 msg="Sent 407 bytes of data to MQTT Broker in pipeline 'default-pipeline' to topic 'mqtt-export'"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->