### PR TITLE
fix: Only one ldflags flag is allowed

### DIFF
--- a/app-service-template/Makefile
+++ b/app-service-template/Makefile
@@ -17,9 +17,9 @@
 .PHONY: build test clean docker
 
 # change the following boolean flag to enable or disable the Full RELRO (RELocation Read Only) for linux ELF (Executable and Linkable Format) binaries
-ENABLE_FULL_RELRO:="true"
+ENABLE_FULL_RELRO=true
 # change the following boolean flag to enable or disable PIE for linux binaries which is needed for ASLR (Address Space Layout Randomization) on Linux, the ASLR support on Windows is enabled by default
-ENABLE_PIE:="true"
+ENABLE_PIE=true
 
 GOTESTFLAGS?=-race
 
@@ -33,19 +33,21 @@ APPVERSION=$(shell cat ./VERSION 2>/dev/null || echo 0.0.0)
 # it must first remove the word 'required' so the offset of $2 is the same if there are multiple required modules
 SDKVERSION=$(shell cat ./go.mod | grep 'github.com/edgexfoundry/app-functions-sdk-go/v3 v' | sed 's/require//g' | awk '{print $$2}')
 
+ifeq ($(ENABLE_FULL_RELRO), true)
+	ENABLE_FULL_RELRO_GOFLAGS = -bindnow
+endif
+
 MICROSERVICE=app-new-service
-GOFLAGS=-ldflags "-s -w -X github.com/edgexfoundry/app-functions-sdk-go/v4/internal.SDKVersion=$(SDKVERSION) -X github.com/edgexfoundry/app-functions-sdk-go/v4/internal.ApplicationVersion=$(APPVERSION)" -trimpath -mod=readonly
+GOFLAGS=-ldflags "-s -w -X github.com/edgexfoundry/app-functions-sdk-go/v4/internal.SDKVersion=$(SDKVERSION) \
+				  -X github.com/edgexfoundry/app-functions-sdk-go/v4/internal.ApplicationVersion=$(APPVERSION) \
+				  $(ENABLE_FULL_RELRO_GOFLAGS)" -trimpath -mod=readonly
 
 # TODO: uncomment and remove default once files are in a Github repository or
 #       remove totally including usage below
 #GIT_SHA=$(shell git rev-parse HEAD)
 GIT_SHA=no-sha
 
-ifeq ($(ENABLE_FULL_RELRO), "true")
-	GOFLAGS += -ldflags "-bindnow"
-endif
-
-ifeq ($(ENABLE_PIE), "true")
+ifeq ($(ENABLE_PIE), true)
 	GOFLAGS += -buildmode=pie
 endif
 


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->