### PR TITLE
fix: Replace fmt.Sprintf("%v",v) with cast.ToString(v)

### DIFF
--- a/pkg/transforms/metrics.go
+++ b/pkg/transforms/metrics.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2022 Intel Corporation
+// Copyright (c) 2025 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +23,8 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/v4/pkg/interfaces"
+
+	"github.com/spf13/cast"
 )
 
 // MetricsProcessor contains functions to process the Metric DTO
@@ -38,7 +41,7 @@ func NewMetricsProcessor(additionalTags map[string]interface{}) (*MetricsProcess
 			return nil, err
 		}
 
-		mp.additionalTags = append(mp.additionalTags, dtos.MetricTag{Name: name, Value: fmt.Sprintf("%v", value)})
+		mp.additionalTags = append(mp.additionalTags, dtos.MetricTag{Name: name, Value: cast.ToString(value)})
 	}
 
 	return mp, nil

--- a/pkg/transforms/metrics_test.go
+++ b/pkg/transforms/metrics_test.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2022 Intel Corporation
+// Copyright (c) 2025 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,11 +38,13 @@ func TestNewMetricsProcessor(t *testing.T) {
 		"Tag1": "str1",
 		"Tag2": 123,
 		"Tag3": 12.34,
+		"Tag4": 1234567.1,
 	}
 	expectedTags := []dtos.MetricTag{
 		{Name: "Tag1", Value: "str1"},
 		{Name: "Tag2", Value: "123"},
 		{Name: "Tag3", Value: "12.34"},
+		{Name: "Tag4", Value: "1234567.1"},
 	}
 
 	actual, err = NewMetricsProcessor(inputTags)


### PR DESCRIPTION
Replace fmt.Sprintf("%v",v) with cast.ToString(v) to ensure consistent string conversion and avoid scientific notation for float values.

fix: #1744 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
