### PR TITLE
feat: Add retry on success capability for Store and Forward

### DIFF
--- a/internal/appfunction/context.go
+++ b/internal/appfunction/context.go
@@ -67,6 +67,7 @@ type Context struct {
 	inputContentType     string
 	responseData         []byte
 	retryData            []byte
+	triggerRetry         bool
 	responseContentType  string
 	contextData          map[string]string
 	valuePlaceholderSpec *regexp.Regexp
@@ -146,6 +147,23 @@ func (appContext *Context) SetRetryData(payload []byte) {
 // so it is internal SDK use only
 func (appContext *Context) RetryData() []byte {
 	return appContext.retryData
+}
+
+// TriggerRetryFailedData sets the flag to trigger retry of failed data.
+func (appContext *Context) TriggerRetryFailedData() {
+	appContext.triggerRetry = true
+}
+
+// ClearRetryTriggerFlag clears the flag to trigger retry of failed data. This function is not part of the AppFunctionContext interface,
+// so it is internal SDK use only
+func (appContext *Context) ClearRetryTriggerFlag() {
+	appContext.triggerRetry = false
+}
+
+// RetryTriggerFlag gets the flag to trigger retry of failed data. This function is not part of the AppFunctionContext interface,
+// so it is internal SDK use only
+func (appContext *Context) RetryTriggerFlag() bool {
+	return appContext.triggerRetry
 }
 
 // SecretProvider returns the SecretProvider instance

--- a/internal/appfunction/context.go
+++ b/internal/appfunction/context.go
@@ -160,9 +160,9 @@ func (appContext *Context) ClearRetryTriggerFlag() {
 	appContext.triggerRetry = false
 }
 
-// RetryTriggerFlag gets the flag to trigger retry of failed data. This function is not part of the AppFunctionContext interface,
+// IsRetryTriggered gets the flag to trigger retry of failed data. This function is not part of the AppFunctionContext interface,
 // so it is internal SDK use only
-func (appContext *Context) RetryTriggerFlag() bool {
+func (appContext *Context) IsRetryTriggered() bool {
 	return appContext.triggerRetry
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -343,7 +343,7 @@ func (fpr *FunctionsPipelineRuntime) ExecutePipeline(
 			break
 		}
 
-		if !isRetry && appContext.RetryTriggerFlag() {
+		if !isRetry && appContext.IsRetryTriggered() {
 			go fpr.storeForward.triggerRetry()
 			appContext.ClearRetryTriggerFlag()
 		}

--- a/internal/runtime/storeforward.go
+++ b/internal/runtime/storeforward.go
@@ -289,6 +289,12 @@ func (sf *storeForwardInfo) retryExportFunction(item interfaces.StoredObject, pi
 
 func (sf *storeForwardInfo) triggerRetry() {
 	if sf.dataCount.Count() > 0 {
+		config := container.ConfigurationFrom(sf.dic.Get)
+		if !config.Writable.StoreAndForward.Enabled {
+			sf.lc.Debug("Store and Forward not enabled, skipping triggering retry of failed data")
+			return
+		}
+
 		sf.lc.Debug("Triggering Store and Forward retry of failed data")
 		sf.retryStoredData(sf.serviceKey)
 	}

--- a/internal/runtime/storeforward.go
+++ b/internal/runtime/storeforward.go
@@ -21,15 +21,17 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/v3/internal/appfunction"
 	"github.com/edgexfoundry/app-functions-sdk-go/v3/internal/bootstrap/container"
 	"github.com/edgexfoundry/app-functions-sdk-go/v3/pkg/interfaces"
-
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
+	gometrics "github.com/rcrowley/go-metrics"
 )
 
 const (
@@ -37,8 +39,25 @@ const (
 )
 
 type storeForwardInfo struct {
-	runtime *FunctionsPipelineRuntime
-	dic     *di.Container
+	runtime         *FunctionsPipelineRuntime
+	dic             *di.Container
+	lc              logger.LoggingClient
+	serviceKey      string
+	dataCount       gometrics.Counter
+	retryInProgress atomic.Bool
+}
+
+func newStoreAndForward(runtime *FunctionsPipelineRuntime, dic *di.Container, serviceKey string) *storeForwardInfo {
+	return &storeForwardInfo{
+		runtime:    runtime,
+		dic:        dic,
+		lc:         bootstrapContainer.LoggingClientFrom(dic.Get),
+		serviceKey: serviceKey,
+		// Using counter metric now for the retry on success feature because it is thread safe
+		// and will also be used in future metrics feature to track size of the S&F queue.
+		// TODO: Register counter metric when using it for the metrics capability
+		dataCount: gometrics.NewCounter(),
+	}
 }
 
 func (sf *storeForwardInfo) startStoreAndForwardRetryLoop(
@@ -52,7 +71,17 @@ func (sf *storeForwardInfo) startStoreAndForwardRetryLoop(
 	enabledWg.Add(1)
 
 	config := container.ConfigurationFrom(sf.dic.Get)
-	lc := bootstrapContainer.LoggingClientFrom(sf.dic.Get)
+	storeClient := container.StoreClientFrom(sf.dic.Get)
+
+	sf.serviceKey = serviceKey
+
+	items, err := storeClient.RetrieveFromStore(serviceKey)
+	if err != nil {
+		sf.lc.Errorf("Unable to initialize Store and Forward data count: Failed to load items from DB: %v", err)
+	} else {
+		sf.dataCount.Clear()
+		sf.dataCount.Inc(int64(len(items)))
+	}
 
 	go func() {
 		defer appWg.Done()
@@ -60,25 +89,27 @@ func (sf *storeForwardInfo) startStoreAndForwardRetryLoop(
 
 		retryInterval, err := time.ParseDuration(config.Writable.StoreAndForward.RetryInterval)
 		if err != nil {
-			lc.Warn(
+			sf.lc.Warn(
 				fmt.Sprintf("StoreAndForward RetryInterval failed to parse, defaulting to %s",
 					defaultMinRetryInterval.String()))
 			retryInterval = defaultMinRetryInterval
 		} else if retryInterval < defaultMinRetryInterval {
-			lc.Warn(
+			sf.lc.Warn(
 				fmt.Sprintf("StoreAndForward RetryInterval value %s is less than the allowed minimum value, defaulting to %s",
 					retryInterval.String(), defaultMinRetryInterval.String()))
 			retryInterval = defaultMinRetryInterval
 		}
 
 		if config.Writable.StoreAndForward.MaxRetryCount < 0 {
-			lc.Warn("StoreAndForward MaxRetryCount can not be less than 0, defaulting to 1")
+			sf.lc.Warn("StoreAndForward MaxRetryCount can not be less than 0, defaulting to 1")
 			config.Writable.StoreAndForward.MaxRetryCount = 1
 		}
 
-		lc.Info(
-			fmt.Sprintf("Starting StoreAndForward Retry Loop with %s RetryInterval and %d max retries",
-				retryInterval.String(), config.Writable.StoreAndForward.MaxRetryCount))
+		sf.lc.Info(
+			fmt.Sprintf("Starting StoreAndForward Retry Loop with %s RetryInterval and %d max retries. %d stored items waiting for retry.",
+				retryInterval.String(),
+				config.Writable.StoreAndForward.MaxRetryCount,
+				len(items)))
 
 	exit:
 		for {
@@ -97,7 +128,7 @@ func (sf *storeForwardInfo) startStoreAndForwardRetryLoop(
 			}
 		}
 
-		lc.Info("Exiting StoreAndForward Retry Loop")
+		sf.lc.Info("Exiting StoreAndForward Retry Loop")
 	}()
 }
 
@@ -126,9 +157,18 @@ func (sf *storeForwardInfo) storeForLaterRetry(
 	if _, err := storeClient.Store(item); err != nil {
 		appContext.LoggingClient().Errorf("Failed to store item for later retry for pipeline '%s': %s", pipeline.Id, err.Error())
 	}
+
+	sf.dataCount.Inc(1)
 }
 
 func (sf *storeForwardInfo) retryStoredData(serviceKey string) {
+	// Skip if another thread is already doing the retry
+	if sf.retryInProgress.Load() {
+		return
+	}
+
+	sf.retryInProgress.Store(true)
+	defer sf.retryInProgress.Store(false)
 
 	storeClient := container.StoreClientFrom(sf.dic.Get)
 	lc := bootstrapContainer.LoggingClientFrom(sf.dic.Get)
@@ -145,7 +185,7 @@ func (sf *storeForwardInfo) retryStoredData(serviceKey string) {
 		itemsToRemove, itemsToUpdate := sf.processRetryItems(items)
 
 		lc.Debugf(" %d stored data items will be removed post retry", len(itemsToRemove))
-		lc.Debugf(" %d stored data items will be update post retry", len(itemsToUpdate))
+		lc.Debugf(" %d stored data items will be updated post retry", len(itemsToUpdate))
 
 		for _, item := range itemsToRemove {
 			if err := storeClient.RemoveFromStore(item); err != nil {
@@ -164,6 +204,8 @@ func (sf *storeForwardInfo) retryStoredData(serviceKey string) {
 					item.ID)
 			}
 		}
+
+		sf.dataCount.Dec(int64(len(itemsToRemove)))
 	}
 }
 
@@ -245,4 +287,11 @@ func (sf *storeForwardInfo) retryExportFunction(item interfaces.StoredObject, pi
 		pipeline,
 		item.PipelinePosition,
 		true) == nil
+}
+
+func (sf *storeForwardInfo) triggerRetry() {
+	if sf.dataCount.Count() > 0 {
+		sf.lc.Debug("Triggering Store and Forward retry of failed data")
+		sf.retryStoredData(sf.serviceKey)
+	}
 }

--- a/pkg/interfaces/context.go
+++ b/pkg/interfaces/context.go
@@ -62,6 +62,8 @@ type AppFunctionContext interface {
 	// SetRetryData set the data that is to be retried later as part of the Store and Forward capability.
 	// Used when there was failure sending the data to an external source.
 	SetRetryData(data []byte)
+	// TriggerRetryFailedData sets the flag to trigger the retry of any stored failed export data.
+	TriggerRetryFailedData()
 	// SecretProvider returns the SecretProvider instance
 	SecretProvider() bootstrapInterfaces.SecretProvider
 	// LoggingClient returns the Logger client

--- a/pkg/interfaces/mocks/AppFunctionContext.go
+++ b/pkg/interfaces/mocks/AppFunctionContext.go
@@ -425,6 +425,11 @@ func (_m *AppFunctionContext) SubscriptionClient() clientsinterfaces.Subscriptio
 	return r0
 }
 
+// TriggerRetryFailedData provides a mock function with given fields:
+func (_m *AppFunctionContext) TriggerRetryFailedData() {
+	_m.Called()
+}
+
 type mockConstructorTestingTNewAppFunctionContext interface {
 	mock.TestingT
 	Cleanup(func())

--- a/pkg/transforms/http.go
+++ b/pkg/transforms/http.go
@@ -234,6 +234,11 @@ func (sender *HTTPSender) httpSend(ctx interfaces.AppFunctionContext, data inter
 		return true, data
 	}
 
+	// Data successfully sent, so retry any failed data, if Store and Forward enabled and data has been saved
+	if sender.persistOnError {
+		ctx.TriggerRetryFailedData()
+	}
+
 	// capture the size into metrics
 	exportDataBytes := len(exportData)
 	sender.httpSizeMetrics.Update(int64(exportDataBytes))

--- a/pkg/transforms/mqttsecret.go
+++ b/pkg/transforms/mqttsecret.go
@@ -286,6 +286,11 @@ func (sender *MQTTSecretSender) MQTTSend(ctx interfaces.AppFunctionContext, data
 		return false, token.Error()
 	}
 
+	// Data successfully sent, so retry any failed data, if Store and Forward enabled and data has been saved
+	if sender.persistOnError {
+		ctx.TriggerRetryFailedData()
+	}
+
 	// capture the size for metrics
 	exportDataBytes := len(exportData)
 	sender.mqttSizeMetrics.Update(int64(exportDataBytes))


### PR DESCRIPTION
closes #1526

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
https://github.com/edgexfoundry/edgex-docs/pull/1328

## Testing Instructions
Run non-secure Edgex stack with Device Rest and MQTT Broker from compose builder
```
make run no-secty ds-rest mqtt-broker
```
Build ASC with this branch of APP SDK
Modify the ASC mqtt-export profile as follows:
- Enable Store and Forward
    ```
      StoreAndForward:
        Enabled: true
    ```
- Set MaxReconnectInterval for MQTT Export
    ```
    MaxReconnectInterval: "5s"
    ```
- Enable PersistOnError for MQTT Export
    ```
    PersistOnError: "true"
    ```
Run ASC with DEBUG logging
```
WRITABLE_LOGLEVEL=DEBUG ./app-service-configurable -p=mqtt-export -cp -d -o 
```
Verify Store and Forward started by checking for this log message.
```
msg="Starting StoreAndForward Retry Loop with 5m0s RetryInterval and 10 max retries. 0 stored items waiting for retry."
```
Send "1234" to localhost:59986/api/v3/resource/sample-numeric/int using postman or curl
Verify data was exported successfully via this log message
```
"Sent 377 bytes of data to MQTT Broker in pipeline 'default-pipeline' to topic 'edgex-export'"
```
Verify Retry was not triggered since no failed data stored for retry. I.e. this message **NOT** in logs
```
msg="Triggering Store and Forward retry of failed data "
```
Stop the MQTT Broker
Send "1234" to localhost:59986/api/v3/resource/sample-numeric/int using postman or curl 5 times
Verify each was saved for later retry
```
msg="MessageBus Trigger: Failed to process message on pipeline(s): 1 error occurred:\n\t* in pipeline 'default-pipeline', connection to mqtt server for export not open, persisting Event for later retry\n\n"
```
Stop ASC
Restart MQTT Broker
Restart ASC
Verify Store and Forward started and has 5 items stored for retry. 
```
 msg="Starting StoreAndForward Retry Loop with 5m0s RetryInterval and 10 max retries. 5 stored items waiting for retry."
```
Send "1234" to localhost:59986/api/v3/resource/sample-numeric/int using postman or curl
Verify data was exported successfully via this log message
```
"Sent 377 bytes of data to MQTT Broker in pipeline 'default-pipeline' to topic 'edgex-export'"
```
Verify the successful send triggered the retry of failed items. 
```
msg="Triggering Store and Forward retry of failed data "
msg="5 stored data items found for retrying"    
msg="Sent 377 bytes of data to MQTT Broker in pipeline 'default-pipeline' to topic 'edgex-export'"
msg="Sent 377 bytes of data to MQTT Broker in pipeline 'default-pipeline' to topic 'edgex-export'"
msg="Sent 377 bytes of data to MQTT Broker in pipeline 'default-pipeline' to topic 'edgex-export'"
msg="Sent 377 bytes of data to MQTT Broker in pipeline 'default-pipeline' to topic 'edgex-export'"
msg="Sent 377 bytes of data to MQTT Broker in pipeline 'default-pipeline' to topic 'edgex-export'"
msg=" 5 stored data items will be removed post retry"
msg=" 0 stored data items will be updated post retry"
```
Send "1234" to localhost:59986/api/v3/resource/sample-numeric/int using postman or curl on final time
Verify data was exported successfully via this log message
```
"Sent 377 bytes of data to MQTT Broker in pipeline 'default-pipeline' to topic 'edgex-export'"
```
Verify Retry was not triggered since no failed data stored for retry. I.e. this message **NOT** in logs
```
msg="Triggering Store and Forward retry of failed data "
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->