### PR TITLE
fix: Fully replace pipelines on Writable.Pipeline update

### DIFF
--- a/internal/app/configupdates.go
+++ b/internal/app/configupdates.go
@@ -151,11 +151,16 @@ func (processor *ConfigUpdateProcessor) processConfigChangedPipeline() {
 		sdk.runtime.TargetType = sdk.targetType
 
 		// Update the pipelines with their new transforms
-		for _, pipeline := range pipelines {
-			// TODO: Look at better way to apply pipeline updates
-			sdk.runtime.SetFunctionsPipelineTransforms(pipeline.Id, pipeline.Transforms)
-			sdk.runtime.SetFunctionsPipelineTopics(pipeline.Id, pipeline.Topics)
+		for i, pipeline := range pipelines {
+			fullTopics, err := getFullTopics(pipeline.Topics, sdk.config.MessageBus.GetBaseTopicPrefix())
+			if err != nil {
+				sdk.LoggingClient().Errorf("failed to get full topics for pipeline %s: %v", pipeline.Id, err)
+				return
+			}
+			pipeline.Topics = fullTopics
+			pipelines[i] = pipeline
 		}
+		sdk.runtime.UpdateFunctionsPipelines(pipelines)
 
 		sdk.LoggingClient().Info("Configurable Pipeline successfully reloaded from new configuration")
 	}


### PR DESCRIPTION
## Problem
When Writable.Pipeline is updated, the runtime previously only updated topics/transforms per pipeline ID. This PR changes the update to a full replacement: pipelines absent from the new config are removed (and their metrics unregistered) and new pipelines are created and registered. Incoming topics are expanded with the message-bus base prefix.

## What changed
- Build full topics using base topic prefix before applying config.
- Replace per-field setters with `UpdateFunctionsPipelines(...)`.
- `UpdateFunctionsPipelines`:
  - acquires a lock,
  - unregisters metrics and deletes pipelines not in the new config,
  - creates new `FunctionPipeline` instances and registers their metrics.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->