### PR TITLE
feat: support multiple configurable providers

### DIFF
--- a/internal/app/configupdates.go
+++ b/internal/app/configupdates.go
@@ -189,3 +189,13 @@ func (svc *Service) findMatchingFunction(configurable reflect.Value, functionNam
 	functionType := functionValue.Type()
 	return functionValue, functionType, nil
 }
+
+func (svc *Service) findMatchingFunctionWrapper(configurables []reflect.Value, functionName string) (functionValue reflect.Value, functionType reflect.Type, err error) {
+	for _, conconfigurable := range configurables {
+		functionValue, functionType, err = svc.findMatchingFunction(conconfigurable, functionName)
+		if err == nil {
+			return
+		}
+	}
+	return
+}

--- a/pkg/interfaces/mocks/ApplicationService.go
+++ b/pkg/interfaces/mocks/ApplicationService.go
@@ -704,6 +704,13 @@ func (_m *ApplicationService) SubscriptionClient() clientsinterfaces.Subscriptio
 	return r0
 }
 
+func (_m *ApplicationService) RegisterExternalConfigurable(name string, f interfaces.ConfigurableFactory) {
+	_m.Called()
+}
+func (_m *ApplicationService) UnregisterExternalConfigurable(name string) {
+	_m.Called()
+}
+
 // NewApplicationService creates a new instance of ApplicationService. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewApplicationService(t interface {

--- a/pkg/interfaces/service.go
+++ b/pkg/interfaces/service.go
@@ -193,4 +193,27 @@ type ApplicationService interface {
 	Publish(data any, contentType string) error
 	// PublishWithTopic pushes data to the MessageBus using given topic
 	PublishWithTopic(topic string, data any, contentType string) error
+	// RegisterExternalConfigurable registers a named ConfigurableFactory.
+	//
+	// This allows runtime users to plug in their own "Configurable"-style provider,
+	// i.e. a struct exposing methods such as:
+	//
+	//     func (c *MyConfigurable) FilterByDeviceName(params map[string]string) interfaces.AppFunction
+	//
+	// Registration must happen before LoadConfigurableFunctionPipelines() is called,
+	// typically in init() or early in main(). Once registered, the functions on the
+	// provided configurable can be referenced in Writable.Pipeline configuration.
+	RegisterExternalConfigurable(name string, f ConfigurableFactory)
+	// UnregisterExternalConfigurable removes a previously registered factory by name.
+	//
+	// This can be used in tests or dynamic scenarios to clear or replace an external
+	// configurable provider. Usually registration is done once at startup and does
+	// not need to be removed in normal application flows.
+	UnregisterExternalConfigurable(name string)
 }
+
+// ConfigurableFactory creates a configurable instance given SDK logging/secret provider.
+// Returned value should be a pointer to a struct whose methods have signature
+//
+//	FuncName(parameters map[string]string) interfaces.AppFunction
+type ConfigurableFactory func(lc logger.LoggingClient, sp bootstrapInterfaces.SecretProvider) interface{}


### PR DESCRIPTION


## problem
sdk only instantiates a single Configurable by default, so adding new named pipeline functions typically requires forking or changing SDK internals — slow and hard to maintain.

## solution
Introduce a configurables collection and let runtime users register their own Configurable-style providers (factories). This lets operators/apps add custom pipeline functions without rebuilding or forking the SDK.

## usage
```
// register before pipelines are loaded (e.g. in init() or early in main)
svc.RegisterExternalConfigurable("mycfg", func(lc logger.LoggingClient, sp bootstrapInterfaces.SecretProvider) interface{} {
    return &mycfg.MyConfigurable{lc: lc, sp: sp}
})

// MyConfigurable must expose methods like:
func (m *MyConfigurable) FilterByDeviceName(params map[string]string) interfaces.AppFunction {
    // build and return an AppFunction using params
}

```

## changes
- add ConfigurableFactory and Service.Register/Unregister APIs
- build configurables list from builtin + registered factories
- iterate configurables when resolving pipeline functions

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->