### PR TITLE
build(deps): update go directive to released version

### DIFF
--- a/app-service-template/go.mod
+++ b/app-service-template/go.mod
@@ -2,7 +2,7 @@
 
 module app-new-service
 
-go 1.23
+go 1.23.0
 
 // To build local docker image of the template App you must
 // comment out this replace statement and update the SDK version to latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgexfoundry/app-functions-sdk-go/v4
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
Per https://github.com/dependabot/dependabot-core/issues/11825 and https://github.com/dependabot/dependabot-core/pull/11826 , the dependabot has been updated to use GOTOOLCHAIN=go1.24.1 and it will add toolchain in go mod tidy when the go directive is specified with language version(1.N). As we don't want to the toolchain to be specified with go1.24.1, change the go directive to released version(1.N.P).

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->