### PR TITLE
fix: Prevent AppCustom config from being updated directly by ConfigProvider

### DIFF
--- a/app-service-template/main.go
+++ b/app-service-template/main.go
@@ -95,7 +95,7 @@ func (app *myApp) CreateAndRunAppService(serviceKey string, newServiceFactory fu
 	// the Configuration Provider, aka keeper.
 	// For more details see https://docs.edgexfoundry.org/latest/microservices/application/GeneralAppServiceConfig/#writable-custom-configuration
 	// TODO: Remove if not using writable custom configuration
-	if err := app.service.ListenForCustomConfigChanges(&app.serviceConfig.AppCustom, "AppCustom", app.ProcessConfigUpdates); err != nil {
+	if err := app.service.ListenForCustomConfigChanges(&config.AppCustomConfig{}, "AppCustom", app.ProcessConfigUpdates); err != nil {
 		app.lc.Errorf("unable to watch custom writable configuration: %s", err.Error())
 		return -1
 	}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Deploy core services and app-service-template
2. Update AppCustom configuration. For example:
```
curl -X PUT "http://localhost:59890/api/v3/kvs/key/edgex/v4/app-new-service/AppCustom?flatten=true" \
  -d '{"value": {"SomeValue": 1234}}'
```
3. Verify logs contain the following messages:
```
level=INFO ts=2025-06-18T17:35:45.204554+08:00 app=app-new-service source=main.go:187 msg="AppCustom.SomeValue changed to: 1234"
```
